### PR TITLE
Remove clock synchronization (host->device) at each clock cycle

### DIFF
--- a/brian2cuda/cuda_generator.py
+++ b/brian2cuda/cuda_generator.py
@@ -189,7 +189,11 @@ class CUDACodeGenerator(CodeGenerator):
             else:
                 line = ''
             line = line + self.c_data_type(var.dtype) + ' ' + varname + ' = '
-            line = line + self.get_array_name(var, self.variables) + '[' + index_var + '];'
+            if varname in ['t', 'timestep', '_clock_t', '_clock_timestep', '_source_t', '_source_timestep']:
+                # variables passed by value to kernel
+                line = line + self.get_array_name(var, self.variables) + ';'
+            else:
+                line = line + self.get_array_name(var, self.variables) + '[' + index_var + '];'
             lines.append(line)
         return lines
 

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -123,8 +123,6 @@ __global__ void {{path.name}}_init(
 timer_type brian::{{codeobj}}_timer_start;
 timer_type brian::{{codeobj}}_timer_stop;
 {% endfor %}
-timer_type brian::_sync_clocks_timer_start;
-timer_type brian::_sync_clocks_timer_stop;
 timer_type brian::random_number_generation_timer_start;
 timer_type brian::random_number_generation_timer_stop;
 
@@ -132,7 +130,6 @@ timer_type brian::random_number_generation_timer_stop;
 {% for codeobj in active_objects %}
 double brian::{{codeobj}}_profiling_info = 0.0;
 {% endfor %}
-double brian::_sync_clocks_profiling_info = 0.0;
 double brian::random_number_generation_profiling_info = 0.0;
 
 //////////////random numbers//////////////////
@@ -186,8 +183,6 @@ void _init_arrays()
 	cudaEventCreate(&{{codeobj}}_timer_start);
 	cudaEventCreate(&{{codeobj}}_timer_stop);
 	{% endfor %}
-	cudaEventCreate(&_sync_clocks_timer_start);
-	cudaEventCreate(&_sync_clocks_timer_stop);
 	cudaEventCreate(&random_number_generation_timer_start);
 	cudaEventCreate(&random_number_generation_timer_stop);
 	{% endif %}
@@ -357,7 +352,6 @@ void _write_arrays()
 	{% for obj in active_objects %}
 	outfile_profiling_info << "{{obj}}\t" << {{obj}}_profiling_info << std::endl;
 	{% endfor %}
-	outfile_profiling_info << "_sync_clocks\t" << _sync_clocks_profiling_info << std::endl;
 	outfile_profiling_info << "random_number_generation\t" << random_number_generation_profiling_info << std::endl;
 	outfile_profiling_info.close();
 	} else
@@ -399,8 +393,6 @@ void _dealloc_arrays()
 	cudaEventDestroy({{codeobj}}_timer_start);
 	cudaEventDestroy({{codeobj}}_timer_stop);
 	{% endfor %}
-	cudaEventDestroy(_sync_clocks_timer_start);
-	cudaEventDestroy(_sync_clocks_timer_stop);
 	cudaEventDestroy(random_number_generation_timer_start);
 	cudaEventDestroy(random_number_generation_timer_stop);
 	{% endif %}
@@ -567,8 +559,6 @@ typedef cudaEvent_t timer_type;
 extern timer_type {{codeobj}}_timer_start;
 extern timer_type {{codeobj}}_timer_stop;
 {% endfor %}
-extern timer_type _sync_clocks_timer_start;
-extern timer_type _sync_clocks_timer_stop;
 extern timer_type random_number_generation_timer_start;
 extern timer_type random_number_generation_timer_stop;
 
@@ -576,7 +566,6 @@ extern timer_type random_number_generation_timer_stop;
 {% for codeobj in active_objects %}
 extern double {{codeobj}}_profiling_info;
 {% endfor %}
-extern double _sync_clocks_profiling_info;
 extern double random_number_generation_profiling_info;
 
 //////////////// random numbers /////////////////

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -1,6 +1,10 @@
 {% extends 'common_group.cu' %}
 {# USES_VARIABLES { rate, t, _spikespace, _clock_t, _clock_dt,
                     _num_source_neurons, _source_start, _source_stop } #}
+{# we can't use _clock_t since it returns var[0] but our t is not a pointer #}
+//{{_clock_t}}
+{% set _clock_t = get_array_name(owner.clock.variables['t']) %}
+//{{_clock_t}}
 
 {% block define_N %}
 {% endblock %}
@@ -24,6 +28,16 @@ kernel_{{codeobj_name}}<<<1,1>>>(
 	thrust::raw_pointer_cast(&(dev{{_dynamic_t}}[0])),
 	///// HOST_PARAMETERS /////
 	%HOST_PARAMETERS%);
+
+cudaError_t status = cudaGetLastError();
+if (status != cudaSuccess)
+{
+	       printf("ERROR launching kernel_{{codeobj_name}} in %s:%d %s\n",
+				                          __FILE__, __LINE__, cudaGetErrorString(status));
+		          _dealloc_arrays();
+				         exit(status);
+}
+
 {% endblock %}
 
 {% block kernel %}

--- a/brian2cuda/templates/run.cu
+++ b/brian2cuda/templates/run.cu
@@ -11,33 +11,6 @@
 #include "{{name}}"
 {% endfor %}
 
-void _sync_clocks()
-{
-	using namespace brian;
-
-	{% if profile and profile == 'blocking'%}
-	_sync_clocks_timer_start= std::clock();
-	{% elif profile %}
-	cudaEventRecord(_sync_clocks_timer_start);
-	{% endif %}
-
-	{% for clock in clocks | sort(attribute='name') %}
-	cudaMemcpy(dev{{array_specs[clock.variables['timestep']]}}, {{array_specs[clock.variables['timestep']]}},
-			sizeof(uint64_t)*_num_{{array_specs[clock.variables['timestep']]}}, cudaMemcpyHostToDevice);
-	cudaMemcpy(dev{{array_specs[clock.variables['dt']]}}, {{array_specs[clock.variables['dt']]}},
-			sizeof(double)*_num_{{array_specs[clock.variables['dt']]}}, cudaMemcpyHostToDevice);
-	cudaMemcpy(dev{{array_specs[clock.variables['t']]}}, {{array_specs[clock.variables['t']]}},
-			sizeof(double)*_num_{{array_specs[clock.variables['t']]}}, cudaMemcpyHostToDevice);
-    	{% endfor %}
-
-	{% if profile and profile == 'blocking'%}
-	cudaDeviceSynchronize();
-	_sync_clocks_timer_stop = std::clock();
-	{% elif profile %}
-	cudaEventRecord(_sync_clocks_timer_stop);
-	{% endif %}
-}
-
 void brian_start()
 {
 	_init_arrays();
@@ -74,7 +47,6 @@ void {{name}}()
 
 {% macro h_file() %}
 
-void _sync_clocks();
 void brian_start();
 void brian_end();
 

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -1,5 +1,5 @@
 {% extends 'common_group.cu' %}
-{# USES_VARIABLES { N, _clock_t, count,
+{# USES_VARIABLES { N, count,
                     _source_start, _source_stop} #}
                     
 {% block extra_device_helper %}

--- a/brian2cuda/templates/threshold.cu
+++ b/brian2cuda/templates/threshold.cu
@@ -30,7 +30,8 @@
 		// might contain references to not_refractory or lastspike and in
 		// that case the names will refer to a single entry.
 		{{not_refractory}}[_idx] = false;
-		{{lastspike}}[_idx] = {{t}};
+		{# we can't use {{t}} directly, since it returns ...[0] (in Device.code_object()) but our t is not a pointer #}
+		{{lastspike}}[_idx] = {{get_array_name(variables['t'])}};
 		{% endif %}
 	}
 {% endblock %}


### PR DESCRIPTION
We now just pass `t` and `dt` clock variables by value in
KERNEL_PARAMETERS if a kernel need them. This reduces the previous
`cudaMemcpy` overhead for small networks significantly.