### PR TITLE
Create random numbers in bigger chunks

### DIFF
--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -139,10 +139,12 @@ double brian::random_number_generation_profiling_info = 0.0;
 curandGenerator_t brian::random_float_generator;
 {% for co in codeobj_with_rand | sort(attribute='name') %}
 float* brian::dev_{{co.name}}_rand;
+float* brian::dev_{{co.name}}_rand_allocator;
 __device__ float* brian::_array_{{co.name}}_rand;
 {% endfor %}
 {% for co in codeobj_with_randn | sort(attribute='name') %}
 float* brian::dev_{{co.name}}_randn;
+float* brian::dev_{{co.name}}_randn_allocator;
 __device__ float* brian::_array_{{co.name}}_randn;
 {% endfor %}
 
@@ -406,10 +408,10 @@ void _dealloc_arrays()
 	{% endif %}
 
 	{% for co in codeobj_with_rand | sort(attribute='name') %}
-	cudaFree(dev_{{co.name}}_rand);
+	cudaFree(dev_{{co.name}}_rand_allocator);
 	{% endfor %}
 	{% for co in codeobj_with_randn | sort(attribute='name') %}
-	cudaFree(dev_{{co.name}}_randn);
+	cudaFree(dev_{{co.name}}_randn_allocator);
 	{% endfor %}
 
 	{% for S in synapses | sort(attribute='name') %}
@@ -584,10 +586,12 @@ extern curandGenerator_t random_float_generator;
 
 {% for co in codeobj_with_rand | sort(attribute='name') %}
 extern float* dev_{{co.name}}_rand;
+extern float* dev_{{co.name}}_rand_allocator;
 extern __device__ float* _array_{{co.name}}_rand;
 {% endfor %}
 {% for co in codeobj_with_randn | sort(attribute='name') %}
 extern float* dev_{{co.name}}_randn;
+extern float* dev_{{co.name}}_randn_allocator;
 extern __device__ float* _array_{{co.name}}_randn;
 {% endfor %}
 


### PR DESCRIPTION
Before we created them every clock cycle which creates significant
overhead. This implementation still needs to call one
`cudaMemcpyToSymbol` per clock cycle and codeobject using rand/randn,
which could be avoided.

This implementation very generically generates a max of `50MB` of random number per codeobject and regenerates them after they are used up. This way for mall simulations we only generate once and for bigger simulations (where memory is a potential limit), we don't generate too many numbers. 

This is a quick and dirty solution here which might fail if we run into memory limits. but for our current benchmarks its good enough and since we should probably use a cleaner buffer system at some point, I will leave it like this for now.