### PR TITLE
Add single precision support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "brian2genn_frozen"]
 	path = frozen_repos/brian2genn
 	url = https://github.com/brian-team/brian2genn.git
+[submodule "frozen_repos/brian2"]
+	path = frozen_repos/brian2
+	url = https://github.com/denisalevi/brian2.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "brian2_frozen"]
-	path = frozen_repos/brian2
-	url = https://github.com/denisalevi/brian2.git
 [submodule "genn_frozen"]
 	path = frozen_repos/genn
 	url = https://github.com/genn-team/genn.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "brian2_frozen"]
 	path = frozen_repos/brian2
-	url = https://github.com/brian-team/brian2.git
+	url = https://github.com/denisalevi/brian2.git
 [submodule "genn_frozen"]
 	path = frozen_repos/genn
 	url = https://github.com/genn-team/genn.git

--- a/brian2cuda/brianlib/spikequeue.h
+++ b/brian2cuda/brianlib/spikequeue.h
@@ -14,7 +14,6 @@ using namespace std;
 //      variables (delays, dt) are assumed to use the same data type
 typedef int32_t DTYPE_int;
 
-template <class scalar>
 class CudaSpikeQueue
 {
 private:
@@ -74,7 +73,7 @@ public:
         int tid,
         int num_threads,
         int _num_blocks,
-        scalar _dt,
+        double _dt,
         int _neuron_N,
         int _syn_N,
         int _num_queues,

--- a/brian2cuda/cuda_generator.py
+++ b/brian2cuda/cuda_generator.py
@@ -33,8 +33,8 @@ prefs.register_preferences(
                 types is not type safe. And convertion from 64bit integral types to double precision (64bit)
                 floating-point types neither. In those cases the closest higher or lower (implementation
                 defined) representable value will be selected.''',
-            validator=lambda v: v in ['single_precision', 'double_precision'],
-            default='double_precision')
+            validator=lambda v: v in ['float32', 'float64'],
+            default='float64')
 )
 
 
@@ -258,7 +258,7 @@ class CUDACodeGenerator(CodeGenerator):
                 brian_funcs = re.search('_brian_(' + '|'.join(functions_C99) + ')', line)
                 if brian_funcs is not None:
                     for identifier in get_identifiers(line):
-                        if convertion_pref == 'double_precision':
+                        if convertion_pref == 'float64':
                             # 64bit integer to floating-point conversions are not type safe
                             int64_type = re.search(r'\bu?int64_t\s*{}\b'.format(identifier), code)
                             if int64_type is not None:
@@ -269,20 +269,20 @@ class CUDACodeGenerator(CodeGenerator):
                                             "statement:\n\t{}\nGenerated from abstract code statements:\n\t{}\n".format(line, statements),
                                             once=True)
                                 self.warned_integral_convertion = True
-                                self.previous_convertion_pref = 'double_precision'
-                        else:  # convertion_pref = 'single_precision'
+                                self.previous_convertion_pref = 'float64'
+                        else:  # convertion_pref = 'float32'
                             # 32bit and 64bit integer to floating-point conversions are not type safe
                             int32_64_type = re.search(r'\bu?int(32|64)_t\s*{}\b'.format(identifier), code)
                             if int32_64_type is not None:
                                 logger.warn("Detected code statement with default function and 32bit or 64bit integer type in the same line and the "
-                                            "preference for default_functions_integral_convertion is 'single_precision'. "
+                                            "preference for default_functions_integral_convertion is 'float32'. "
                                             "Using 32bit or 64bit integer types as default function arguments is not type safe due to convertion of "
                                             "integer to single-precision floating-point types in device code. (relevant functions: sin, cos, tan, sinh, "
                                             "cosh, tanh, exp, log, log10, sqrt, ceil, floor, arcsin, arccos, arctan)\nDetected code "
                                             "statement:\n\t{}\nGenerated from abstract code statements:\n\t{}\n".format(line, statements),
                                             once=True)
                                 self.warned_integral_convertion = True
-                                self.previous_convertion_pref = 'single_precision'
+                                self.previous_convertion_pref = 'float32'
         return stripped_deindented_lines(code)
 
     def denormals_to_zero_code(self):
@@ -374,10 +374,10 @@ class CUDACodeGenerator(CodeGenerator):
         support_code = ''
         hash_defines = ''
         # set convertion types for standard C99 functions in device code
-        if prefs.codegen.generators.cuda.default_functions_integral_convertion == 'double_precision':
+        if prefs.codegen.generators.cuda.default_functions_integral_convertion == 'float64':
             default_func_type = 'double'
             other_func_type = 'float'
-        else:  # 'single_precision'
+        else:  # 'float32'
             default_func_type = 'float'
             other_func_type = 'double'
         for varname, variable in self.variables.items():

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -525,12 +525,12 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                 );
                         curandGenerateNormal{curand_suffix}(curand_generator, dev_array_randn, {number_elements}*{codeobj.randn_calls}, 0, 1);
                         '''.format(number_elements=number_elements, codeobj=codeobj, dtype=c_data_type(prefs['core.default_float_dtype']),
-                                   curand_suffix='Double' if c_data_type(prefs['core.default_float_dtype'])=='double' else '')
+                                   curand_suffix='Double' if prefs['core.default_float_dtype']=='float64' else '')
                     additional_code.append(code_snippet)
                     line = "{dtype}* par_array_{name}_randn".format(dtype=c_data_type(prefs['core.default_float_dtype']), name=codeobj.name)
                     device_parameters_lines.append(line)
                     kernel_variables_lines.append("{dtype}* _ptr_array_{name}_randn = par_array_{name}_randn;".format(dtype=c_data_type(prefs['core.default_float_dtype']),
-                                                                                                          name=codeobj.name))
+                                                                                                                      name=codeobj.name))
                     host_parameters_lines.append("dev_array_randn")
                 elif k == "_python_rand" and codeobj.runs_every_tick == False and codeobj.template_name != "synapses_create_generator":
                     code_snippet = '''
@@ -541,12 +541,12 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                 );
                         curandGenerateUniform{curand_suffix}(curand_generator, dev_array_rand, {number_elements}*{codeobj.rand_calls});
                         '''.format(number_elements=number_elements, codeobj=codeobj, dtype=c_data_type(prefs['core.default_float_dtype']),
-                                   curand_suffix='Double' if c_data_type(prefs['core.default_float_dtype'])=='double' else '')
+                                   curand_suffix='Double' if prefs['core.default_float_dtype']=='float64' else '')
                     additional_code.append(code_snippet)
                     line = "{dtype}* par_array_{name}_rand".format(dtype=c_data_type(prefs['core.default_float_dtype']), name=codeobj.name)
                     device_parameters_lines.append(line)
                     kernel_variables_lines.append("{dtype}* _ptr_array_{name}_rand = par_array_{name}_rand;".format(dtype=c_data_type(prefs['core.default_float_dtype']),
-                                                                                                          name=codeobj.name))
+                                                                                                                    name=codeobj.name))
                     host_parameters_lines.append("dev_array_rand")
                 elif isinstance(v, ArrayVariable):
                     if k in ['t', 'timestep', '_clock_t', '_clock_timestep', '_source_t', '_source_timestep'] and v.scalar:  # monitors have not scalar t variables

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -266,9 +266,9 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
             for varname in variables.iterkeys():
                 if varname in read_write:
                     idx = variable_indices[varname]
-                    if idx == '_presynaptic_idx':
+                    if idx == '_presynaptic_idx' or varname == 'i':
                         self.delete_synaptic_pre[synaptic_pre_array_name] = False
-                    if idx == '_postsynaptic_idx':
+                    if idx == '_postsynaptic_idx' or varname == 'j':
                         self.delete_synaptic_post[synaptic_post_array_name] = False
         if template_name == "synapses":
             prepost = template_kwds['pathway'].prepost

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -75,7 +75,6 @@ const int brian::_num_{{name}} = {{N}};
 //////////////// synapses /////////////////
 {% for S in synapses | sort(attribute='name') %}
 // {{S.name}}
-Synapses<double> brian::{{S.name}}({{S.source|length}}, {{S.target|length}});
 int32_t {{S.name}}_source_start_index;
 int32_t {{S.name}}_source_stop_index;
 bool brian::{{S.name}}_multiple_pre_post = false;
@@ -95,7 +94,7 @@ __device__ int32_t** brian::{{path.name}}_synapse_ids_by_pre;
 __device__ int32_t* brian::{{path.name}}_synapse_ids;
 __device__ int* brian::{{path.name}}_unique_delay_start_idcs;
 __device__ int* brian::{{path.name}}_unique_delays_offset_by_pre;
-__device__ SynapticPathway<double> brian::{{path.name}};
+__device__ SynapticPathway brian::{{path.name}};
 int brian::{{path.name}}_eventspace_idx = 0;
 int brian::{{path.name}}_delay;
 bool brian::{{path.name}}_scalar_delay;
@@ -113,7 +112,6 @@ int brian::num_threads_per_warp;
 __global__ void {{path.name}}_init(
                 int Nsource,
                 int Ntarget,
-                double* delays,
                 int32_t* sources,
                 int32_t* targets,
                 double dt,
@@ -123,7 +121,7 @@ __global__ void {{path.name}}_init(
 {
     using namespace brian;
 
-    {{path.name}}.init(Nsource, Ntarget, delays, sources, targets, dt, start, stop);
+    {{path.name}}.init(Nsource, Ntarget, sources, targets, dt, start, stop);
 }
 {% endfor %}
 {% endfor %}
@@ -186,7 +184,6 @@ void _init_arrays()
     {{path.name}}_init<<<1,1>>>(
             {{path.source|length}},
             {{path.target|length}},
-            thrust::raw_pointer_cast(&dev{{dynamic_array_specs[path.variables['delay']]}}[0]),
             thrust::raw_pointer_cast(&dev{{dynamic_array_specs[path.synapse_sources]}}[0]),
             thrust::raw_pointer_cast(&dev{{dynamic_array_specs[path.synapse_targets]}}[0]),
             0,  //was dt, maybe irrelevant?
@@ -551,7 +548,6 @@ extern const int _num_{{name}};
 //////////////// synapses /////////////////
 {% for S in synapses | sort(attribute='name') %}
 // {{S.name}}
-extern Synapses<double> {{S.name}};
 extern bool {{S.name}}_multiple_pre_post;
 {% for path in S._pathways | sort(attribute='name') %}
 extern __device__ int* {{path.name}}_num_synapses_by_pre;
@@ -568,7 +564,7 @@ extern __device__ int32_t** {{path.name}}_synapse_ids_by_pre;
 extern __device__ int32_t* {{path.name}}_synapse_ids;
 extern __device__ int* {{path.name}}_unique_delay_start_idcs;
 extern __device__ int* {{path.name}}_unique_delays_offset_by_pre;
-extern __device__ SynapticPathway<double> {{path.name}};
+extern __device__ SynapticPathway {{path.name}};
 extern int {{path.name}}_eventspace_idx;
 extern int {{path.name}}_delay;
 extern bool {{path.name}}_scalar_delay;

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -41,8 +41,10 @@ __launch_bounds__(1024, {{sm_multiplier}})
 {% endif %}
 kernel_{{codeobj_name}}(
     int32_t current_iteration,
-    double* ratemonitor_rate,
-    double* ratemonitor_t,
+    {% set c_type = c_data_type(variables['rate'].dtype) %}
+    {{c_type}}* ratemonitor_rate,
+    {% set c_type = c_data_type(variables['t'].dtype) %}
+    {{c_type}}* ratemonitor_t,
     ///// DEVICE_PARAMETERS /////
     %DEVICE_PARAMETERS%
     )

--- a/brian2cuda/templates/synapses_classes.cu
+++ b/brian2cuda/templates/synapses_classes.cu
@@ -11,10 +11,6 @@
 
 #include "brianlib/spikequeue.h"
 
-template<class scalar> class Synapses;
-template<class scalar> class SynapticPathway;
-
-template <class scalar>
 class SynapticPathway
 {
 public:
@@ -22,7 +18,6 @@ public:
     int Nsource;
     int Ntarget;
 
-    scalar* dev_delay;
     int32_t* dev_sources;
     int32_t* dev_targets;
 
@@ -31,23 +26,22 @@ public:
     int spikes_start;
     int spikes_stop;
 
-    scalar dt;
-    CudaSpikeQueue<scalar>* queue;
+    double dt;
+    CudaSpikeQueue* queue;
     bool no_or_const_delay_mode;
 
     //our real constructor
-    __device__ void init(int _Nsource, int _Ntarget, scalar* d_delay, int32_t* _sources,
-                int32_t* _targets, scalar _dt, int _spikes_start, int _spikes_stop)
+    __device__ void init(int _Nsource, int _Ntarget, int32_t* _sources,
+                int32_t* _targets, double _dt, int _spikes_start, int _spikes_stop)
     {
         Nsource = _Nsource;
         Ntarget = _Ntarget;
-        dev_delay = d_delay;
         dev_sources = _sources;
         dev_targets = _targets;
         dt = _dt;
         spikes_start = _spikes_start;
         spikes_stop = _spikes_stop;
-        queue = new CudaSpikeQueue<scalar>;
+        queue = new CudaSpikeQueue;
     };
 
     //our real destructor
@@ -57,29 +51,6 @@ public:
         delete queue;
     }
 };
-
-template <class scalar>
-class Synapses
-{
-public:
-    int _N_value;
-    inline double _N() { return _N_value;};
-    int Nsource;
-    int Ntarget;
-    std::vector< std::vector<int> > _pre_synaptic;
-    std::vector< std::vector<int> > _post_synaptic;
-
-    Synapses(int _Nsource, int _Ntarget)
-        : Nsource(_Nsource), Ntarget(_Ntarget)
-    {
-        for(int i=0; i<Nsource; i++)
-            _pre_synaptic.push_back(std::vector<int>());
-        for(int i=0; i<Ntarget; i++)
-            _post_synaptic.push_back(std::vector<int>());
-        _N_value = 0;
-    };
-};
-
 #endif
 
 {% endmacro %}

--- a/brian2cuda/tests/features/cuda_configuration.py
+++ b/brian2cuda/tests/features/cuda_configuration.py
@@ -163,10 +163,6 @@ class CUDAStandaloneConfigurationNoAssert(CUDAStandaloneConfigurationBase):
     name = 'CUDA standalone (asserts disabled)'
     device_kwargs = {'disable_asserts': True}
 
-class CUDAStandaloneConfigurationCurandDouble(CUDAStandaloneConfigurationBase):
-    name = 'CUDA standalone (curand_float_type = double)'
-    extra_prefs = {'devices.cuda_standalone.curand_float_type': 'double'}
-
 class CUDAStandaloneConfigurationNoCudaOccupancyAPI(CUDAStandaloneConfigurationBase):
     name = 'CUDA standalone (not using cuda occupancy API)'
     extra_prefs = {'devices.cuda_standalone.calc_occupancy': False}

--- a/brian2cuda/tests/test_cuda_generator.py
+++ b/brian2cuda/tests/test_cuda_generator.py
@@ -1,4 +1,4 @@
-from nose import with_setup
+from nose import with_setup, SkipTest
 from nose.plugins.attrib import attr
 from numpy.testing.utils import assert_allclose, assert_raises
 
@@ -358,6 +358,9 @@ def test_default_function_implementations():
 @with_setup(teardown=reinit_devices)
 def test_default_function_convertion_preference():
 
+    if prefs.core.default_float_dtype is np.float32:
+        raise SkipTest('Need double precision for this test')
+
     set_device('cuda_standalone', directory=None)
 
     unrepresentable_int = 2**24 + 1  # can't be represented as 32bit float
@@ -377,7 +380,7 @@ def test_default_function_convertion_preference():
     run(0*ms)
 
     assert G.v[0] != unrepresentable_int, G.v[0]
-    assert G2.v[0] == unrepresentable_int, G.v2[0]
+    assert G2.v[0] == unrepresentable_int, '{} != {}'.format(G2.v[0], unrepresentable_int)
 
 
 @attr('cuda_standalone', 'standalone-only')

--- a/brian2cuda/tests/test_cuda_generator.py
+++ b/brian2cuda/tests/test_cuda_generator.py
@@ -365,13 +365,13 @@ def test_default_function_convertion_preference():
 
     unrepresentable_int = 2**24 + 1  # can't be represented as 32bit float
 
-    prefs.codegen.generators.cuda.default_functions_integral_convertion = 'single_precision'
+    prefs.codegen.generators.cuda.default_functions_integral_convertion = 'float32'
     G = NeuronGroup(1, 'v: 1')
     G.variables.add_array('myarr', dtype=np.int32, size=1)
     G.variables['myarr'].set_value(unrepresentable_int)
     G.v = 'floor(myarr)'.format(unrepresentable_int)
 
-    prefs.codegen.generators.cuda.default_functions_integral_convertion = 'double_precision'
+    prefs.codegen.generators.cuda.default_functions_integral_convertion = 'float64'
     G2 = NeuronGroup(1, 'v: 1')
     G2.variables.add_array('myarr', dtype=np.int32, size=1)
     G2.variables['myarr'].set_value(unrepresentable_int)
@@ -417,7 +417,7 @@ def test_default_function_convertion_warnings():
         G4.variables.add_array('myarr', dtype=np.uint32, size=1)
         G4.v = 'arcsin(i*myarr)'
 
-    prefs.codegen.generators.cuda.default_functions_integral_convertion = 'single_precision'
+    prefs.codegen.generators.cuda.default_functions_integral_convertion = 'float32'
 
     BrianLogger._log_messages.clear()
     with catch_logs() as logs5:

--- a/brian2cuda/tools/run_single_test.py
+++ b/brian2cuda/tools/run_single_test.py
@@ -12,13 +12,18 @@ parser.add_argument('--targets', nargs='*', default=['cuda_standalone'], type=st
                     choices=['cuda_standalone', 'genn', 'cpp_standalone'],
                     help=("Which codegeneration targets to use, can be multiple. "
                           "Only standalone targets. (default=['cuda_standalone'])"))
+parser.add_argument('--float-dtype', nargs=1, default='float64', type=str,
+                    choices=['float32', 'float64'], help=("The "
+                    "prefs['core.default_float_dtype'] with which tests should be run."))
 parser.add_argument('--reset-prefs', action='store_true',
                     help="Weather to reset prefs between tests or not.")
 args = parser.parse_args()
 
 import sys
 from brian2.devices.device import set_device
+from brian2 import prefs
 import nose
+import numpy as np
 
 if 'cuda_standalone' in args.targets:
     import brian2cuda
@@ -26,7 +31,9 @@ if 'genn' in args.targets:
     import brian2genn
 
 for target in args.targets:
-    sys.stderr.write('Running test(s) {} for device {} ...\n'.format(args.test[0], target))
+    prefs['core.default_float_dtype'] = getattr(np, args.float_dtype[0])
+    sys.stderr.write('Running test(s) {} for device {} with float type {} '
+                     '...\n'.format(args.test[0], target, args.float_dtype[0]))
     set_device(target, directory=None, with_output=False)
     argv = ['nosetests', args.test[0],
             '-c=',  # no config file loading

--- a/brian2cuda/tools/run_single_test.py
+++ b/brian2cuda/tools/run_single_test.py
@@ -12,7 +12,7 @@ parser.add_argument('--targets', nargs='*', default=['cuda_standalone'], type=st
                     choices=['cuda_standalone', 'genn', 'cpp_standalone'],
                     help=("Which codegeneration targets to use, can be multiple. "
                           "Only standalone targets. (default=['cuda_standalone'])"))
-parser.add_argument('--float-dtype', nargs=1, default='float64', type=str,
+parser.add_argument('--float-dtype', nargs=1, default=['float64'], type=str,
                     choices=['float32', 'float64'], help=("The "
                     "prefs['core.default_float_dtype'] with which tests should be run."))
 parser.add_argument('--reset-prefs', action='store_true',

--- a/brian2cuda/tools/run_test_suite.py
+++ b/brian2cuda/tools/run_test_suite.py
@@ -10,7 +10,7 @@ parser.add_argument('--targets', nargs='*', default=['cuda_standalone'], type=st
                           "Only standalone targets. (default='cuda_standalone')"))
 parser.add_argument('--float-dtype', nargs='*', default=['float32', 'float64'],
                     choices=['float32', 'float64'], help=("The "
-                    "prefs['core.default_float_dtype'] for which tests should be run."))
+                    "prefs['core.default_float_dtype'] with which tests should be run."))
 parser.add_argument('--no-long-tests', action='store_false',
                     help="Set to not run long tests. By default they are run.")
 parser.add_argument('--no-reset-prefs', action='store_false',

--- a/brian2cuda/tools/run_test_suite.py
+++ b/brian2cuda/tools/run_test_suite.py
@@ -63,6 +63,8 @@ dtypes = []
 for dtype in args.float_dtype:
     dtypes.append(getattr(np, dtype))
 
+stored_prefs = prefs.as_file
+
 for target in args.targets:
 
     test_in_parallel = []
@@ -80,3 +82,5 @@ for target in args.targets:
              extra_test_dirs=extra_test_dirs,
              float_dtype=dtype
             )
+
+        prefs.read_preference_file(StringIO(stored_prefs))


### PR DESCRIPTION
PR for #37.
Our brian2 submodule now tracks the `float32_support` branch at my brian2 fork (denisalevi/brian2). This way we have the single precision support that we need and can easily pull any changes in the brian-team/brian2@float32_support branch. But if that branch stays unmerged, we can also merge in the updated master branch when needed. I don't see an easier solution right now if we want the single preference support.

The tests are passing except for the known issues and an additional issue when connecting synapses to synapses (not a new bug, just overseen before, see #133 ).

We can now also run all tests with single precision preference.