### PR TITLE
Make single precision mode more efficient

### DIFF
--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -179,6 +179,8 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
         super(CUDAStandaloneDevice, self).__init__()
 
     def get_array_name(self, var, access_data=True):
+        # In single-precision mode we replace dt variables in codeobjects with
+        # a single precision version, for details see #148
         if hasattr(var, 'real_var'):
             return self.get_array_name(var.real_var, access_data=access_data)
         return super(CUDAStandaloneDevice, self).get_array_name(var, access_data)
@@ -241,6 +243,8 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     variable_indices, codeobj_class=None, template_kwds=None,
                     override_conditional_write=None):
         if prefs['core.default_float_dtype'] == np.float32 and 'dt' in variables:
+            # In single-precision mode we replace dt variables in codeobjects with
+            # a single precision version, for details see #148
             dt_var = variables['dt']
             new_dt_var = ArrayVariable(dt_var.name,
                                        dt_var.owner,
@@ -547,8 +551,9 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
             else:
                 number_elements = "_N"
             for k, v in codeobj.variables.iteritems():
-                # use the double array versions for dt in the templates
                 if k == 'dt' and prefs['core.default_float_dtype'] == np.float32:
+                    # use the double-precision array versions for dt as kernel arguments
+                    # they are cast to single-precision scalar dt in scalar_code
                     v = v.real_var
                 #code objects which only run once
                 if k == "_python_randn" and codeobj.runs_every_tick == False and codeobj.template_name != "synapses_create_generator":
@@ -680,12 +685,17 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
             code = code.replace('%CODEOBJ_NAME%', codeobj.name)
             code = '#include "objects.h"\n'+code
 
+            # substitue in generated code double types with float types in
+            # single-precision mode
             if prefs['core.default_float_dtype'] == np.float32:
+                # cast time differences (double) to float in event-drive updates
                 sub = 't - lastupdate'
                 if sub in code:
                     code = code.replace(sub, 'float({})'.format(sub))
                     logger.debug("Replaced {sub} with float({sub}) in {codeobj}"
                                  "".format(sub=sub, codeobj=codeobj))
+                # replace double-precision floating-point literals with their
+                # single-precision version (e.g. `1.0` -> `1.0f`)
                 code = replace_floating_point_literals(code)
                 logger.debug("Replaced floating point literals by single "
                              "precision version (appending `f`) in {}."

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -31,6 +31,8 @@ from brian2.devices.cpp_standalone.device import CPPWriter, CPPStandaloneDevice
 from brian2.monitors.statemonitor import StateMonitor
 from brian2.groups.neurongroup import Thresholder
 
+from brian2cuda.utils.stringtools import replace_floating_point_literals
+
 from .codeobject import CUDAStandaloneCodeObject, CUDAStandaloneAtomicsCodeObject
 
 
@@ -684,6 +686,10 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     code = code.replace(sub, 'float({})'.format(sub))
                     logger.debug("Replaced {sub} with float({sub}) in {codeobj}"
                                  "".format(sub=sub, codeobj=codeobj))
+                code = replace_floating_point_literals(code)
+                logger.debug("Replaced floating point literals by single "
+                             "precision version (appending `f`) in {}."
+                             "".format(codeobj))
 
             writer.write('code_objects/'+codeobj.name+'.cu', code)
             writer.write('code_objects/'+codeobj.name+'.h', codeobj.code.h_file)

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -678,6 +678,13 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
             code = code.replace('%CODEOBJ_NAME%', codeobj.name)
             code = '#include "objects.h"\n'+code
 
+            if prefs['core.default_float_dtype'] == np.float32:
+                sub = 't - lastupdate'
+                if sub in code:
+                    code = code.replace(sub, 'float({})'.format(sub))
+                    logger.debug("Replaced {sub} with float({sub}) in {codeobj}"
+                                 "".format(sub=sub, codeobj=codeobj))
+
             writer.write('code_objects/'+codeobj.name+'.cu', code)
             writer.write('code_objects/'+codeobj.name+'.h', codeobj.code.h_file)
 

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -233,6 +233,13 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
     def code_object(self, owner, name, abstract_code, variables, template_name,
                     variable_indices, codeobj_class=None, template_kwds=None,
                     override_conditional_write=None):
+        if prefs['core.default_float_dtype'] == np.float32 and 'dt' in variables:
+            print 'DEBUG dt before\n', variables['dt']
+            variables['dt'] = Constant('dt',
+                                       np.float32(variables['dt'].get_value().item()),
+                                       dimensions=variables['dt'].dim,
+                                       owner=variables['dt'].owner)
+            print 'DEBUG dt after\n', variables['dt']
         if template_kwds is None:
             template_kwds = dict()
         else:

--- a/brian2cuda/tests/test_stringtools.py
+++ b/brian2cuda/tests/test_stringtools.py
@@ -6,22 +6,15 @@ from brian2cuda.utils.stringtools import replace_floating_point_literals
 
 @attr('codegen-independent')
 def test_replace_floating_point_literals():
-    float_literals = ['1.',
-                      '.2',
-                      '3.14',
-                      '5e6',
-                      '5e-6',
-                      '5E+6',
-                      '7.e8',
-                      '9.0E-10',
-                      '.11e12']
+    float_literals = ['1.', '.2', '3.14', '5e6', '5e-6', '5E+6', '7.e8',
+                      '9.0E-10', '.11e12']
 
-    others = ['-', '+', '/', '%', '*', '(', ')', ' ', ';', ':', '>', '<', '|',
-              '&']
+    delimiters = ['-', '+', '/', '%', '*', '(', ')', ' ', ';', ':', '>', '<',
+                  '|', '&', ',', '=']
 
     for l in float_literals:
-        for start in others:
-            for end in others:
+        for start in delimiters:
+            for end in delimiters:
                 string = start + l + end
                 f_string = start + l + 'f' + end
 
@@ -38,14 +31,27 @@ def test_replace_floating_point_literals():
     not_float_literals = ['1', '100', '002', 'a1.b', '-.-']
 
     for l in not_float_literals:
-        for start in others:
-            for end in others:
+        for start in delimiters:
+            for end in delimiters:
                 string = start + l + end
 
                 # test that these these are not matched
                 replaced = replace_floating_point_literals(string)
                 eq_(replaced, string)
 
+    # test that multiple concatenated literals are correctly replaced
+    concat = ''.join(a + b for a, b in zip(float_literals,
+                                           delimiters[:len(float_literals)]))
+    f_concat = ''.join(a + 'f' + b for a, b in zip(float_literals,
+                                                   delimiters[:len(float_literals)]))
+
+    # replacing double to single precision version
+    replaced = replace_floating_point_literals(concat)
+    eq_(replaced, f_concat)
+
+    # not replacing sincle precision version
+    f_replaced = replace_floating_point_literals(f_concat)
+    eq_(f_replaced, f_concat)
 
 if __name__ == '__main__':
     test_replace_floating_point_literals()

--- a/brian2cuda/tests/test_stringtools.py
+++ b/brian2cuda/tests/test_stringtools.py
@@ -1,0 +1,51 @@
+from nose.tools import eq_
+from nose.plugins.attrib import attr
+
+from brian2cuda.utils.stringtools import replace_floating_point_literals
+
+
+@attr('codegen-independent')
+def test_replace_floating_point_literals():
+    float_literals = ['1.',
+                      '.2',
+                      '3.14',
+                      '5e6',
+                      '5e-6',
+                      '5E+6',
+                      '7.e8',
+                      '9.0E-10',
+                      '.11e12']
+
+    others = ['-', '+', '/', '%', '*', '(', ')', ' ', ';', ':', '>', '<', '|',
+              '&']
+
+    for l in float_literals:
+        for start in others:
+            for end in others:
+                string = start + l + end
+                f_string = start + l + 'f' + end
+
+                # test that floating point literals are correctly replaced by
+                # single precision versions (`f` appended)
+                replaced = replace_floating_point_literals(string)
+                eq_(replaced, f_string)
+
+                # test that single precision floating-point literals are not
+                # touched (e.g `1.0f`)
+                f_replaced = replace_floating_point_literals(f_string)
+                eq_(f_replaced, f_string)
+
+    not_float_literals = ['1', '100', '002', 'a1.b', '-.-']
+
+    for l in not_float_literals:
+        for start in others:
+            for end in others:
+                string = start + l + end
+
+                # test that these these are not matched
+                replaced = replace_floating_point_literals(string)
+                eq_(replaced, string)
+
+
+if __name__ == '__main__':
+    test_replace_floating_point_literals()

--- a/brian2cuda/utils/__init__.py
+++ b/brian2cuda/utils/__init__.py
@@ -2,3 +2,4 @@
 Utility functions for Brian2CUDA
 '''
 from .logger import *
+from .stringtools import *

--- a/brian2cuda/utils/stringtools.py
+++ b/brian2cuda/utils/stringtools.py
@@ -3,7 +3,23 @@ Brian2CUDA regex functions.
 '''
 import re
 
+
 def append_f(match):
+    '''
+    Append ``'f'`` to the string in ``match`` if it doesn't end with ``'f'``.
+    Used in ``replace_floating_point_literals``.
+
+    Parameters
+    ----------
+    match : re.MatchObject
+        The return type of e.g. ``re.match`` or ``re.search``.
+
+    Returns
+    -------
+    str
+        The string returned from ``match.group()`` if it end with ``'f'``, else
+        the string with ``'f'`` appended.
+    '''
     string = match.group()
     if string.endswith('f'):
         # literal has already f
@@ -11,20 +27,50 @@ def append_f(match):
     f_string = string[:-1] + 'f' + string[-1]
     return f_string
 
-def replace_floating_point_literals(code, single_precision=True):
-    #regex = '[^A-Za-z_](((([1-9][0-9]*\.[0-9]*)|(\.[0-9]+))([Ee][+-]?[0-9]+)?)|([0-9]+([Ee][+-]?[0-9]+)))\D'#'(?!f)'
+
+def replace_floating_point_literals(code):
+    '''
+    Replace double-precision floating-point literals in ``code`` by
+    single-precision literals.
+
+    Parameters
+    ----------
+    code : str
+        A string to replace the literals in. C++ syntax is assumed, s.t. e.g.
+        `a1.b` would not be replaced.
+
+    Returns
+    -------
+    str
+        A copy of ``code``, with double-precision floating point literals
+        replaced by single-precision flaoting-point literals (with an ``f``
+        appended).
+
+    Examples
+    --------
+    >>> replace_floating_point_literals('1.|.2=3.14:5e6>.5E-2<7.e-8==a1.b')
+    1.f|.2f=3.14f:5e6f>.5E-2f<7.e-8f==a1.b
+
+    '''
+    # NOTE: this regex fails when `code` ends with a literal that should be
+    # replaced. E.g `sldkfjwe11.e12` -> `sldkfjwe11.fe12`, because the regex
+    # relies on the first non-digit after the literal, which is not existing at
+    # the end of the string. If ``code`` is a valid c++ file, this can't happen
+    # though.
+
     # numbers are not part of variable (e.g. `a1.method()`)
-    notV = '[^A-Za-z_]'
+    #notVar = '[^A-Za-z_]'
+    notVar = '(?<!([A-Za-z_]))'
     # anything that has a digit before the dot (e.g. 2.1, 3. 1002.0293)
     preDot = '([1-9]\d*\.\d*)'
     # anything that starts with dot (e.g. .1 .09382)
     postDot = '(\.\d+)'
     # exponential syntax (e.g. e12, E-4, e+100)
-    E = '([Ee][+-]?\d+)'
+    Exp = '([Ee][+-]?\d+)'
     # not digit (match the first not digit to check if it is `f` already)
-    notD = '(\D)'
-    regex = '{notV}((({preDot}|{postDot}){E}?)|(\d+{E})){notD}'.format(
-        notV=notV, preDot=preDot, postDot=postDot, E=E, notD=notD)
+    notDigit = '([\D$])'
+    regex = '{notVar}((({preDot}|{postDot}){Exp}?)|(\d+{Exp})){notDigit}'.format(
+        notVar=notVar, preDot=preDot, postDot=postDot, Exp=Exp, notDigit=notDigit)
     code = re.sub(regex, append_f, code)
     return code
 

--- a/brian2cuda/utils/stringtools.py
+++ b/brian2cuda/utils/stringtools.py
@@ -1,0 +1,30 @@
+'''
+Brian2CUDA regex functions.
+'''
+import re
+
+def append_f(match):
+    string = match.group()
+    if string.endswith('f'):
+        # literal has already f
+        return string
+    f_string = string[:-1] + 'f' + string[-1]
+    return f_string
+
+def replace_floating_point_literals(code, single_precision=True):
+    #regex = '[^A-Za-z_](((([1-9][0-9]*\.[0-9]*)|(\.[0-9]+))([Ee][+-]?[0-9]+)?)|([0-9]+([Ee][+-]?[0-9]+)))\D'#'(?!f)'
+    # numbers are not part of variable (e.g. `a1.method()`)
+    notV = '[^A-Za-z_]'
+    # anything that has a digit before the dot (e.g. 2.1, 3. 1002.0293)
+    preDot = '([1-9]\d*\.\d*)'
+    # anything that starts with dot (e.g. .1 .09382)
+    postDot = '(\.\d+)'
+    # exponential syntax (e.g. e12, E-4, e+100)
+    E = '([Ee][+-]?\d+)'
+    # not digit (match the first not digit to check if it is `f` already)
+    notD = '(\D)'
+    regex = '{notV}((({preDot}|{postDot}){E}?)|(\d+{E})){notD}'.format(
+        notV=notV, preDot=preDot, postDot=postDot, E=E, notD=notD)
+    code = re.sub(regex, append_f, code)
+    return code
+

--- a/brian2cuda/utils/stringtools.py
+++ b/brian2cuda/utils/stringtools.py
@@ -59,7 +59,9 @@ def replace_floating_point_literals(code):
     # though.
 
     # numbers are not part of variable (e.g. `a1.method()`)
-    #notVar = '[^A-Za-z_]'
+    # use negative lookbehind (?<!) in order to not consume the letter before
+    # the match, s.t. consecutive literals don't overlap (otherwise only one
+    # would be matched, e.g. `1.-.2;` -> `1.f-.2;` instead of `1.f-.2f;`)
     notVar = '(?<!([A-Za-z_]))'
     # anything that has a digit before the dot (e.g. 2.1, 3. 1002.0293)
     preDot = '([1-9]\d*\.\d*)'

--- a/examples/cuba_cuda.py
+++ b/examples/cuba_cuda.py
@@ -8,7 +8,9 @@ matplotlib.use('Agg')
 from brian2 import *
 
 import brian2cuda
-set_device('cuda_standalone', directory='CUBA_CUDA',compile=True, run=True, debug=True)
+set_device('cuda_standalone', directory='CUBA_CUDA_sp',compile=True, run=True, debug=True)
+
+prefs['core.default_float_dtype'] = float32
 
 taum = 20*ms
 taue = 5*ms


### PR DESCRIPTION
This is a PR for #148 
1. use single precision for `dt` variable in code objects
2. use single precision for constant literals
3. cast time differences in even-driven stateupdates to float `float(t-lastupdate)`