### PR TITLE
Cleanup KERNEL_VARIABLES

### DIFF
--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -640,7 +640,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     if k in ['t', 'timestep', '_clock_t', '_clock_timestep', '_source_t', '_source_timestep'] and v.scalar:  # monitors have not scalar t variables
                         arrayname = self.get_array_name(v)
                         host_parameters_lines.append(arrayname + '[0]')
-                        device_parameters_lines.append("const {dtype} _ptr_{name}".format(dtype=c_data_type(v.dtype), name=arrayname))
+                        device_parameters_lines.append("const {dtype} _ptr{name}".format(dtype=c_data_type(v.dtype), name=arrayname))
                     else:
                         try:
                             if isinstance(v, DynamicArrayVariable):
@@ -658,15 +658,15 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                     host_parameters_lines.append(array_name)
                                     host_parameters_lines.append("_num" + k)
 
-                                    line = "{c_type}* _ptr_{array_name}"
+                                    line = "{c_type}* _ptr{array_name}"
                                     device_parameters_lines.append(line.format(c_type=c_data_type(v.dtype), array_name=array_name))
-                                    line = "const int _num_{array_name}"
+                                    line = "const int _num{array_name}"
                                     device_parameters_lines.append(line.format(array_name=k))
 
                             else:  # v is ArrayVariable but not DynamicArrayVariable
                                 arrayname = self.get_array_name(v)
                                 host_parameters_lines.append("dev"+arrayname)
-                                device_parameters_lines.append("%s* _ptr_%s" % (c_data_type(v.dtype), arrayname))
+                                device_parameters_lines.append("%s* _ptr%s" % (c_data_type(v.dtype), arrayname))
 
                                 code_object_defs_lines.append('const int _num%s = %s;' % (k, v.size))
                                 kernel_variables_lines.append('const int _num%s = %s;' % (k, v.size))

--- a/brian2cuda/tools/remote_run_scripts/on_headnode.sh
+++ b/brian2cuda/tools/remote_run_scripts/on_headnode.sh
@@ -17,42 +17,6 @@ trap cleanup EXIT
 logdir="$(dirname $logfile)"
 run_name="$(basename $logfile)"
 
-mkdir -p logdir
-
-# get code state
-cd "$b2c_dir"
-b2c_branch="$(git rev-parse --abbrev-ref HEAD)"
-b2c_commit="$(git rev-parse HEAD)"
-b2c_diff="$(git diff)"
-cd frozen_repos/brian2
-brian2_branch="$(git rev-parse --abbrev-ref HEAD)"
-brian2_commit="$(git rev-parse HEAD)"
-brian2_diff="$(git diff)"
-
-# create logfile
-if [ -f $logfile ]; then
-    echo "ERROR: logfile $logfile already exists. Overwriting..."
-fi
-
-cat > "$logfile" <<EOL
-brian2CUDA test suite run
-name: $run_name
-run directory: $b2c_dir
-
-b2c branch: $b2c_branch
-b2c commit: $b2c_commit
---- b2c-diff start ---
-$b2c_diff
---- b2c-diff end ---
-
-brian2 branch: $brian2_branch
-brian2 commit: $brian2_commit
---- brian2-diff start ---
-$brian2_diff
---- brian2-diff end ---
-
-EOL
-
 # activate bashrc (for conda activation and CUDA paths)
 . ~/anaconda3/etc/profile.d/conda.sh
 conda activate b2c

--- a/brian2cuda/tools/run_test_suite.py
+++ b/brian2cuda/tools/run_test_suite.py
@@ -10,7 +10,7 @@ parser = argparse.ArgumentParser(description='Run the brian2 testsuite on GPU.')
 parser.add_argument('--no-long-tests', action='store_false',
                     help="Set to not run long tests. By default they are run.")
 
-parser.add_argument('--fail-not-implemented', action='store_true',
+parser.add_argument('--skip-not-implemented', action='store_true',
                     help="Weather to reset prefs between tests or not.")
 
 parser.add_argument('--test-parallel', nargs='?', const=None, default=[],
@@ -85,7 +85,7 @@ for target in args.targets:
                        test_codegen_independent=False,
                        test_standalone=target,
                        reset_preferences=False,
-                       fail_for_not_implemented=args.fail_not_implemented,
+                       fail_for_not_implemented=not args.skip_not_implemented,
                        test_in_parallel=test_in_parallel,
                        extra_test_dirs=extra_test_dirs,
                        float_dtype=None)


### PR DESCRIPTION
Remove unnecessary pointer copies in `%KERNEL_VARIABLES% inside codeobject kernels. Define pointer and variable keywords in the function definition (`%DEVICE_PARAMETERS%`) instead.

Good to go once tests have passed (running). 