### PR TITLE
Fix spikegenerator.cu template

### DIFF
--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -34,6 +34,7 @@ from brian2.devices.cpp_standalone.device import CPPWriter, CPPStandaloneDevice
 from brian2.monitors.statemonitor import StateMonitor
 from brian2.groups.neurongroup import Thresholder
 from brian2.input.timedarray import TimedArray
+from brian2.input.spikegeneratorgroup import SpikeGeneratorGroup
 
 from brian2cuda.utils.stringtools import replace_floating_point_literals
 
@@ -372,7 +373,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
         template_kwds["sm_multiplier"] = prefs["devices.cuda_standalone.SM_multiplier"]
         template_kwds["syn_launch_bounds"] = prefs["devices.cuda_standalone.syn_launch_bounds"]
         template_kwds["calc_occupancy"] = prefs["devices.cuda_standalone.calc_occupancy"]
-        if template_name == "threshold":
+        if template_name in ["threshold", "spikegenerator"]:
             template_kwds["extra_threshold_kernel"] = prefs["devices.cuda_standalone.extra_threshold_kernel"]
         codeobj = super(CUDAStandaloneDevice, self).code_object(owner, name, abstract_code, variables,
                                                                template_name, variable_indices,
@@ -392,9 +393,13 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
         curand_generator_type = prefs.devices.cuda_standalone.random_number_generator_type
         curand_generator_ordering = prefs.devices.cuda_standalone.random_number_generator_ordering
         self.eventspace_arrays = {}
+        self.spikegenerator_eventspaces = []
         for var, varname in self.arrays.iteritems():
             if var.name.endswith('space'):  # get all eventspace variables
                 self.eventspace_arrays[var] = varname
+                #if hasattr(var, 'owner') and isinstance(v.owner, Clock):
+                if isinstance(var.owner, SpikeGeneratorGroup):
+                    self.spikegenerator_eventspaces.append(varname)
         for var in self.eventspace_arrays.iterkeys():
             del self.arrays[var]
         multisyn_vars = []
@@ -422,6 +427,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                         curand_generator_ordering=curand_generator_ordering,
                         curand_float_type=c_data_type(prefs['core.default_float_dtype']),
                         eventspace_arrays=self.eventspace_arrays,
+                        spikegenerator_eventspaces=self.spikegenerator_eventspaces,
                         multisynaptic_idx_vars=multisyn_vars,
                         profiled_codeobjects=self.profiled_codeobjects)
         # Reinsert deleted entries, in case we use self.arrays later? maybe unnecassary...
@@ -804,7 +810,8 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
             maximum_run_time = float(maximum_run_time)
         network_tmp = self.code_object_class().templater.network(None, None,
                                                                  maximum_run_time=maximum_run_time,
-                                                                 eventspace_arrays=self.eventspace_arrays)
+                                                                 eventspace_arrays=self.eventspace_arrays,
+                                                                 spikegenerator_eventspaces=self.spikegenerator_eventspaces)
         writer.write('network.*', network_tmp)
 
     def generate_synapses_classes_source(self, writer):

--- a/brian2cuda/templates/network.cu
+++ b/brian2cuda/templates/network.cu
@@ -90,6 +90,9 @@ void Network::run(const double duration, void (*report_func)(const double, const
 
         // Advance index for circular eventspace vector (for no_or_const_delay_mode)
         {% for var, varname in eventspace_arrays | dictsort(by='value') %}
+        {% if varname in spikegenerator_eventspaces %}
+        brian::previous_idx{{varname}} = brian::current_idx{{varname}};
+        {% endif %}
         brian::current_idx{{varname}} = (brian::current_idx{{varname}} + 1) % brian::dev{{varname}}.size();
         {% endfor %}
 

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -49,6 +49,9 @@ const int brian::_num_{{varname}} = {{var.size}};
 const int brian::_num_{{varname}} = {{var.size}};
 thrust::host_vector<{{c_data_type(var.dtype)}}*> brian::dev{{varname}}(1);
 int brian::current_idx{{varname}} = 0;
+{% if varname in spikegenerator_eventspaces %}
+int brian::previous_idx{{varname}};
+{% endif %}
 {% endfor %}
 
 //////////////// dynamic arrays 1d /////////
@@ -570,6 +573,9 @@ extern {{c_data_type(var.dtype)}} * {{varname}};
 extern thrust::host_vector<{{c_data_type(var.dtype)}}*> dev{{varname}};
 extern const int _num_{{varname}};
 extern int current_idx{{varname}};
+{% if varname in spikegenerator_eventspaces %}
+extern int previous_idx{{varname}};
+{% endif %}
 {% endfor %}
 
 //////////////// dynamic arrays 2d /////////

--- a/brian2cuda/templates/spikegenerator.cu
+++ b/brian2cuda/templates/spikegenerator.cu
@@ -1,97 +1,80 @@
 {% extends 'common_group.cu' %}
-{% block extra_device_helper %}
-int mem_per_thread(){
-    return sizeof(int32_t);
-}
+{#
+    Notes: This codeobject is run every time step and fills the spikespace of
+           the spikegenerator neurongroup with the neuron IDs of the neurons that
+           spike in this time step. If there are multiple circular spikespaces
+           due to synaptic delays, the correct spikespaces are filled.
 
-__device__ int _last_element_checked = 0;
-{% endblock %}
+           I found the variable naming in the cpp_standalone template not very
+           intuitive. I changed names and referenced the corresponding name in
+           the cpp_standalone template. The implemented algorithm is the same
+           though.
 
-{% block kernel_call %}
-kernel_{{codeobj_name}}<<<num_blocks, num_threads>>>(
-        _N,
-        num_threads,
-        {{owner.clock.name}}.t[0],
-        {{owner.clock.name}}.dt[0],
-        ///// HOST_PARAMETERS /////
-        %HOST_PARAMETERS%
-    );
+           This tempalte is very similar to the threshold.cu template since it
+           has to fill the spikespace in a similar fashion. Therefore, it also
+           needs a separate kernel to reset the spikespace before filling it
+           again (we need a global synchronization after reset, therefore I use
+           two separate kernels). Additionally, this template needs to keep
+           track of the `lastindex` variable that references the index in the
+           spikes of the spikegenerator. This also needs to be set once per
+           time step with global synchronization. I added it to the reset
+           kernel.
 
-CUDA_CHECK_ERROR("kernel_{{codeobj_name}}");
-{% endblock kernel_call %}
+    Variables:
+     - {{spike_time}} and {{neuron_index}} are `times` and `index` of
+         SpikeGeneratorGroup and are storted first by times, then by index
+     - {{period}} gives generator period in ms, after which all spikes defined
+         by `times` and `index` are repeated.
+     - {{_lastindex} starts always with 0,
+     - `test`: True if a spike time comes after the current time step
+         (>= implementation with epsilon precision)
+
+    TODOs:
+     - We do know all spike times before the simulation. We could just
+       precompute all spikespaces once in the beginning for one period and reuse
+       them here. This could save quite some compute when using many periods of
+       input.
+     - The template ended up to be a bit messy with the
+       _get_time_within_period() function calls. We could just compute everything
+       on the host and pass the computed values that we need to the kernels
+       (instead of letting each thread compute the same).
+#}
+
+{# USES_VARIABLES {_spikespace, N, t, dt, neuron_index, spike_time, period, _lastindex } #}
 
 
-{% block kernel %}
-    {# USES_VARIABLES {_spikespace, N, neuron_index, spike_time, period, _lastindex } #}
-
-__global__ void
-{% if launch_bounds %}
-__launch_bounds__(1024, {{sm_multiplier}})
-{% endif %}
-kernel_{{codeobj_name}}(
-    int _N,
-    int THREADS_PER_BLOCK,
-    double t,
-    double dt,
-    ///// KERNEL_PARAMETERS /////
-    %KERNEL_PARAMETERS%
-    )
-{
-    {# USES_VARIABLES { N } #}
-    using namespace brian;
-
-    int tid = threadIdx.x;
-    int bid = blockIdx.x;
-    int _idx = bid * THREADS_PER_BLOCK + tid;
-    int _vectorisation_idx = _idx;
-
-    ///// KERNEL_CONSTANTS /////
-    %KERNEL_CONSTANTS%
-
-    ///// kernel_lines /////
-    {{kernel_lines|autoindent}}
-
-    if(_idx >= _N)
-    {
-        return;
-    }
-
-    double _the_period = {{period}};
-    double padding_before = fmod(t, _the_period);
-    double padding_after  = fmod(t+dt, _the_period);
-    double epsilon        = 1e-3*dt;
-
-    // We need some precomputed values that will be used during looping
-    bool not_first_spike = ({{_lastindex}} > 0);
-    bool not_end_period  = (fabs(padding_after) > epsilon);
+{% block maincode %}
+    double _epsilon = 1e-3 * {{dt}};
+    {# In spikegenerator.cpp, this is `padding_after` #}
+    double _time_within_period = _get_time_within_period({{t}}, {{dt}}, {{period}});
+    {# In spikegenerator.cpp, this is `(! not_end_period)` #}
+    const bool _last_in_period = _check_last_in_period(_time_within_period, _epsilon, {{period}});
     bool test;
 
-    //// MAIN CODE ////////////
-    // scalar code
-
-    for(int i = tid; i < N; i+= THREADS_PER_BLOCK)
+    // Reset the spikespace
+    for (int i = tid; i < N; i+= THREADS_PER_BLOCK)
     {
         {{_spikespace}}[i] = -1;
     }
 
-    if(tid == 0)
+    if (tid == 0)
     {
-        //init number of spikes with 0
+        // Reset number of spikes to 0
         {{_spikespace}}[N] = 0;
     }
     __syncthreads();
 
-    for(int spike_idx = {{_lastindex}} + tid; spike_idx < _numspike_time; spike_idx += THREADS_PER_BLOCK)
+    for (int spike_idx = {{_lastindex}} + tid; spike_idx < _numspike_time; spike_idx += THREADS_PER_BLOCK)
     {
-        if (not_end_period)
+        if (! _last_in_period)
         {
-            test = ({{spike_time}}[spike_idx] > padding_after) || (fabs({{spike_time}}[spike_idx] - padding_after) < epsilon);
+            test = ({{spike_time}}[spike_idx] > _time_within_period) || (fabs({{spike_time}}[spike_idx] - _time_within_period) < _epsilon);
         }
         else
         {
             // If we are in the last timestep before the end of the period, we remove the first part of the
             // test, because padding will be 0
-            test = (fabs({{spike_time}}[spike_idx] - padding_after) < epsilon);
+            test = (fabs({{spike_time}}[spike_idx] - _time_within_period) < _epsilon);
         }
         if (test)
         {
@@ -99,14 +82,103 @@ kernel_{{codeobj_name}}(
         }
         int32_t neuron_id = {{neuron_index}}[spike_idx];
         int32_t spikespace_index = atomicAdd(&{{_spikespace}}[N], 1);
-        atomicAdd(&{{_lastindex}}, 1);
         {{_spikespace}}[spikespace_index] = neuron_id;
-        __syncthreads();
     }
-}
+
 {% endblock %}
 
-{% block prepare_kernel_inner %}
-num_threads = 1;
-num_blocks = 1;
+
+{% block extra_device_helper %}
+    {# Since we use these functions in both, the codeobject and the reset
+       kernel, I defined extra functions for them. #}
+    __host__ __device__ inline double
+    _get_time_within_period(double _t, double _dt, double _the_period)
+    {
+        // In cpp_standalone template, this is called `padding_after`
+        return fmod(_t + _dt, _the_period);
+    }
+
+
+    __host__ __device__ inline const bool
+    _check_last_in_period(
+            double _time_within_period,
+            double _epsilon,
+            double _the_period)
+    {
+        // Whether the current time step IS NOT the last of the period
+        // Naming taken from cpp_standalone template
+        const bool not_end_period = (fabs(_time_within_period) > _epsilon) \
+                                    && (fabs(_time_within_period) < (_the_period - _epsilon));
+
+        // Return, whether the current time step IS the last of the period
+        return (! not_end_period);
+    }
+
+
+    __global__ void
+    {% if launch_bounds %}
+    __launch_bounds__(1024, {{sm_multiplier}})
+    {% endif %}
+    _reset_{{codeobj_name}}(
+        //int32_t* _spikespace,
+        int32_t* _previous_spikespace,
+        ///// KERNEL_PARAMETERS /////
+        %KERNEL_PARAMETERS%
+        )
+    {
+        using namespace brian;
+
+        int _idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+        // We need kernel_lines for time variables
+        ///// kernel_lines /////
+        {{kernel_lines|autoindent}}
+
+        if (_idx >= N) {
+            return;
+        }
+
+        if (_idx == 0)
+        {
+            // TODO: Should we compute _first_in_period on the host instead?
+            // If the previous time step was last in the period, this time step
+            // is the first in the new period.
+            double _epsilon = 1e-3 * {{dt}};
+            double _previous_t = {{t}} - {{dt}};
+            double _prev_time_within_period = _get_time_within_period(_previous_t, {{dt}}, {{period}});
+            const bool _first_in_period = _check_last_in_period(_prev_time_within_period, _epsilon, {{period}});
+
+            // If there is a periodicity in the SpikeGenerator, we need to reset the lastindex
+            // when all spikes have been played and the start of a new period.
+            if (_first_in_period) {
+                // Reset the spike index within a period
+                {{_lastindex}} = 0;
+            }
+            else {
+                // Update the last spike index with the number of spikes in the
+                // previous time step
+                {{_lastindex}} += _previous_spikespace[N];
+            }
+
+            // Reset spikespace counter for this time step
+            {{_spikespace}}[N] = 0;
+        }
+
+        // Reset spikespace
+        {{_spikespace}}[_idx] = -1;
+    }
 {% endblock %}
+
+
+{% block extra_kernel_call %}
+    {% set _spikespace_name = get_array_name(variables['_spikespace'], access_data=False) %}
+    // Note: If we have no delays, there is only one spikespace and
+    //       current_idx equals previous_idx.
+    _reset_{{codeobj_name}}<<<num_blocks, num_threads>>>(
+            dev{{_spikespace_name}}[previous_idx{{_spikespace_name}}],
+            ///// HOST_PARAMETERS /////
+            %HOST_PARAMETERS%
+        );
+
+    CUDA_CHECK_ERROR("_reset_{{codeobj_name}}");
+{% endblock extra_kernel_call %}


### PR DESCRIPTION
Fixes bug in periodicity (see #48) and and implement correct spikespace usage when having homogeneous delays.

Tests are running.

The spikegenerator template could be further optimized, but I am leaving this for another time (see #193).

Additional TODOs:
- [ ] There is a test in `brian2/tests/test_spikegenerator` which is not marked as `standalone-compatible`. Implement that for `cuda_standalone`.
- [ ] Write test(s) that use the spikegenerator as source of a `Synapses` object with homogeneous and heterogeneous delays. I didn't test at all if the spikespaces work correctly.
- [ ] Check if advancing the circular eventspace indices in network.cu works if the spikegenerator (or a thresholder) run on a different clock dt?