### PR TITLE
Issue 195: Refactoring prefs

### DIFF
--- a/brian2cuda/cuda_prefs.py
+++ b/brian2cuda/cuda_prefs.py
@@ -2,22 +2,160 @@
 Preferences that relate to the brian2cuda interface.
 '''
 
-from brian2.core.preferences import prefs, BrianPreference
+from brian2.core.preferences import prefs, BrianPreference, PreferenceError
+from brian2.core.core_preferences import default_float_dtype_validator, dtype_repr
+import numpy as np
 
 
+def compute_capability_validator(cc):
+    """
+    This function checks compute capability preference and raises an error if it is
+    larger than the minimal supported compute capability.
+    """
+    if cc is not None:
+        pref_name = "prefs.devices.cuda_standalone.cuda_backend.compute_capability"
+        if not isinstance(cc, float):
+            raise PreferenceError(
+                "Preference `{}` has to be of type float "
+                "(e.g. `6.1`), got `{}`".format(pref_name, type(cc))
+            )
+
+    return True
+
+
+# Preferences
 prefs.register_preferences(
-    'codegen.cuda',
-    'CUDA compilation preferences',
-    extra_compile_args_nvcc=BrianPreference(
-        docs='''Extra compile arguments (a list of strings) to pass to the nvcc compiler.''',
-        default=['-w', '-use_fast_math']
-    )
+    'devices.cuda_standalone',
+    'CUDA standalone preferences',
+
+    SM_multiplier = BrianPreference(
+        default=1,
+        docs='''
+        The number of blocks per SM. By default, this value is set to 1.
+        ''',
+        ),
+
+    parallel_blocks = BrianPreference(
+        docs='''
+        The total number of parallel blocks to use. The default is the number
+        of streaming multiprocessors.
+        ''',
+        validator=lambda v: v is None or (isinstance(v, int) and v > 0),
+        default=None),
+
+    launch_bounds=BrianPreference(
+        docs='''
+        Weather or not to use `__launch_bounds__` to optimise register usage in kernels.
+        ''',
+        default=False),
+
+    syn_launch_bounds=BrianPreference(
+        docs='''
+        Weather or not to use `__launch_bounds__` in synapses and synapses_push to optimise register usage in kernels.
+        ''',
+        default=False),
+
+    calc_occupancy=BrianPreference(
+        docs='''
+        Weather or not to use cuda occupancy api to choose num_threads and num_blocks.
+        ''',
+        default=True),
+
+    extra_threshold_kernel=BrianPreference(
+        docs='''
+        Weather or not to use a extra threshold kernel for resetting or not.
+        ''',
+        default=True),
+
+    random_number_generator_type=BrianPreference(
+        docs='''Generator type (str) that cuRAND uses for random number generation.
+            Setting the generator type automatically resets the generator ordering
+            (prefs.devices.cuda_standalone.random_number_generator_ordering) to its default value.
+            See cuRAND documentation for more details on generator types and orderings.''',
+        validator=lambda v: v in ['CURAND_RNG_PSEUDO_DEFAULT',
+                                  'CURAND_RNG_PSEUDO_XORWOW',
+                                  'CURAND_RNG_PSEUDO_MRG32K3A',
+                                  'CURAND_RNG_PSEUDO_MTGP32',
+                                  'CURAND_RNG_PSEUDO_PHILOX4_32_10',
+                                  'CURAND_RNG_PSEUDO_MT19937',
+                                  'CURAND_RNG_QUASI_DEFAULT',
+                                  'CURAND_RNG_QUASI_SOBOL32',
+                                  'CURAND_RNG_QUASI_SCRAMBLED_SOBOL32',
+                                  'CURAND_RNG_QUASI_SOBOL64',
+                                  'CURAND_RNG_QUASI_SCRAMBLED_SOBOL64'],
+        default='CURAND_RNG_PSEUDO_DEFAULT'),
+
+    random_number_generator_ordering=BrianPreference(
+        docs='''The ordering parameter (str) used to choose how the results of cuRAND
+            random number generation are ordered in global memory.
+            See cuRAND documentation for more details on generator types and orderings.''',
+        validator=lambda v: not v or v in ['CURAND_ORDERING_PSEUDO_DEFAULT',
+                                           'CURAND_ORDERING_PSEUDO_BEST',
+                                           'CURAND_ORDERING_PSEUDO_SEEDED',
+                                           'CURAND_ORDERING_QUASI_DEFAULT'],
+        default=False),  # False will prevent setting ordering in objects.cu (-> curRAND will uset the correct ..._DEFAULT)
+
+    push_synapse_bundles=BrianPreference(
+        docs='''If True, synaptic events are propagated by pushing bundles of
+        synapse IDs with same delays into the corresponding delay queue. If
+        False, each synapse of a spiking neuron is pushed in the corresponding
+        queue individually. For very small bundle sizes (number of synapses
+        with same delay, connected to a single neuron), pushing single Synapses
+        can be faster. This option only has effect for `Synapses` objects ith
+        heterogenous delays.''',
+        default=True),
+
+    no_pre_references=BrianPreference(
+        docs='''Set this preference if you don't need access to ``i`` in any
+        synaptic code string and no Synapses object applies effects to
+        presynaptic variables. This preference is for memory optimization until
+        unnecassary device memory allocations in synapse creation are fixed, it
+        is only relevant if your network uses close to all memory.''',
+        default=False),
+
+    no_post_references=BrianPreference(
+        docs='''Set this preference if you don't need access to ``j`` in any
+        synaptic code string and no Synapses object applies effects to
+        postsynaptic variables. This preference is for memory optimization until
+        unnecassary device memory allocations in synapse creation are fixed, it
+        is only relevant if your network uses close to all memory.''',
+        default=False),
+    
+    default_functions_integral_convertion=BrianPreference(
+        docs='''The floating point precision to which integral types will be converted when
+        passed as arguments to default functions that have no integral type overload in device
+        code (sin, cos, tan, sinh, cosh, tanh, exp, log, log10, sqrt, ceil, floor, arcsin, arccos, arctan)."
+        NOTE: Convertion from 32bit and 64bit integral types to single precision (32bit) floating-point
+        types is not type safe. And convertion from 64bit integral types to double precision (64bit)
+        floating-point types neither. In those cases the closest higher or lower (implementation
+        defined) representable value will be selected.''',
+        validator=default_float_dtype_validator,
+        representor=dtype_repr,
+        default=np.float64),
+
+    use_atomics=BrianPreference(
+        docs='''Weather to try to use atomic operations for synaptic effect
+        application. Since this avoids race conditions, effect application can
+        be parallelised.''',
+        validator=lambda v: isinstance(v, bool),
+        default=True)
 )
 
 prefs.register_preferences(
-    'brian2cuda',
-    'General brian2CUDA preferences',
-
+    'devices.cuda_standalone.cuda_backend',
+    'CUDA standalone CUDA backend preferences',
+    
+    gpu_heap_size = BrianPreference(
+        docs='''
+        Size of the heap (in MB) used by malloc() and free() device system calls, which
+        are used in the `cudaVector` implementation. `cudaVectors` are used to
+        dynamically allocate device memory for `SpikeMonitors` and the synapse
+        queues in the `CudaSpikeQueue` implementation for networks with
+        heterogeneously distributed delays.
+        ''',
+        validator=lambda v: isinstance(v, int) and v >= 0,
+        default=128),
+    
     detect_gpus=BrianPreference(
         docs='''Whether to detect names and compute capabilities of all available GPUs.
         This needs access to `nvidia-smi` and `deviceQuery` binaries.''',
@@ -30,11 +168,24 @@ prefs.register_preferences(
         default=None,
         validator=lambda v: v is None or isinstance(v, int)
     ),
+    
+    extra_compile_args_nvcc=BrianPreference(
+        docs='''Extra compile arguments (a list of strings) to pass to the nvcc compiler.''',
+        default=['-w', '-use_fast_math']
+    ),
+    
+    compute_capability=BrianPreference(
+        docs='''Manually set the compute capability for which CUDA code will be
+        compiled. Has to be a float (e.g. `6.1`) or None. If None, compute capability is
+        chosen depending on GPU in use. ''',
+        validator=compute_capability_validator,
+        default=None),
 
     cuda_path=BrianPreference(
         docs='''The path to the CUDA installation. If set, this preferences takes
         precedence over environment variable `CUDA_PATH`.''',
         default=None,
         validator=lambda v: v is None or isinstance(v, str)
-    ),
+    )
+    
 )

--- a/brian2cuda/tests/test_cuda_generator.py
+++ b/brian2cuda/tests/test_cuda_generator.py
@@ -370,13 +370,13 @@ def test_default_function_convertion_preference():
 
     unrepresentable_int = 2**24 + 1  # can't be represented as 32bit float
 
-    prefs.codegen.generators.cuda.default_functions_integral_convertion = np.float32
+    prefs.devices.cuda_standalone.default_functions_integral_convertion = np.float32
     G = NeuronGroup(1, 'v: 1')
     G.variables.add_array('myarr', dtype=np.int32, size=1)
     G.variables['myarr'].set_value(unrepresentable_int)
     G.v = 'floor(myarr)'.format(unrepresentable_int)
 
-    prefs.codegen.generators.cuda.default_functions_integral_convertion = np.float64
+    prefs.devices.cuda_standalone.default_functions_integral_convertion = np.float64
     G2 = NeuronGroup(1, 'v: 1')
     G2.variables.add_array('myarr', dtype=np.int32, size=1)
     G2.variables['myarr'].set_value(unrepresentable_int)
@@ -422,7 +422,7 @@ def test_default_function_convertion_warnings():
         G4.variables.add_array('myarr', dtype=np.uint32, size=1)
         G4.v = 'arcsin(i*myarr)'
 
-    prefs.codegen.generators.cuda.default_functions_integral_convertion = np.float32
+    prefs.devices.cuda_standalone.default_functions_integral_convertion = np.float32
 
     BrianLogger._log_messages.clear()
     with catch_logs() as logs5:

--- a/brian2cuda/tests/test_gpu_detection.py
+++ b/brian2cuda/tests/test_gpu_detection.py
@@ -40,7 +40,7 @@ def test_wrong_cuda_path_error():
 @with_setup(teardown=reinit_devices)
 def test_manual_setting_compute_capability():
     compute_capability_pref = '3.5'
-    prefs.codegen.generators.cuda.compute_capability = float(compute_capability_pref)
+    prefs.devices.cuda_standalone.cuda_backend.compute_capability = float(compute_capability_pref)
     with catch_logs(log_level=logging.INFO) as logs:
         run(0*ms)
     log_start = "Compiling device code for compute capability "
@@ -53,7 +53,7 @@ def test_manual_setting_compute_capability():
 @attr('cuda_standalone', 'standalone-only')
 @with_setup(teardown=reinit_devices)
 def test_unsupported_compute_capability_error():
-    prefs.codegen.generators.cuda.compute_capability = 2.0
+    prefs.devices.cuda_standalone.cuda_backend.compute_capability = 2.0
     with assert_raises(NotImplementedError):
         run(0*ms)
 
@@ -61,7 +61,7 @@ def test_unsupported_compute_capability_error():
 @attr('cuda_standalone', 'standalone-only')
 @with_setup(teardown=reinit_devices)
 def test_warning_compute_capability_set_twice():
-    prefs.codegen.generators.cuda.compute_capability = 3.5
+    prefs.devices.cuda_standalone.cuda_backend.compute_capability = 3.5
     prefs.codegen.cuda.extra_compile_args_nvcc.append('-arch=sm_37')
     with catch_logs() as logs:
         run(0*ms)
@@ -76,7 +76,7 @@ def test_warning_compute_capability_set_twice():
 @attr('cuda_standalone', 'standalone-only')
 @with_setup(teardown=reinit_devices)
 def test_no_gpu_detection_preference_error():
-    prefs.brian2cuda.detect_gpus = False
+    prefs.devices.cuda_standalone.cuda_backend.detect_gpus = False
     # needs setting gpu_id and compute_capability as well
     with assert_raises(PreferenceError):
         run(0*ms)
@@ -86,7 +86,7 @@ def test_no_gpu_detection_preference_error():
 @with_setup(teardown=reinit_devices)
 def test_no_gpu_detection_preference():
     # Test that disabling gpu detection works when setting gpu_id and compute_capability
-    prefs.brian2cuda.detect_gpus = False
-    prefs.brian2cuda.gpu_id = 0
-    prefs.codegen.generators.cuda.compute_capability = 6.1
+    prefs.devices.cuda_standalone.cuda_backend.detect_gpus = False
+    prefs.devices.cuda_standalone.cuda_backend.gpu_id = 0
+    prefs.devices.cuda_standalone.cuda_backend.compute_capability = 6.1
     run(0*ms)

--- a/brian2cuda/tests/test_synaptic_propagations.py
+++ b/brian2cuda/tests/test_synaptic_propagations.py
@@ -72,7 +72,7 @@ def test_CudaSpikeQueue_push_outer_loop2():
     num_blocks = 1
     prefs['devices.cuda_standalone.parallel_blocks'] = num_blocks
     # make sure we don't use less then 1024 threads due to register usage
-    prefs['codegen.cuda.extra_compile_args_nvcc'] += ['-maxrregcount=64']
+    prefs['devices.cuda_standalone.cuda_backendextra_compile_args_nvcc'] += ['-maxrregcount=64']
 
     threads_per_block = 1024
     neurons_per_block = 2 * threads_per_block

--- a/brian2cuda/tools/utils.py
+++ b/brian2cuda/tools/utils.py
@@ -122,7 +122,7 @@ def set_preferences(args, prefs, fast_compilation=True, suppress_warnings=True,
     if suppress_warnings:
         # Surpress some warnings from nvcc compiler
         compile_args = ['-Xcudafe "--diag_suppress=declared_but_not_referenced"']
-        prefs['codegen.cuda.extra_compile_args_nvcc'].extend(compile_args)
+        prefs['devices.cuda_standalone.cuda_backend.extra_compile_args_nvcc'].extend(compile_args)
         prints.append("Suppressing compiler warnings")
 
     if args.jobs is not None:
@@ -149,7 +149,7 @@ def set_preferences(args, prefs, fast_compilation=True, suppress_warnings=True,
 
         if not args.no_atomics:
             all_prefs_list.append(
-                {'codegen.generators.cuda.use_atomics': False})
+                {'devices.cuda_standalone.use_atomics': False})
 
         # create a powerset (all combinations) of the all_prefs_list
         all_prefs_combinations = []
@@ -168,7 +168,7 @@ def set_preferences(args, prefs, fast_compilation=True, suppress_warnings=True,
         fixed_prefs_dict[k] = v
 
     if args.no_atomics:
-        k = 'codegen.generators.cuda.use_atomics'
+        k = 'devices.cuda_standalone.use_atomics'
         v = False
         prefs[k] = v
         fixed_prefs_dict[k] = v

--- a/brian2cuda/utils/gputools.py
+++ b/brian2cuda/utils/gputools.py
@@ -42,7 +42,7 @@ def get_cuda_path():
     """
     Detect the path to the CUDA installation (e.g. '/usr/local/cuda'). This takes into
     account user defined environmental variable `CUDA_PATH` and preference
-    `prefs.brian2cuda.cuda_path`.
+    `prefs.devices.cuda_standalone.cuda_backend.cuda_path`.
     """
     # If cuda_path was already detected, reuse the global variable
     global _cuda_installation
@@ -109,7 +109,7 @@ def get_available_gpus():
 
 def select_gpu():
     """
-    Select GPU for simulation, based on user preference `prefs.brian2cuda.gpu_id` or (if
+    Select GPU for simulation, based on user preference `prefs.devices.cuda_standalone.cuda_backend.gpu_id` or (if
     not provided) pick the GPU with highest compute capability. Returns tuple of
     (gpu_id, compute_capability) of type (int, float).
     """
@@ -166,11 +166,11 @@ def restore_gpu_selection(gpu_selection):
 
 def _get_cuda_path():
     # Use preference if set
-    cuda_path_pref = prefs.brian2cuda.cuda_path
+    cuda_path_pref = prefs.devices.cuda_standalone.cuda_backend.cuda_path
     if cuda_path_pref is not None:
         logger.info(
             "CUDA installation directory given via preference "
-            "`prefs.brian2cuda.cuda_path={}`".format(cuda_path_pref)
+            "`prefs.devices.cuda_standalone.cuda_backend.cuda_path={}`".format(cuda_path_pref)
         )
         return cuda_path_pref
 
@@ -260,10 +260,10 @@ def _get_cuda_runtime_version():
 
 
 def _select_gpu():
-    gpu_id = prefs.brian2cuda.gpu_id
-    compute_capability = prefs.codegen.generators.cuda.compute_capability
+    gpu_id = prefs.devices.cuda_standalone.cuda_backend.gpu_id
+    compute_capability = prefs.devices.cuda_standalone.cuda_backend.compute_capability
     gpu_list = None
-    if prefs.brian2cuda.detect_gpus:
+    if prefs.devices.cuda_standalone.cuda_backend.detect_gpus:
         if gpu_id is None:
             gpu_id, compute_capability = get_best_gpu()
         else:
@@ -276,11 +276,11 @@ def _select_gpu():
         )
         if gpu_id is None or compute_capability is None:
             raise PreferenceError(
-                "Got `prefs.brian2cuda.detect_gpus` == `False`. Without GPU detection, "
-                "you need to set `prefs.brian2cuda.gpu_id` and "
-                "`prefs.codegen.generators.cuda.compute_capability` (got "
-                "`{prefs.brian2cuda.gpu_id}` and "
-                "`{prefs.codegen.generators.cuda.compute_capability}`).".format(
+                "Got `prefs.devices.cuda_standalone.cuda_backend.detect_gpus` == `False`. Without GPU detection, "
+                "you need to set `prefs.devices.cuda_standalone.cuda_backend.gpu_id` and "
+                "`prefs.devices.cuda_standalone.cuda_backend.compute_capability` (got "
+                "`{prefs.devices.cuda_standalone.cuda_backend.gpu_id}` and "
+                "`{prefs.devices.cuda_standalone.cuda_backend.compute_capability}`).".format(
                     prefs=prefs
                 )
             )
@@ -347,7 +347,7 @@ def _get_available_gpus():
             "Running `{command}` failed. If `nvidia-smi` is not available in your "
             "system, you can disable automatic detection of GPU name and compute "
             "capability by setting "
-            "`prefs.devices.brian2cuda.detect_gpus` = `False`".format(
+            "`prefs.devices.cuda_standalone.cuda_backend.detect_gpus` = `False`".format(
                 command=command
             )
         )
@@ -393,7 +393,7 @@ def get_compute_capability(gpu_id):
             "the GPU. Please open an issue at "
             "https://github.com/brian-team/brian2cuda/issues/new. To continue, you can "
             "set the compute capability manually via "
-            "`prefs.codegen.generators.cuda.compute_capability` (visit "
+            "`prefs.devices.cuda_standalone.cuda_backend.compute_capability` (visit "
             "https://developer.nvidia.com/cuda-gpus to find the compute capability of "
             "your GPU).".format(device_query_path)
         )

--- a/dev/benchmarks/results_2018_08_27_complete_before_september/merope_heterogeneous_no_bundle_no_atomics/run_speed_test_script.py
+++ b/dev/benchmarks/results_2018_08_27_complete_before_september/merope_heterogeneous_no_bundle_no_atomics/run_speed_test_script.py
@@ -83,7 +83,7 @@ configs = [# configuration                          project_directory
            'cuda_standalone'),
 
           (DynamicConfigCreator("CUDA standalone (no atomics)",
-                                prefs={'codegen.generators.cuda.use_atomics': False}),
+                                prefs={'devices.cuda_standalone.use_atomics': False}),
            'cuda_standalone'),
 
           (DynamicConfigCreator("CUDA standalone (1 post block)",
@@ -91,12 +91,12 @@ configs = [# configuration                          project_directory
            'cuda_standalone'),
 
           #(DynamicConfigCreator("CUDA standalone (no atomics, no bundles)",
-          #                      prefs={'codegen.generators.cuda.use_atomics': False,
+          #                      prefs={'devices.cuda_standalone.use_atomics': False,
           #                             'devices.cuda_standalone.push_synapse_bundles': False}),
           # 'cuda_standalone'),
 
           #(DynamicConfigCreator("CUDA standalone (no atomics, 1 post block)",
-          #                      prefs={'codegen.generators.cuda.use_atomics': False,
+          #                      prefs={'devices.cuda_standalone.use_atomics': False,
           #                             'devices.cuda_standalone.parallel_blocks': 1}),
           # 'cuda_standalone'),
 

--- a/dev/benchmarks/run_manunscript_runtime_vs_N_benchmarks.py
+++ b/dev/benchmarks/run_manunscript_runtime_vs_N_benchmarks.py
@@ -134,11 +134,11 @@ configs = [# configuration                          project_directory
 
 
           #(DynamicConfigCreator('CUDA standalone (max blocks, no atomics)',
-          #                      prefs={'codegen.generators.cuda.use_atomics': False}),
+          #                      prefs={'devices.cuda_standalone.use_atomics': False}),
           # 'cuda_standalone'),
 
           #(DynamicConfigCreator('CUDA standalone (1 block, no atomics)',
-          #                      prefs={'codegen.generators.cuda.use_atomics': False,
+          #                      prefs={'devices.cuda_standalone.use_atomics': False,
           #                             'devices.cuda_standalone.parallel_blocks': 1}),
           # 'cuda_standalone'),
 

--- a/dev/benchmarks/run_speed_tests.py
+++ b/dev/benchmarks/run_speed_tests.py
@@ -79,11 +79,11 @@ configs = [# configuration                          project_directory
            'cuda_standalone'),
 
           (DynamicConfigCreator('CUDA standalone (15 blocks, no atomics)',
-                                prefs={'codegen.generators.cuda.use_atomics': False}),
+                                prefs={'devices.cuda_standalone.use_atomics': False}),
            'cuda_standalone'),
 
           (DynamicConfigCreator('CUDA standalone (1 block, no atomics)',
-                                prefs={'codegen.generators.cuda.use_atomics': False,
+                                prefs={'devices.cuda_standalone.use_atomics': False,
                                        'devices.cuda_standalone.parallel_blocks': 1}),
            'cuda_standalone'),
 

--- a/dev/documentation/preferences.txt
+++ b/dev/documentation/preferences.txt
@@ -1,12 +1,12 @@
 
-prefs.codegen.generators.cuda.default_functions_integral_convertion = 'single_precision' | 'double_precision'
+prefs.devices.cuda_standalone.default_functions_integral_convertion = 'single_precision' | 'double_precision'
 We can use this between definitions, getting different behaviour for different codeobjects
 ```
-prefs.codegen.generators.cuda.default_functions_integral_convertion == 'double_precision'
+prefs.devices.cuda_standalone.default_functions_integral_convertion == 'double_precision'
 G = NeuronGroup(1, 'v:1')
 G.v = 'sin(i)'  # will convert i to double
 
-prefs.codegen.generators.cuda.default_functions_integral_convertion == 'single_precision'
+prefs.devices.cuda_standalone.default_functions_integral_convertion == 'single_precision'
 G2 = NeuronGroup(1, 'v:1')
 G.v = 'sin(i)'  # will convert i to float
 

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -140,7 +140,7 @@ def set_prefs(params, prefs):
             prefs['devices.cuda_standalone.push_synapse_bundles'] = False
 
         if not params['atomics']:
-            prefs['codegen.generators.cuda.use_atomics'] = False
+            prefs['devices.cuda_standalone.use_atomics'] = False
 
     if params['single_precision']:
         from numpy import float32


### PR DESCRIPTION
I have two queries 

1. Should I change the strings present in logger.py 
2. In `run_speed_test_script.py`, we see `prefs['devices.cuda_standalone.profile'] = 'blocking'` , but such a preference is not present. Should I add it ?

I have also pushed changes for [#140](https://github.com/brian-team/brian2cuda/issues/140) here.

The output is 

```
INFO       CUDA installation directory detected via location of `nvcc` binary: /usr/local/cuda [brian2.devices.cuda_standalone]
INFO       Automatic detection of GPU names and compute capabilities disabled, using manual preferences [brian2.devices.cuda_standalone]
INFO       Compiling device code for GPU 0 [brian2.devices.cuda_standalone]
INFO       Compiling device code for compute capability 7.5 (compiler flags: ['-arch=sm_75']) [brian2.devices.cuda_standalone]
INFO       Using the following preferences for CUDA standalone: [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.random_number_generator_ordering = False [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.parallel_blocks = None [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.push_synapse_bundles = True [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.launch_bounds = False [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.use_atomics = True [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.cuda_backend.detect_gpus = False [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.extra_threshold_kernel = True [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.calc_occupancy = True [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.cuda_backend.compute_capability = 7.5 [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.SM_multiplier = 1 [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.cuda_backend.extra_compile_args_nvcc = ['-use_fast_math'] [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.cuda_backend.cuda_path = None [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.cuda_backend.gpu_heap_size = 128 [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.cuda_backend.gpu_id = 0 [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.no_post_references = False [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.random_number_generator_type = CURAND_RNG_PSEUDO_DEFAULT [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.default_functions_integral_convertion = <type 'numpy.float64'> [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.no_pre_references = False [brian2.devices.cuda_standalone]
INFO       devices.cuda_standalone.syn_launch_bounds = False [brian2.devices.cuda_standalone]

```