### PR TITLE
Acknowledge `CUDA_DEVICE_QUERY` during GPU selection

### DIFF
--- a/brian2cuda/cuda_prefs.py
+++ b/brian2cuda/cuda_prefs.py
@@ -120,7 +120,7 @@ prefs.register_preferences(
         unnecassary device memory allocations in synapse creation are fixed, it
         is only relevant if your network uses close to all memory.''',
         default=False),
-    
+
     default_functions_integral_convertion=BrianPreference(
         docs='''The floating point precision to which integral types will be converted when
         passed as arguments to default functions that have no integral type overload in device
@@ -144,7 +144,7 @@ prefs.register_preferences(
 prefs.register_preferences(
     'devices.cuda_standalone.cuda_backend',
     'CUDA standalone CUDA backend preferences',
-    
+
     gpu_heap_size = BrianPreference(
         docs='''
         Size of the heap (in MB) used by malloc() and free() device system calls, which
@@ -155,7 +155,7 @@ prefs.register_preferences(
         ''',
         validator=lambda v: isinstance(v, int) and v >= 0,
         default=128),
-    
+
     detect_gpus=BrianPreference(
         docs='''Whether to detect names and compute capabilities of all available GPUs.
         This needs access to `nvidia-smi` and `deviceQuery` binaries.''',
@@ -168,12 +168,12 @@ prefs.register_preferences(
         default=None,
         validator=lambda v: v is None or isinstance(v, int)
     ),
-    
+
     extra_compile_args_nvcc=BrianPreference(
         docs='''Extra compile arguments (a list of strings) to pass to the nvcc compiler.''',
         default=['-w', '-use_fast_math']
     ),
-    
+
     compute_capability=BrianPreference(
         docs='''Manually set the compute capability for which CUDA code will be
         compiled. Has to be a float (e.g. `6.1`) or None. If None, compute capability is
@@ -187,5 +187,5 @@ prefs.register_preferences(
         default=None,
         validator=lambda v: v is None or isinstance(v, str)
     )
-    
+
 )

--- a/brian2cuda/cuda_prefs.py
+++ b/brian2cuda/cuda_prefs.py
@@ -169,12 +169,9 @@ prefs.register_preferences(
         `None`, in which case the GPU with the highest compute capability and lowest ID
         is used.
 
-        If this preference is set, it has to be the ID reported by `nvidia-smi`, which
-        ignores the environment variable `CUDA_VISIBLE_DEVICES`.
-
-        If this preference isn't set, `CUDA_VISIBLE_DEVICES` is not ignored. E.g. with
-        `CUDA_DEVICE_QUERY=1,2` only GPUs 1 and 2 will be considered during GPU
-        detection.
+        If environment variable `CUDA_VISIBLE_DEVICES` is set, this preference will be
+        interpreted as ID from the visible devices (e.g. with `CUDA_VISIBLE_DEVICES=2`
+        and `gpu_id=0` preference, the GPU 2 will be used).
         ''',
         default=None,
         validator=lambda v: v is None or isinstance(v, int)

--- a/brian2cuda/cuda_prefs.py
+++ b/brian2cuda/cuda_prefs.py
@@ -164,7 +164,18 @@ prefs.register_preferences(
     ),
 
     gpu_id=BrianPreference(
-        docs='''The ID of the GPU that should be used''',
+        docs='''
+        The ID of the GPU that should be used for code execution. Default value is
+        `None`, in which case the GPU with the highest compute capability and lowest ID
+        is used.
+
+        If this preference is set, it has to be the ID reported by `nvidia-smi`, which
+        ignores the environment variable `CUDA_VISIBLE_DEVICES`.
+
+        If this preference isn't set, `CUDA_VISIBLE_DEVICES` is not ignored. E.g. with
+        `CUDA_DEVICE_QUERY=1,2` only GPUs 1 and 2 will be considered during GPU
+        detection.
+        ''',
         default=None,
         validator=lambda v: v is None or isinstance(v, int)
     ),

--- a/brian2cuda/utils/gputools.py
+++ b/brian2cuda/utils/gputools.py
@@ -355,10 +355,18 @@ def _get_available_gpus():
         # raise new_error from excepted_error
         raise new_error
 
+    cuda_visible_devices = None
+    if "CUDA_VISIBLE_DEVICES" in os.environ:
+        cuda_visible_devices = os.environ["CUDA_VISIBLE_DEVICES"].split(",")
+
     gpu_list = []
     if gpu_info_lines is not None:
         for i, gpu_info in enumerate(gpu_info_lines):
             if gpu_info == "":  # last list item is empty
+                continue
+
+            # Skip GPUs that are not in cuda_visible_devices
+            if cuda_visible_devices is not None and str(i) not in cuda_visible_devices:
                 continue
 
             # `gpu_info` example:
@@ -369,8 +377,9 @@ def _get_available_gpus():
             # Split ID and NAME parts
             id_str, gpu_name = gpu_info.split(": ")
             assert id_str.startswith("GPU ")
-            gpu_id = id_str[4]
-            assert int(gpu_id) == i
+            if cuda_visible_devices is None:
+                gpu_id = id_str[4]
+                assert int(gpu_id) == i
             gpu_list.append(gpu_name)
     return gpu_list
 

--- a/brian2cuda/utils/gputools.py
+++ b/brian2cuda/utils/gputools.py
@@ -355,18 +355,10 @@ def _get_available_gpus():
         # raise new_error from excepted_error
         raise new_error
 
-    cuda_visible_devices = None
-    if "CUDA_VISIBLE_DEVICES" in os.environ:
-        cuda_visible_devices = os.environ["CUDA_VISIBLE_DEVICES"].split(",")
-
-    gpu_list = []
+    all_gpu_list = []
     if gpu_info_lines is not None:
         for i, gpu_info in enumerate(gpu_info_lines):
             if gpu_info == "":  # last list item is empty
-                continue
-
-            # Skip GPUs that are not in cuda_visible_devices
-            if cuda_visible_devices is not None and str(i) not in cuda_visible_devices:
                 continue
 
             # `gpu_info` example:
@@ -377,11 +369,19 @@ def _get_available_gpus():
             # Split ID and NAME parts
             id_str, gpu_name = gpu_info.split(": ")
             assert id_str.startswith("GPU ")
-            if cuda_visible_devices is None:
-                gpu_id = id_str[4]
-                assert int(gpu_id) == i
-            gpu_list.append(gpu_name)
-    return gpu_list
+            gpu_id = id_str[4]
+            assert int(gpu_id) == i
+            all_gpu_list.append(gpu_name)
+
+    visible_gpu_list = all_gpu_list
+    if "CUDA_VISIBLE_DEVICES" in os.environ:
+        visible_gpu_list = []
+        cuda_visible_devices = os.environ["CUDA_VISIBLE_DEVICES"].split(",")
+        for id_str in cuda_visible_devices:
+            gpu_id = int(id_str)
+            visible_gpu_list.append(all_gpu_list[gpu_id])
+
+    return visible_gpu_list
 
 
 def get_compute_capability(gpu_id):


### PR DESCRIPTION
Before, `CUDA_DEVICE_QUERY` had not effect for GPU selection in brian2cuda. This PR should fix that. 

This needs some tinkering around with the different IDs (the ones reported by `nvidia-smi`, which ignores `CUDA_VISIBLE_DEVICES`) and the ones defined by `CUDA_VISIBLE_DEVICES` (which e.g. `deviceQuery` takes into account).

Here is the updated doc for the `gpu_id` preferences. This is how it should work. What is missing is that with `prefs....gpu_id = None` and `CUDA_VISIBLE_DEVICES` set, it still ignored `CUDA_VISIBLE_DEVICES` currently.

        The ID of the GPU that should be used for code execution. Default value is
        `None`, in which case the GPU with the highest compute capability and lowest ID
        is used.

        If this preference is set, it has to be the ID reported by `nvidia-smi`, which
        ignores the environment variable `CUDA_VISIBLE_DEVICES`.

        If this preference isn't set, `CUDA_VISIBLE_DEVICES` is not ignored. E.g. with
        `CUDA_DEVICE_QUERY=1,2` only GPUs 1 and 2 will be considered during GPU
        detection.