### PR TITLE
Add support for deleting standalone code / results

### DIFF
--- a/brian2cuda/tests/test_cpp_cuda_consistency.py
+++ b/brian2cuda/tests/test_cpp_cuda_consistency.py
@@ -7,6 +7,7 @@ from brian2.devices.device import reinit_and_delete, reinit_devices, set_device,
 
 import brian2cuda
 
+# CUDA version of brian2.tests.test_cpp_standalone.test_openmp_consistency
 @attr('cuda_standalone', 'standalone-only')
 @with_setup(teardown=reinit_and_delete)
 def test_stdp_example():

--- a/brian2cuda/tests/test_cpp_cuda_consistency.py
+++ b/brian2cuda/tests/test_cpp_cuda_consistency.py
@@ -3,12 +3,12 @@ from nose.plugins.attrib import attr
 
 from brian2 import *
 from brian2.tests.utils import assert_allclose
-from brian2.devices.device import reinit_devices, set_device, reset_device
+from brian2.devices.device import reinit_and_delete, reinit_devices, set_device, reset_device
 
 import brian2cuda
 
 @attr('cuda_standalone', 'standalone-only')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_stdp_example():
     previous_device = get_device()
     n_cells    = 100
@@ -89,7 +89,7 @@ def test_stdp_example():
 
 
 @attr('cuda_standalone', 'standalone-only')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_stdp_heterog_delays_example():
     previous_device = get_device()
     n_cells    = 100
@@ -173,7 +173,7 @@ def test_stdp_heterog_delays_example():
 
 
 @attr('cuda_standalone', 'standalone-only')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_sorted_indices_statemonitor():
     previous_device = get_device()
 

--- a/brian2cuda/tests/test_cuda_generator.py
+++ b/brian2cuda/tests/test_cuda_generator.py
@@ -7,7 +7,7 @@ import logging
 from brian2 import *
 from brian2.tests.utils import assert_allclose
 from brian2.utils.logger import catch_logs
-from brian2.devices.device import reinit_devices, set_device
+from brian2.devices.device import reinit_and_delete, set_device
 from brian2.tests.test_synapses import permutation_analysis_good_examples
 from brian2.utils.stringtools import get_identifiers, deindent
 
@@ -15,7 +15,7 @@ import brian2cuda
 from brian2cuda.cuda_generator import CUDACodeGenerator
 
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_default_function_implementations():
     ''' Test that all default functions work as expected '''
     # NeuronGroup variables are set in device code
@@ -360,7 +360,7 @@ def test_default_function_implementations():
 
 
 @attr('cuda_standalone', 'standalone-only')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_default_function_convertion_preference():
 
     if prefs.core.default_float_dtype is np.float32:
@@ -389,7 +389,7 @@ def test_default_function_convertion_preference():
 
 
 @attr('cuda_standalone', 'standalone-only')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_default_function_convertion_warnings():
 
     set_device('cuda_standalone', directory=None)
@@ -479,7 +479,7 @@ def test_default_function_convertion_warnings():
 
 
 @attr('long', 'cuda_standalone', 'standalone-only')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_atomics_parallelisation():
     # Adapted from brian2.test_synapses:test_ufunc_at_vectorisation()
     for n, code in enumerate(permutation_analysis_good_examples):

--- a/brian2cuda/tests/test_functions.py
+++ b/brian2cuda/tests/test_functions.py
@@ -8,14 +8,14 @@ from brian2 import *
 from brian2.core.functions import timestep
 from brian2.parsing.sympytools import str_to_sympy, sympy_to_str
 from brian2.utils.logger import catch_logs
-from brian2.devices.device import reinit_devices
+from brian2.devices.device import reinit_and_delete
 from brian2.tests.utils import assert_allclose
 from brian2.codegen.generators import CodeGenerator
 from brian2.codegen.codeobject import CodeObject
 
 
 @attr('cuda-standalone', 'standalone-only')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_user_defined_function():
     @implementation('cuda',"""
     __host__ __device__ inline double usersin(double x)
@@ -40,7 +40,7 @@ def test_user_defined_function():
 
 
 @attr('cuda_standalone', 'standalone-only')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_user_function_with_namespace_variable():
 
     my_var = 0.1 * np.array(np.arange(5))

--- a/brian2cuda/tests/test_gpu_detection.py
+++ b/brian2cuda/tests/test_gpu_detection.py
@@ -6,7 +6,7 @@ from nose.plugins.attrib import attr
 from numpy.testing import assert_raises, assert_equal
 
 from brian2 import prefs, ms, run
-from brian2.devices.device import reinit_devices
+from brian2.devices.device import reinit_and_delete
 from brian2.utils.logger import catch_logs
 from brian2.core.preferences import PreferenceError
 from brian2cuda.utils.gputools import (
@@ -15,7 +15,7 @@ from brian2cuda.utils.gputools import (
 
 
 @attr('cuda_standalone', 'standalone-only')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_wrong_cuda_path_error():
     # store global _cuda_installation and environment variable before changing them
     cuda_installation_backup = get_cuda_installation()
@@ -37,7 +37,7 @@ def test_wrong_cuda_path_error():
         os.environ['CUDA_PATH'] = cuda_path_env
 
 @attr('cuda_standalone', 'standalone-only')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_manual_setting_compute_capability():
     compute_capability_pref = '3.5'
     prefs.devices.cuda_standalone.cuda_backend.compute_capability = float(compute_capability_pref)
@@ -51,7 +51,7 @@ def test_manual_setting_compute_capability():
             assert_equal(compute_capability_pref, compute_capability)
 
 @attr('cuda_standalone', 'standalone-only')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_unsupported_compute_capability_error():
     prefs.devices.cuda_standalone.cuda_backend.compute_capability = 2.0
     with assert_raises(NotImplementedError):
@@ -59,7 +59,7 @@ def test_unsupported_compute_capability_error():
 
 
 @attr('cuda_standalone', 'standalone-only')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_warning_compute_capability_set_twice():
     prefs.devices.cuda_standalone.cuda_backend.compute_capability = 3.5
     prefs.codegen.cuda.extra_compile_args_nvcc.append('-arch=sm_37')
@@ -74,7 +74,7 @@ def test_warning_compute_capability_set_twice():
 
 
 @attr('cuda_standalone', 'standalone-only')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_no_gpu_detection_preference_error():
     prefs.devices.cuda_standalone.cuda_backend.detect_gpus = False
     # needs setting gpu_id and compute_capability as well
@@ -83,7 +83,7 @@ def test_no_gpu_detection_preference_error():
 
 
 @attr('cuda_standalone', 'standalone-only')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_no_gpu_detection_preference():
     # Test that disabling gpu detection works when setting gpu_id and compute_capability
     prefs.devices.cuda_standalone.cuda_backend.detect_gpus = False

--- a/brian2cuda/tests/test_network_multiple_runs.py
+++ b/brian2cuda/tests/test_network_multiple_runs.py
@@ -4,13 +4,13 @@ from numpy.testing.utils import assert_equal, assert_raises
 
 from brian2 import *
 from brian2.tests.utils import assert_allclose
-from brian2.devices.device import reinit_devices
+from brian2.devices.device import reinit_and_delete
 
 import brian2cuda
 
 
 @attr('standalone-compatible', 'multiple-runs')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_changing_delay_scalar():
 
     set_device('cuda_standalone', directory=None, build_on_run=False)
@@ -33,7 +33,7 @@ def test_changing_delay_scalar():
 
 
 @attr('standalone-compatible', 'multiple-runs')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_changing_delay_heterogeneous():
 
     set_device('cuda_standalone', directory=None, build_on_run=False)

--- a/brian2cuda/tests/test_not_implemented_brian2_test_suite_fails.py
+++ b/brian2cuda/tests/test_not_implemented_brian2_test_suite_fails.py
@@ -8,7 +8,7 @@ from nose.plugins.attrib import attr
 from numpy.testing.utils import assert_raises, assert_equal, assert_array_equal
 
 from brian2 import *
-from brian2.devices.device import reinit_devices
+from brian2.devices.device import reinit_and_delete
 
 import brian2cuda
 
@@ -47,7 +47,7 @@ def test_manual_user_defined_function_cuda_standalone_compiler_args():
 
 #TODO: Update BinomialFunction with cuda implementation
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_binomial():
     binomial_f_approximated = BinomialFunction(100, 0.1, approximate=True)
     binomial_f = BinomialFunction(100, 0.1, approximate=False)
@@ -66,7 +66,7 @@ def test_binomial():
 
 #TODO: Update TimedArray with cuda implementations
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_time_dependent_rate():
     # The following two groups should show the same behaviour
     timed_array = TimedArray(np.array([[0, 0],
@@ -87,7 +87,7 @@ def test_time_dependent_rate():
 
 #TODO: needs BinomialFunction
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_poissoninput():
     # Test extreme cases and do a very basic test of an intermediate case, we
     # don't want tests to be stochastic
@@ -129,7 +129,7 @@ def test_poissoninput():
 #TODO Why do we get a NotImplementedError in this test?
 # NotImplementedError: Cannot retrieve the values of state variables in standalone code before the simulation has been run.
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_synapses_to_synapses():
     source = SpikeGeneratorGroup(3, [0, 1, 2], [0, 0, 0]*ms, period=2*ms)
     modulator = SpikeGeneratorGroup(3, [0, 2], [1, 3]*ms)
@@ -148,7 +148,7 @@ def test_synapses_to_synapses():
 #TODO Why do we get a NotImplementedError in this test?
 # NotImplementedError: Cannot retrieve the values of state variables in standalone code before the simulation has been run.
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_synapses_to_synapses_different_sizes():
     prefs.codegen.target = 'numpy'
     source = NeuronGroup(100, 'v : 1', threshold='False')
@@ -168,7 +168,7 @@ def test_synapses_to_synapses_different_sizes():
 #TODO Why do we get a NotImplementedError in this test?
 # NotImplementedError: Cannot retrieve the values of state variables in standalone code before the simulation has been run.
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_synapses_to_synapses_summed_variable():
     source = NeuronGroup(5, '', threshold='False')
     target = NeuronGroup(5, '')
@@ -190,7 +190,7 @@ def test_synapses_to_synapses_summed_variable():
 #TODO: Update TimedArray with cuda implementations
 
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_timedarray_semantics():
     # Make sure that timed arrays are interpreted as specifying the values
     # between t and t+dt (not between t-dt/2 and t+dt/2 as in Brian1)
@@ -203,7 +203,7 @@ def test_timedarray_semantics():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_timedarray_no_units():
     ta = TimedArray(np.arange(10), dt=0.1*ms)
     G = NeuronGroup(1, 'value = ta(t) + 1: 1', dt=0.1*ms)
@@ -213,7 +213,7 @@ def test_timedarray_no_units():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_timedarray_with_units():
     ta = TimedArray(np.arange(10)*amp, dt=0.1*ms)
     G = NeuronGroup(1, 'value = ta(t) + 2*nA: amp', dt=0.1*ms)
@@ -223,7 +223,7 @@ def test_timedarray_with_units():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_timedarray_2d():
     # 4 time steps, 3 neurons
     ta2d = TimedArray(np.arange(12).reshape(4, 3), dt=0.1*ms)
@@ -236,7 +236,7 @@ def test_timedarray_2d():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_timedarray_no_upsampling():
     # Test a TimedArray where no upsampling is necessary because the monitor's
     # dt is bigger than the TimedArray's

--- a/brian2cuda/tests/test_profiling.py
+++ b/brian2cuda/tests/test_profiling.py
@@ -4,13 +4,13 @@ from numpy.testing.utils import assert_raises
 
 from brian2 import *
 from brian2.utils.logger import catch_logs
-from brian2.devices.device import reinit_devices, set_device
+from brian2.devices.device import reinit_and_delete, set_device
 
 import brian2cuda
 
 
 @attr('cuda_standalone', 'standalone-only')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_changing_profile_arg():
     set_device('cuda_standalone', build_on_run=False)
     G = NeuronGroup(10000, 'v : 1')

--- a/brian2cuda/tests/test_random_number_generation.py
+++ b/brian2cuda/tests/test_random_number_generation.py
@@ -6,7 +6,7 @@ from brian2 import *
 from brian2.monitors.statemonitor import StateMonitor
 from brian2.core.clocks import defaultclock
 from brian2.utils.logger import catch_logs
-from brian2.devices.device import reinit_devices, device
+from brian2.devices.device import reinit_and_delete, device
 
 import brian2cuda
 from brian2cuda.device import check_codeobj_for_rng
@@ -64,7 +64,7 @@ def test_rand_randn_regex():
 
 
 @attr('cuda_standalone', 'standalone-only')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_rand_randn_occurence_counting():
 
     set_device('cuda_standalone', directory=None)
@@ -94,7 +94,7 @@ def test_rand_randn_occurence_counting():
 
 
 @attr('cuda_standalone', 'standalone-only')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_binomial_occurence():
 
     set_device('cuda_standalone', directory=None)
@@ -129,7 +129,7 @@ def test_binomial_occurence():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_rand():
     G = NeuronGroup(1000, 'dv/dt = rand() : second')
     mon = StateMonitor(G, 'v', record=True)
@@ -142,7 +142,7 @@ def test_rand():
 
 
 @attr('standalone-compatible', 'multiple-runs')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_random_number_generation_with_multiple_runs():
     G = NeuronGroup(1000, 'dv/dt = rand() : second')
     mon = StateMonitor(G, 'v', record=True)
@@ -158,7 +158,7 @@ def test_random_number_generation_with_multiple_runs():
 # adapted for standalone mode from brian2/tests/test_neurongroup.py
 # brian2.tests.test_neurongroup.test_random_values_fixed_and_random().
 @attr('standalone-compatible', 'multiple-runs')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_random_values_fixed_and_random_seed():
     G = NeuronGroup(10, 'dv/dt = -v/(10*ms) + 0.1*xi/sqrt(ms) : 1')
     mon = StateMonitor(G, 'v', record=True)
@@ -188,7 +188,7 @@ def test_random_values_fixed_and_random_seed():
 
 
 @attr('standalone-compatible', 'multiple-runs')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_random_values_codeobject_every_tick():
     G = NeuronGroup(10, 'dv/dt = -v/(10*ms) + 0.1*xi/sqrt(ms) : 1')
     mon = StateMonitor(G, 'v', record=True)
@@ -216,7 +216,7 @@ def test_random_values_codeobject_every_tick():
 
 # Test all binomial is single test
 @attr('standalone-compatible', 'multiple-runs')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_binomial_values():
     my_f_approximated = BinomialFunction(100, 0.1, approximate=True)
     my_f = BinomialFunction(100, 0.1, approximate=False)
@@ -317,7 +317,7 @@ def test_binomial_values():
 
 ### 3. rand/randn in synapses set_conditional template
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_random_values_set_synapses_random_seed():
     G = NeuronGroup(10, 'z : 1')
     S = Synapses(G, G, '''v1 : 1
@@ -334,7 +334,7 @@ def test_random_values_set_synapses_random_seed():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_random_values_set_synapses_fixed_seed():
     G = NeuronGroup(10, 'z : 1')
     S = Synapses(G, G, '''v1 : 1
@@ -352,7 +352,7 @@ def test_random_values_set_synapses_fixed_seed():
 
 ### 4. randn in synapses stateupdater and mixing seed random/fixed
 @attr('standalone-compatible', 'multiple-runs')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_random_values_synapse_dynamics_fixed_and_random_seed():
     G = NeuronGroup(10, 'z : 1')
     S = Synapses(G, G, 'dv/dt = -v/(10*ms) + 0.1*xi/sqrt(ms) : 1')
@@ -395,7 +395,7 @@ def test_random_values_synapse_dynamics_fixed_and_random_seed():
 
 ### 5. rand/randn in host side rng (synapses_init tempalte)
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_random_values_init_synapses_fixed_and_random_seed():
     G = NeuronGroup(10, 'z : 1')
 
@@ -437,7 +437,7 @@ def test_random_values_init_synapses_fixed_and_random_seed():
 
 ### 1. binomial in neurongroup set_conditional templates
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_binomial_values_random_seed():
     G = NeuronGroup(100, '''v1 : 1
                             v2 : 1''')
@@ -454,7 +454,7 @@ def test_binomial_values_random_seed():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_binomial_values_fixed_seed():
     G = NeuronGroup(100, '''v1 : 1
                             v2 : 1''')
@@ -472,7 +472,7 @@ def test_binomial_values_fixed_seed():
 
 ### 2. binomial in neurongroup stateupdater and mixed seed random/fixed
 @attr('standalone-compatible', 'multiple-runs')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_binomial_values_fixed_and_random_seed():
     my_f = BinomialFunction(100, 0.1, approximate=False)
     my_f_approximated = BinomialFunction(100, 0.1, approximate=True)
@@ -516,7 +516,7 @@ def test_binomial_values_fixed_and_random_seed():
 
 ### 3. binomial in synapses set_conditional template
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_random_values_set_synapses_random_seed():
     G = NeuronGroup(10, 'z : 1')
     S = Synapses(G, G, '''v1 : 1
@@ -537,7 +537,7 @@ def test_random_values_set_synapses_random_seed():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_random_values_set_synapses_fixed_seed():
     G = NeuronGroup(10, 'z : 1')
     S = Synapses(G, G, '''v1 : 1
@@ -559,7 +559,7 @@ def test_random_values_set_synapses_fixed_seed():
 
 ### 4. binomial in synapses stateupdater and mixing seed random/fixed
 @attr('standalone-compatible', 'multiple-runs')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_binomial_values_synapse_dynamics_fixed_and_random_seed():
     my_f = BinomialFunction(100, 0.1, approximate=False)
     my_f_approximated = BinomialFunction(100, 0.1, approximate=True)
@@ -605,7 +605,7 @@ def test_binomial_values_synapse_dynamics_fixed_and_random_seed():
 
 ### 5. binomial in host side rng (synapses_init tempalte)
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_binomial_values_init_synapses_fixed_and_random_seed():
     G = NeuronGroup(10, 'z : 1')
 
@@ -647,7 +647,7 @@ def test_binomial_values_init_synapses_fixed_and_random_seed():
 
 ### Extra: group_set template (not conditional), only for neurongroup, not synapse
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_random_binomial_set_template_random_seed():
     G = NeuronGroup(10, '''v1 : 1
                            v2 : 1''')
@@ -665,7 +665,7 @@ def test_random_binomial_set_template_random_seed():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_random_values_set_synapses_fixed_seed():
     G = NeuronGroup(10, '''v1 : 1
                            v2 : 1''')

--- a/brian2cuda/tests/test_synaptic_propagations.py
+++ b/brian2cuda/tests/test_synaptic_propagations.py
@@ -5,13 +5,13 @@ from numpy.testing.utils import assert_equal, assert_array_equal
 from brian2 import *
 from brian2.tests.utils import assert_allclose
 from brian2.utils.logger import catch_logs
-from brian2.devices.device import reinit_devices
+from brian2.devices.device import reinit_and_delete
 
 import brian2cuda
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_CudaSpikeQueue_push_outer_loop():
 
     # This test only works, if the CudaSpikeQueue::push() kernel is called with
@@ -53,7 +53,7 @@ def test_CudaSpikeQueue_push_outer_loop():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_CudaSpikeQueue_push_outer_loop2():
 
     # This test was testing a special case scenario in an old version of
@@ -156,7 +156,7 @@ def test_CudaSpikeQueue_push_outer_loop2():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_circular_eventspaces():
     # test postsynaptic effects in no_or_const_delay_mode are applied correctly
 
@@ -188,7 +188,7 @@ def test_circular_eventspaces():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
+@with_setup(teardown=reinit_and_delete)
 def test_synaptic_effect_modes():
     # make sure on_pre pathway changing pre variables has the same mode as
     # on_post pathway changing post variables


### PR DESCRIPTION
PR implements changes following brian-team/brian2#1104

Closes #173 

To my surprise, the `CPPStandaloneDevice.delete()` function works without modification for our `CUDAStandaloneDevice` (which inherits it). I thought we had a few additional header files at least in `brianlib`, but those are deleted as well. Didn't look into it in detail, if it works, it works!