### PR TITLE
Update spikegenerator

### DIFF
--- a/brian2cuda/templates/spikegenerator.cu
+++ b/brian2cuda/templates/spikegenerator.cu
@@ -5,10 +5,8 @@
            spike in this time step. If there are multiple circular spikespaces
            due to synaptic delays, the correct spikespaces are filled.
 
-           I found the variable naming in the cpp_standalone template not very
-           intuitive. I changed names and referenced the corresponding name in
-           the cpp_standalone template. The implemented algorithm is the same
-           though.
+           The algorithm here is based on the corresponding cpp_standalone template
+           (spikegenerator.cpp), adapted for CUDA.
 
            This tempalte is very similar to the threshold.cu template since it
            has to fill the spikespace in a similar fashion. Therefore, it also
@@ -21,100 +19,62 @@
            kernel.
 
     Variables:
-     - {{spike_time}} and {{neuron_index}} are `times` and `index` of
-         SpikeGeneratorGroup and are storted first by times, then by index
-     - {{period}} gives generator period in ms, after which all spikes defined
-         by `times` and `index` are repeated.
-     - {{_lastindex} starts always with 0,
-     - `test`: True if a spike time comes after the current time step
-         (>= implementation with epsilon precision)
+     - {{_timebins}} and {{neuron_index}} are `times` (in multiples of dt) and `index`
+       of SpikeGeneratorGroup and are storted first by times, then by index
+     - {{_period_bins}} gives generator period (in multiples of dt), after which all
+       spikes defined by `times` and `index` are repeated.
+     - {{_lastindex}} is the last index / spike in the `times` and `index` array that
+       has already been generated.
 
     TODOs:
      - We do know all spike times before the simulation. We could just
        precompute all spikespaces once in the beginning for one period and reuse
        them here. This could save quite some compute when using many periods of
        input.
-     - The template ended up to be a bit messy with the
-       _get_time_within_period() function calls. We could just compute everything
-       on the host and pass the computed values that we need to the kernels
-       (instead of letting each thread compute the same).
+    - For additional optimizations, see #193.
 #}
 
-{# USES_VARIABLES {_spikespace, N, t, dt, neuron_index, spike_time, period, _lastindex } #}
+{# USES_VARIABLES {_spikespace, neuron_index, _timebins, _period_bins, _lastindex, t_in_timesteps, N} #}
 
 
 {% block kernel_maincode %}
-    double _epsilon = 1e-3 * {{dt}};
-    {# In spikegenerator.cpp, this is `padding_after` #}
-    double _time_within_period = _get_time_within_period({{t}}, {{dt}}, {{period}});
-    {# In spikegenerator.cpp, this is `(! not_end_period)` #}
-    const bool _last_in_period = _check_last_in_period(_time_within_period, _epsilon, {{period}});
-    bool test;
+    // The period in multiples of dt
+    const int32_t _the_period = {{_period_bins}};
+    // The spike times in multiples of dt
+    int32_t _timebin = {{t_in_timesteps}};
 
-    // Reset the spikespace
-    for (int i = tid; i < N; i+= THREADS_PER_BLOCK)
+    if (_the_period > 0)
+        _timebin %= _the_period;
+
+    // We can have at most one spike per neuron per time step, which is the number of
+    // threads we call this kernel with. Hence, no need for any loops.
+
+    // _spike_idx runs through the spikes in the spike generator
+    int _spike_idx = _idx + {{_lastindex}};
+
+    // TODO: Solve this smarter. Currently, we will call the reset kernel and this
+    // kernel at each time step even if the spikegenerator has emitted all its spikes!
+    // Instead, we should know on the host when this happened and not call any kernels.
+    // See also #193
+    if (_spike_idx >= _num_timebins)
+        return;
+
+    // If the spike time of this spike comes after the current time bin, do nothing
+    if ({{_timebins}}[_spike_idx] > _timebin)
     {
-        {{_spikespace}}[i] = -1;
+        return;
     }
 
-    if (tid == 0)
-    {
-        // Reset number of spikes to 0
-        {{_spikespace}}[N] = 0;
-    }
-    __syncthreads();
-
-    for (int spike_idx = {{_lastindex}} + tid; spike_idx < _numspike_time; spike_idx += THREADS_PER_BLOCK)
-    {
-        if (! _last_in_period)
-        {
-            test = ({{spike_time}}[spike_idx] > _time_within_period) || (fabs({{spike_time}}[spike_idx] - _time_within_period) < _epsilon);
-        }
-        else
-        {
-            // If we are in the last timestep before the end of the period, we remove the first part of the
-            // test, because padding will be 0
-            test = (fabs({{spike_time}}[spike_idx] - _time_within_period) < _epsilon);
-        }
-        if (test)
-        {
-            break;
-        }
-        int32_t neuron_id = {{neuron_index}}[spike_idx];
-        int32_t spikespace_index = atomicAdd(&{{_spikespace}}[N], 1);
-        {{_spikespace}}[spikespace_index] = neuron_id;
-    }
+    // Else add the spiking neuron to the spikespace
+    int32_t _neuron_id = {{neuron_index}}[_spike_idx];
+    int32_t _spikespace_index = atomicAdd(&{{_spikespace}}[N], 1);
+    {{_spikespace}}[_spikespace_index] = _neuron_id;
 
 {% endblock %}
 
 
 {% block extra_device_helper %}
-    {# Since we use these functions in both, the codeobject and the reset
-       kernel, I defined extra functions for them. #}
-    __host__ __device__ inline double
-    _get_time_within_period(double _t, double _dt, double _the_period)
-    {
-        // In cpp_standalone template, this is called `padding_after`
-        return fmod(_t + _dt, _the_period);
-    }
-
-
-    __host__ __device__ inline const bool
-    _check_last_in_period(
-            double _time_within_period,
-            double _epsilon,
-            double _the_period)
-    {
-        // Whether the current time step IS NOT the last of the period
-        // Naming taken from cpp_standalone template
-        const bool not_end_period = (fabs(_time_within_period) > _epsilon) \
-                                    && (fabs(_time_within_period) < (_the_period - _epsilon));
-
-        // Return, whether the current time step IS the last of the period
-        return (! not_end_period);
-    }
-
-
+    // Function to reset spikespace and set lastindex
     __global__ void
     {% if launch_bounds %}
     __launch_bounds__(1024, {{sm_multiplier}})
@@ -140,31 +100,32 @@
 
         if (_idx == 0)
         {
-            // TODO: Should we compute _first_in_period on the host instead?
-            // If the previous time step was last in the period, this time step
-            // is the first in the new period.
-            double _epsilon = 1e-3 * {{dt}};
-            double _previous_t = {{t}} - {{dt}};
-            double _prev_time_within_period = _get_time_within_period(_previous_t, {{dt}}, {{period}});
-            const bool _first_in_period = _check_last_in_period(_prev_time_within_period, _epsilon, {{period}});
+            // The period in multiples of dt
+            const int32_t _the_period = {{_period_bins}};
+            // The spike times in multiples of dt
+            int32_t _timebin          = {{t_in_timesteps}};
+            // index of the last spiking neuron in this spikespace
+            int32_t _lastindex = {{_lastindex}};
 
-            // If there is a periodicity in the SpikeGenerator, we need to reset the lastindex
-            // when all spikes have been played and the start of a new period.
-            if (_first_in_period) {
-                // Reset the spike index within a period
-                {{_lastindex}} = 0;
+            // Update the lastindex variable with the number of spikes from the
+            // spikespace from the previous time step
+            _lastindex += _previous_spikespace[N];
+
+            // Now reset the _lastindex if the priod has passed
+            if (_the_period > 0) {
+                _timebin %= _the_period;
+                // If there is a periodicity in the SpikeGenerator, we need to reset the
+                // lastindex when the period has passed
+                if (_lastindex > 0 && {{_timebins}}[_lastindex - 1] >= _timebin)
+                    _lastindex = 0;
             }
-            else {
-                // Update the last spike index with the number of spikes in the
-                // previous time step
-                {{_lastindex}} += _previous_spikespace[N];
-            }
+            {{_lastindex}} = _lastindex;
 
             // Reset spikespace counter for this time step
             {{_spikespace}}[N] = 0;
         }
 
-        // Reset spikespace
+        // Reset the entire spikespace
         {{_spikespace}}[_idx] = -1;
     }
 {% endblock %}

--- a/brian2cuda/tests/test_gpu_detection.py
+++ b/brian2cuda/tests/test_gpu_detection.py
@@ -62,7 +62,7 @@ def test_unsupported_compute_capability_error():
 @with_setup(teardown=reinit_and_delete)
 def test_warning_compute_capability_set_twice():
     prefs.devices.cuda_standalone.cuda_backend.compute_capability = 3.5
-    prefs.codegen.cuda.extra_compile_args_nvcc.append('-arch=sm_37')
+    prefs.devices.cuda_standalone.cuda_backend.extra_compile_args_nvcc.append('-arch=sm_37')
     with catch_logs() as logs:
         run(0*ms)
 

--- a/brian2cuda/tests/test_spikegenerator.py
+++ b/brian2cuda/tests/test_spikegenerator.py
@@ -1,0 +1,105 @@
+from nose import with_setup
+from nose.plugins.attrib import attr
+from numpy.testing.utils import assert_equal, assert_raises
+
+from brian2 import *
+from brian2.tests.utils import assert_allclose
+from brian2.devices.device import reinit_and_delete
+
+import brian2cuda
+
+
+# Copied from brian2.tests.test_spikegenerator (where it isn't 'standalone-compatible')
+@attr('standalone-compatible')
+@with_setup(teardown=reinit_and_delete)
+def test_spikegenerator_extreme_period():
+    '''
+    Basic test for `SpikeGeneratorGroup`.
+    '''
+    indices = np.array([0, 1, 2])
+    times   = np.array([0, 1, 2]) * ms
+    SG = SpikeGeneratorGroup(5, indices, times, period=1e6*second)
+    s_mon = SpikeMonitor(SG)
+    with catch_logs() as l:
+        run(10*ms)
+
+    assert_equal(s_mon.i, np.array([0, 1, 2]))
+    assert_allclose(s_mon.t, [0, 1, 2]*ms)
+    assert len(l) == 1 and l[0][1].endswith('spikegenerator_long_period')
+
+
+# Adapted from brian2.tests.test_spikegenerator (where it isn't 'standalone-compatible')
+@attr('standalone-compatible', 'multiple-runs')
+@with_setup(teardown=reinit_and_delete)
+def test_spikegenerator_period_repeat():
+    '''
+    Basic test for `SpikeGeneratorGroup`.
+    '''
+    indices = np.zeros(10)
+    times   = arange(0, 1, 0.1) * ms
+
+    rec = np.rec.fromarrays([times, indices], names=['t', 'i'])
+    rec.sort()
+    sorted_times = np.ascontiguousarray(rec.t)*1000
+    sorted_indices = np.ascontiguousarray(rec.i)
+    SG = SpikeGeneratorGroup(1, indices, times, period=1*ms)
+    net   = Network(SG, s_mon)
+    rate  = PopulationRateMonitor(SG)
+
+    # XXX: not standalone-version:
+    #s_mon = SpikeMonitor(SG)
+    #for idx in range(5):
+    #    net.run(1*ms)
+    #    assert (idx+1)*len(SG.spike_time) == s_mon.num_spikes
+
+    # Here, I use seperate monitors due to SpikeMonitor bug (#221)
+    monitors = []
+    for idx in range(5):
+        s_mon = SpikeMonitor(SG)
+        monitors.append(s_mon)
+        net.add(s_mon)
+        net.run(1*ms)
+        net.remove(s_mon)
+
+    device.build(direct_call=False, **device.build_options)
+
+    for idx in range(5):
+        assert len(SG.spike_time) == monitors[idx].num_spikes
+
+
+# Adapted from brian2.tests.test_spikegenerator (where it isn't 'standalone-compatible')
+@attr('standalone-compatible', 'multiple-runs')
+@with_setup(teardown=reinit_and_delete)
+def test_spikegenerator_rounding():
+    # all spikes should fall into the first time bin
+    indices = np.arange(100)
+    times = np.linspace(0, 0.1, 100, endpoint=False)*ms
+    SG = SpikeGeneratorGroup(100, indices, times, dt=0.1*ms)
+    mon = SpikeMonitor(SG)
+    net = Network(SG, mon)
+    net.run(0.1*ms)
+
+    # all spikes should fall in separate bins
+    dt = 0.1*ms
+    indices = np.zeros(10000)
+    times = np.arange(10000)*dt
+    SG = SpikeGeneratorGroup(1, indices, times, dt=dt)
+    target = NeuronGroup(1, 'count : 1',
+                         threshold='True', reset='count=0')  # set count to zero at every time step
+    syn = Synapses(SG, target, on_pre='count+=1')
+    syn.connect()
+    # XXX: Using a new monitor here due to SpikeMonitor bug (#221)
+    mon2 = StateMonitor(target, 'count', record=0, when='end')
+    net = Network(SG, target, syn, mon2)
+    # change the schedule so that resets are processed before synapses
+    net.schedule = ['start', 'groups', 'thresholds', 'resets', 'synapses', 'end']
+    net.run(10000*dt)
+
+    device.build(direct_call=False, **device.build_options)
+
+    assert_equal(mon.count, np.ones(100))
+    assert_equal(mon2[0].count, np.ones(10000))
+
+
+if __name__ == '__main__':
+      test_spikegenerator_extreme_period()

--- a/brian2cuda/tests/test_synaptic_propagations.py
+++ b/brian2cuda/tests/test_synaptic_propagations.py
@@ -46,9 +46,8 @@ def test_CudaSpikeQueue_push_outer_loop():
 
     assert_allclose(S.delay[even_indices], 0)
     assert_allclose(S.delay[odd_indices], default_dt)
-    # when issue 46 is done, remove np.sort
-    assert_equal(np.sort(mon.i[mon.t==default_dt]), even_indices)
-    assert_equal(np.sort(mon.i[mon.t==2*default_dt]), odd_indices)
+    assert_equal(mon.i[mon.t==default_dt], even_indices)
+    assert_equal(mon.i[mon.t==2*default_dt], odd_indices)
     assert len(mon) == N
 
 
@@ -185,6 +184,86 @@ def test_circular_eventspaces():
     assert_allclose(mon.t[mon.i[:] == 2], 6*default_dt)
     assert_allclose(mon.t[mon.i[:] == 3], 4*default_dt)
     assert_allclose(mon.t[mon.i[:] == 4], 5*default_dt)
+
+
+@attr('standalone-compatible')
+@with_setup(teardown=reinit_and_delete)
+def test_circular_eventspaces_spikegenerator():
+    # same test as test_circular_eventspaces() but with a SpikeGeneratorGroup spiking
+    # for multiple time steps
+
+    # Change reset to be before synapses, else the NeuronGroup only spikes every second
+    # time step (see https://github.com/brian-team/brian2/issues/1332)
+    prefs.core.network.default_schedule = ['start', 'groups', 'thresholds', 'resets', 'synapses', 'end']
+
+    default_dt = defaultclock.dt
+
+    # inp neuron 0 spikes every time step for the first n_timesteps
+    n_timesteps = 12
+    indices = [0] * n_timesteps
+    times = arange(n_timesteps) * default_dt
+    inp = SpikeGeneratorGroup(1, indices, times)
+    # G neurons spike for each incoming spike
+    G = NeuronGroup(5, 'v:1', threshold='v>1', reset='v=0')
+    # synapses with homogenous delays
+    S0 = Synapses(inp, G, on_pre='v+=1.1', delay=0*ms)
+    S0.connect(i=0, j=0)
+    S1 = Synapses(inp, G, on_pre='v+=1.1', delay=2*default_dt)
+    S1.connect(i=0, j=1)
+    S2 = Synapses(inp, G, on_pre='v+=1.1', delay=5*default_dt)
+    S2.connect(i=0, j=2)
+    # synapse with heterogeneous delays
+    S3 = Synapses(inp, G, on_pre='v+=1.1')
+    S3.connect(i=0, j=[3, 4])
+    S3.delay = 'j*default_dt'
+    mon = SpikeMonitor(G)
+
+    run((n_timesteps + 6) * default_dt, profile=profile)
+
+    # neurons should spike in the timestep after effect application
+    assert_allclose(mon.t[mon.i[:] == 0], arange(1, n_timesteps + 1) * default_dt)
+    assert_allclose(mon.t[mon.i[:] == 1], arange(3, n_timesteps + 3) * default_dt)
+    assert_allclose(mon.t[mon.i[:] == 2], arange(6, n_timesteps + 6) * default_dt)
+    assert_allclose(mon.t[mon.i[:] == 3], arange(4, n_timesteps + 4) * default_dt)
+    assert_allclose(mon.t[mon.i[:] == 4], arange(5, n_timesteps + 5) * default_dt)
+
+
+@attr('standalone-compatible')
+@with_setup(teardown=reinit_and_delete)
+def test_circular_eventspaces_different_clock():
+    # same test as test_circular_eventspaces_spikegenerator() but with a
+    # SpikeGeneratorGroup on a different clock (dt=2*defaultclock.dt)
+
+    default_dt = defaultclock.dt
+
+    # Neuron 0 spikes every second time step in first n_timesteps
+    clock_multiplier = 2  # factor by which SpikeGeneratorGroup clock is slower
+    n_timesteps = 12
+    indices = [0] * (n_timesteps // clock_multiplier)
+    times = arange(0, n_timesteps, clock_multiplier) * default_dt
+    inp = SpikeGeneratorGroup(1, indices, times, dt=2*default_dt)
+    G = NeuronGroup(5, 'v:1', threshold='v>1', reset='v=0')
+    # synapses with homogenous delays
+    S0 = Synapses(inp, G, on_pre='v+=1.1', delay=0*ms)
+    S0.connect(i=0, j=0)
+    S1 = Synapses(inp, G, on_pre='v+=1.1', delay=2*default_dt)
+    S1.connect(i=0, j=1)
+    S2 = Synapses(inp, G, on_pre='v+=1.1', delay=4*default_dt)
+    S2.connect(i=0, j=2)
+    # synapse with heterogeneous delays
+    S3 = Synapses(inp, G, on_pre='v+=1.1')
+    S3.connect(i=0, j=[3, 4])  # delays: 6, 8
+    S3.delay = '2*j*default_dt'
+    mon = SpikeMonitor(G)
+
+    run((n_timesteps + 9) * default_dt, profile=profile)
+
+    # neurons should spike in the timestep after effect application
+    assert_allclose(mon.t[mon.i[:] == 0], arange(1, n_timesteps + 1, clock_multiplier) * default_dt)
+    assert_allclose(mon.t[mon.i[:] == 1], arange(3, n_timesteps + 3, clock_multiplier) * default_dt)
+    assert_allclose(mon.t[mon.i[:] == 2], arange(5, n_timesteps + 5, clock_multiplier) * default_dt)
+    assert_allclose(mon.t[mon.i[:] == 3], arange(7, n_timesteps + 7, clock_multiplier) * default_dt)
+    assert_allclose(mon.t[mon.i[:] == 4], arange(9, n_timesteps + 9, clock_multiplier) * default_dt)
 
 
 @attr('standalone-compatible')

--- a/brian2cuda/tests/test_synaptic_propagations.py
+++ b/brian2cuda/tests/test_synaptic_propagations.py
@@ -72,7 +72,7 @@ def test_CudaSpikeQueue_push_outer_loop2():
     num_blocks = 1
     prefs['devices.cuda_standalone.parallel_blocks'] = num_blocks
     # make sure we don't use less then 1024 threads due to register usage
-    prefs['devices.cuda_standalone.cuda_backendextra_compile_args_nvcc'] += ['-maxrregcount=64']
+    prefs['devices.cuda_standalone.cuda_backend.extra_compile_args_nvcc'] += ['-maxrregcount=64']
 
     threads_per_block = 1024
     neurons_per_block = 2 * threads_per_block

--- a/brian2cuda/tools/remote_run_scripts/run_test_suite_on_cluster.sh
+++ b/brian2cuda/tools/remote_run_scripts/run_test_suite_on_cluster.sh
@@ -189,7 +189,7 @@ rsync -avzz \
     --exclude 'dev'\
     --exclude '.eggs'\
     --exclude '.git' \
-    --exclude 'worktrees' \  # folder used by Denis to store branches via git worktree
+    --exclude 'worktrees' \
     "$local_b2c_dir"/ "$remote:$remote_b2c_dir"
 
 


### PR DESCRIPTION
This PR updates and fixes the spikegenerator after changes in brian2 (brian-team/brian2#1042 and brian-team/brian2#1044).

This also adds additional tests from the TODO list in PR #194:
- Tests from brian2's test_spikegenertor.py which where not
   'standalone-compatible'
- Test for spikegenerator eventspaces for homog. / heterog. delays
- Test for spikegenerator on a different clock (currently not passing, see #222)

This fixes #48. All brian2 spikegenerator tests are passing (except for those suffering from a spikemonitor bug, #221, but the tests pass when the spikemonitor is changes to avoid the bug).

One new test revealed a bug in the spikegenerator when it runs on a different clock. This is likely not a spikegenerator bug but rather one in the circular eventspaces setup. I opened a separate issue for that: #222

And finally, the spikegenerator template can be further optimized but I leave that for another time, see issue #193.