### PR TITLE
Support external header files and compiler keywords

### DIFF
--- a/brian2cuda/templates/common_group.cu
+++ b/brian2cuda/templates/common_group.cu
@@ -7,8 +7,13 @@
 #include <stdint.h>
 #include <ctime>
 #include <stdio.h>
+
 {% block extra_headers %}
 {% endblock %}
+
+{% for name in user_headers %}
+#include {{name}}
+{%endfor %}
 
 ////// SUPPORT CODE ///////
 namespace {

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -12,6 +12,10 @@
 {% block extra_headers %}
 {% endblock %}
 
+{% for name in user_headers %}
+#include {{name}}
+{%endfor %}
+
 ////// SUPPORT CODE ///////
 namespace {
     // Implement dummy functions such that the host compiled code of binomial

--- a/brian2cuda/templates/main.cu
+++ b/brian2cuda/templates/main.cu
@@ -11,8 +11,8 @@
 #include "code_objects/{{codeobj.name}}.h"
 {% endfor %}
 
-{% for name in additional_headers %}
-#include "{{name}}"
+{% for name in user_headers %}
+#include {{name}}
 {% endfor %}
 
 #include <iostream>

--- a/brian2cuda/templates/makefile
+++ b/brian2cuda/templates/makefile
@@ -1,29 +1,24 @@
 PROGRAM = main
-SRCS_CU  = $(wildcard *.cu */*.cu)
-OBJS_CU  = ${SRCS_CU:.cu=.o}
-CC = @{{ nvcc_path }}
-DEBUG = -g -G -DTHRUST_DEBUG
-OPTIMISATIONFLAGS = {{ nvcc_optimization_flags }} -Xcompiler "{{ cpp_compiler_flags }}"
-NVCCFLAGS = {% if disable_warnings %}-w{% endif %} {% if disable_asserts %}-DNDEBUG{% endif %} -I. -std=c++11
-GPU_ARCH_FLAGS = {{ gpu_arch_flags }}
-LFLAGS = -lcurand
 
-# Add optimisation flags
-all: NVCCFLAGS += $(OPTIMISATIONFLAGS)
-all: executable
+SRCS = {{source_files}}
+H_SRCS = {{header_files}}
+OBJS = ${SRCS:.cu=.o}
+OBJS := ${OBJS:.cpp=.o}
+OBJS := ${OBJS:.c=.o}
+NVCC = @{{ nvcc_path }}
+NVCCFLAGS = -I. -std=c++11 {{ nvcc_compiler_flags }} {{ compiler_debug_flags }} -Xcompiler "{{ cpp_compiler_flags }}"
+LFLAGS = -lcurand -I. {{ linker_flags }} {{ linker_debug_flags }}
 
-# Add debug flags
-debug: GPU_ARCH_FLAGS += $(DEBUG)
-debug: executable
+all: $(PROGRAM)
 
-.PHONY: all debug executable clean
+.PHONY: all clean
 
-executable: $(OBJS_CPP) $(OBJS_CU)
-	$(CC) $(GPU_ARCH_FLAGS) $(LFLAGS) $(OBJS_CU) -o $(PROGRAM)
+$(PROGRAM): $(OBJS)
+	$(NVCC) $(LFLAGS) $(OBJS) -o $(PROGRAM)
 
 clean:
-	rm -f $(OBJS_CPP) $(OBJS_CU) $(PROGRAM) results/*
+	{{ rm_cmd }}
 
 %.o : %.cu
-	$(CC) $(GPU_ARCH_FLAGS) $(NVCCFLAGS) -dc $< -o $@
+	$(NVCC) $(NVCCFLAGS) -dc $< -o $@
 

--- a/brian2cuda/templates/makefile
+++ b/brian2cuda/templates/makefile
@@ -6,8 +6,8 @@ OBJS = ${SRCS:.cu=.o}
 OBJS := ${OBJS:.cpp=.o}
 OBJS := ${OBJS:.c=.o}
 NVCC = @{{ nvcc_path }}
-NVCCFLAGS = -I. -std=c++11 {{ nvcc_compiler_flags }} {{ compiler_debug_flags }} -Xcompiler "{{ cpp_compiler_flags }}"
-LFLAGS = -lcurand -I. {{ linker_flags }} {{ linker_debug_flags }}
+NVCCFLAGS = -I. -std=c++11 {{gpu_arch_flags}} {{nvcc_compiler_flags}} {{compiler_debug_flags}} -Xcompiler "{{cpp_compiler_flags}}"
+LFLAGS = -lcurand -I. {{gpu_arch_flags}} {{cpp_linker_flags}} {{linker_debug_flags}}
 
 all: $(PROGRAM)
 
@@ -17,7 +17,7 @@ $(PROGRAM): $(OBJS)
 	$(NVCC) $(LFLAGS) $(OBJS) -o $(PROGRAM)
 
 clean:
-	{{ rm_cmd }}
+	{{rm_cmd}}
 
 %.o : %.cu
 	$(NVCC) $(NVCCFLAGS) -dc $< -o $@

--- a/brian2cuda/templates/run.cu
+++ b/brian2cuda/templates/run.cu
@@ -8,8 +8,8 @@
 #include "code_objects/{{codeobj.name}}.h"
 {% endfor %}
 
-{% for name in additional_headers %}
-#include "{{name}}"
+{% for name in user_headers %}
+#include {{name}}
 {% endfor %}
 
 void brian_start()

--- a/brian2cuda/tests/func_def_cuda.cu
+++ b/brian2cuda/tests/func_def_cuda.cu
@@ -1,0 +1,4 @@
+__host__ __device__ double foo(const double x, const double y)
+{
+    return x + y + 3;
+}

--- a/brian2cuda/tests/func_def_cuda.h
+++ b/brian2cuda/tests/func_def_cuda.h
@@ -1,0 +1,1 @@
+__host__ __device__ double foo(const double, const double);

--- a/brian2cuda/tests/test_functions.py
+++ b/brian2cuda/tests/test_functions.py
@@ -61,3 +61,106 @@ def test_user_function_with_namespace_variable():
     net.run(defaultclock.dt)
 
     assert_allclose(G.v_[:], my_var)
+
+
+@attr('cuda_standalone', 'standalone-only')
+@with_setup(teardown=reinit_and_delete)
+def test_manual_user_defined_function_cuda_standalone_compiler_args():
+    set_device('cuda_standalone', directory=None)
+
+    @implementation('cuda', '''
+    __host__ __device__ static inline double foo(const double x, const double y)
+    {
+        return x + y + _THREE;
+    }''',  # just check whether we can specify the supported compiler args,
+           # only the define macro is actually used
+        headers=[], sources=[], libraries=[], include_dirs=[],
+        library_dirs=[], runtime_library_dirs=[],
+        define_macros=[('_THREE', '3')])
+    @check_units(x=volt, y=volt, result=volt)
+    def foo(x, y):
+        return x + y + 3*volt
+
+    G = NeuronGroup(1, '''
+                       func = foo(x, y) : volt
+                       x : volt
+                       y : volt''')
+    G.x = 1*volt
+    G.y = 2*volt
+    mon = StateMonitor(G, 'func', record=True)
+    net = Network(G, mon)
+    net.run(defaultclock.dt)
+    assert mon[0].func == [6] * volt
+
+
+@attr('cuda_standalone', 'standalone-only')
+@with_setup(teardown=reinit_and_delete)
+def test_manual_user_defined_function_cuda_standalone_wrong_compiler_args1():
+    set_device('cuda_standalone', directory=None)
+
+    @implementation('cuda', '''
+    static inline double foo(const double x, const double y)
+    {
+        return x + y + _THREE;
+    }''',  some_arg=[])  # non-existing argument
+    @check_units(x=volt, y=volt, result=volt)
+    def foo(x, y):
+        return x + y + 3*volt
+
+    G = NeuronGroup(1, '''
+                       func = foo(x, y) : volt
+                       x : volt
+                       y : volt''')
+    mon = StateMonitor(G, 'func', record=True)
+    net = Network(G, mon)
+    assert_raises(ValueError, lambda: net.run(defaultclock.dt,
+                                                 namespace={'foo': foo}))
+
+
+@attr('cuda_standalone', 'standalone-only')
+@with_setup(teardown=reinit_and_delete)
+def test_manual_user_defined_function_cuda_standalone_wrong_compiler_args2():
+    set_device('cuda_standalone', directory=None)
+
+    @implementation('cuda', '''
+    static inline double foo(const double x, const double y)
+    {
+        return x + y + _THREE;
+    }''',  headers='<stdio.h>')  # existing argument, wrong value type
+    @check_units(x=volt, y=volt, result=volt)
+    def foo(x, y):
+        return x + y + 3*volt
+
+    G = NeuronGroup(1, '''
+                       func = foo(x, y) : volt
+                       x : volt
+                       y : volt''')
+    mon = StateMonitor(G, 'func', record=True)
+    net = Network(G, mon)
+    assert_raises(TypeError, lambda: net.run(defaultclock.dt,
+                                                 namespace={'foo': foo}))
+
+
+@attr('cuda_standalone', 'standalone-only')
+@with_setup(teardown=reinit_and_delete)
+def test_external_function_cuda_standalone():
+    set_device('cuda_standalone', directory=None)
+    this_dir = os.path.abspath(os.path.dirname(__file__))
+    @implementation('cuda', '//all code in func_def_cuda.cu',
+                    headers=['"func_def_cuda.h"'],
+                    include_dirs=[this_dir],
+                    sources=[os.path.join(this_dir, 'func_def_cuda.cu')])
+    @check_units(x=volt, y=volt, result=volt)
+    def foo(x, y):
+        return x + y + 3*volt
+
+    G = NeuronGroup(1, '''
+                       func = foo(x, y) : volt
+                       x : volt
+                       y : volt''')
+    G.x = 1*volt
+    G.y = 2*volt
+    mon = StateMonitor(G, 'func', record=True)
+    net = Network(G, mon)
+    net.run(defaultclock.dt)
+    assert mon[0].func == [6] * volt


### PR DESCRIPTION
This PR implements support for:
- `codegen.cpp` preferences which set include/lib directories. These preferences are passed down to the C++ compiler. Generally, we just use the same flags generated for C++ Standalone compilation (by `distutils.ccompiler`) but modify them such that `nvcc` understands them and passes them correctly to the C++ compiler (via `-Xcompiler`) or to the linker `(via `-Xlinker`). This is not thoroughly tested (I don't know what options `distutils` might generate on other systems than mine). But I think it is good enough for now, if there are problems for some use cases, we can fix that later.
- external source files for `cuda_standalone` functions (see [here](https://brian2.readthedocs.io/en/stable/advanced/functions.html?highlight=header#external-source-files))
- additional compiler arguments in function implementations (see [here](https://brian2.readthedocs.io/en/stable/advanced/functions.html?highlight=header#additional-compiler-arguments))

These changes were mostly following brian2 PR brian-team/brian2#1047.

What I didn't implement yet is a `make.deps` dependency file that brian2 has. I added a comment to #179.