### PR TITLE
[MRG] Add `standalone_compatible` versions of otherwise Runtime only stateupdater tests

### DIFF
--- a/brian2cuda/tests/conftest.py
+++ b/brian2cuda/tests/conftest.py
@@ -1,0 +1,20 @@
+'''
+Module containing fixtures and hooks used by the pytest test suite.
+'''
+# We set `--rootidr=/path/to/brian`, such that `brian2/conftest.py` is loaded for all
+# tests run in the test suite. This `conftest.py` will only be loaded for all tests in
+# this directory
+
+from brian2.conftest import fake_randn, fake_randn_randn_fixture
+
+# Add a cuda implementation for the fake_randn_randn_fixture,
+# used in test_stateupdaters.py
+fake_randn.implementations.add_implementation(
+    'cuda',
+    '''
+    __host__ __device__ double randn(int vectorisation_idx)
+    {
+        return 0.5;
+    }
+    '''
+)

--- a/brian2cuda/tests/test_stateupdaters.py
+++ b/brian2cuda/tests/test_stateupdaters.py
@@ -1,15 +1,248 @@
+import pytest
+
 from brian2 import *
+from brian2.devices.device import reinit_and_delete
+from brian2.utils.logger import catch_logs
+from brian2.stateupdaters.base import UnsupportedEquationsException
+from numpy.testing import assert_equal, assert_allclose
 
-# The "random" values are always 0.5
-@implementation('cuda',
-                '''
-                __device__ __global__ double randn(int vectorisation_idx)
-                {
-                    return 0.5;
-                }
-                ''')
-@check_units(N=Unit(1), result=Unit(1))
-def fake_randn(N):
-    return 0.5*ones(N)
 
-# TODO check brian2 stateupdaters.py for tests not standalone-compatible?
+# Tests below are standalone-compatible versions of all tests from
+# `brian2/tests/test_stateupdaters.py`, which aren't standalone-compatible (due to
+# multiple run calls).
+
+
+@pytest.mark.standalone_compatible
+@pytest.mark.multiple_runs
+def test_multiple_noise_variables_extended():
+    # Some actual simulations with multiple noise variables
+    eqs = '''dx/dt = y : 1
+             dy/dt = - 1*ms**-1*y - 40*ms**-2*x : Hz
+            '''
+    all_eqs_noise = ['''dx/dt = y : 1
+                        dy/dt = noise_factor*ms**-1.5*xi_1 + noise_factor*ms**-1.5*xi_2
+                           - 1*ms**-1*y - 40*ms**-2*x : Hz
+                     ''',
+                     '''dx/dt = y + noise_factor*ms**-0.5*xi_1: 1
+                        dy/dt = noise_factor*ms**-1.5*xi_2
+                            - 1*ms**-1*y - 40*ms**-2*x : Hz
+                     ''']
+    G = NeuronGroup(2, eqs, method='euler')
+    G.x = [0.5, 1]
+    G.y = [0, 0.5] * Hz
+    mon1 = StateMonitor(G, ['x', 'y'], record=True)
+    net = Network(G, mon1)
+    net.run(10*ms)
+
+    monitors = []
+    for eqs_noise in all_eqs_noise:
+        monitors.append(dict())
+        for method_name, method in [('euler', euler), ('heun', heun)]:
+            with catch_logs('WARNING'):
+                G = NeuronGroup(2, eqs_noise, method=method)
+                G.x = [0.5, 1]
+                G.y = [0, 0.5] * Hz
+                mon = StateMonitor(G, ['x', 'y'], record=True)
+                net = Network(G, mon)
+                # We run it deterministically, but still we'd detect major errors (e.g.
+                # non-stochastic terms that are added twice, see #330
+                net.run(10*ms, namespace={'noise_factor': 0})
+                monitors[-1][method_name] = mon
+
+    device.build(direct_call=False, **device.build_options)
+
+    no_noise_x, no_noise_y = mon1.x[:], mon1.y[:]
+    for i in range(len(all_eqs_noise)):
+        for method_name in ['euler', 'heun']:
+            mon = monitors[i][method_name]
+            assert_allclose(mon.x[:], no_noise_x,
+                            err_msg='Method %s gave incorrect results' % method_name)
+            assert_allclose(mon.y[:], no_noise_y,
+                            err_msg='Method %s gave incorrect results' % method_name)
+
+
+@pytest.mark.standalone_compatible
+@pytest.mark.multiple_runs
+def test_multiple_noise_variables_deterministic_noise(fake_randn_randn_fixture):
+    all_eqs = ['''dx/dt = y : 1
+                          dy/dt = -y / (10*ms) + dt**-.5*0.5*ms**-1.5 + dt**-.5*0.5*ms**-1.5: Hz
+                     ''',
+                     '''dx/dt = y + dt**-.5*0.5*ms**-0.5: 1
+                        dy/dt = -y / (10*ms) + dt**-.5*0.5 * ms**-1.5 : Hz
+                ''']
+    all_eqs_noise = ['''dx/dt = y : 1
+                          dy/dt = -y / (10*ms) + xi_1 * ms**-1.5 + xi_2 * ms**-1.5: Hz
+                     ''',
+                     '''dx/dt = y + xi_1*ms**-0.5: 1
+                        dy/dt = -y / (10*ms) + xi_2 * ms**-1.5 : Hz
+                     ''']
+
+    monitors_no_noise = []
+    monitors = []
+    for eqs, eqs_noise in zip(all_eqs, all_eqs_noise):
+        G = NeuronGroup(2, eqs, method='euler')
+        G.x = [5,  17]
+        G.y = [25, 5 ] * Hz
+        mon = StateMonitor(G, ['x', 'y'], record=True)
+        net = Network(G, mon)
+        net.run(10*ms)
+        monitors_no_noise.append(mon)
+        monitors.append(dict())
+
+        for method_name, method in [('euler', euler), ('heun', heun)]:
+            with catch_logs('WARNING'):
+                G = NeuronGroup(2, eqs_noise, method=method)
+                G.x = [5,  17]
+                G.y = [25, 5 ] * Hz
+                mon = StateMonitor(G, ['x', 'y'], record=True)
+                net = Network(G, mon)
+                net.run(10*ms)
+                monitors[-1][method_name] = mon
+
+    device.build(direct_call=False, **device.build_options)
+
+    for i in range(len(all_eqs)):
+        mon = monitors_no_noise[i]
+        no_noise_x, no_noise_y = mon.x[:], mon.y[:]
+        for method_name in ['euler', 'heun']:
+            mon = monitors[i][method_name]
+            assert_allclose(mon.x[:], no_noise_x,
+                            err_msg='Method %s gave incorrect results' % method_name)
+            assert_allclose(mon.y[:], no_noise_y,
+                            err_msg='Method %s gave incorrect results' % method_name)
+
+
+@pytest.mark.standalone_compatible
+@pytest.mark.multiple_runs
+def test_pure_noise_deterministic(fake_randn_randn_fixture):
+    sigma = 3
+    eqs = Equations('dx/dt = sigma*xi/sqrt(ms) : 1')
+    dt = 0.1*ms
+    G_dict = {}
+    for method in ['euler', 'heun', 'milstein']:
+        G = NeuronGroup(1, eqs, dt=dt, method=method)
+        run(10*dt)
+        G_dict[method] = G
+
+    device.build(direct_call=False, **device.build_options)
+
+    for method in ['euler', 'heun', 'milstein']:
+        G = G_dict[method]
+        assert_allclose(G.x, sqrt(dt)*sigma*0.5/sqrt(1*ms)*10,
+                        err_msg='method %s did not give the expected result' % method)
+
+
+@pytest.mark.standalone_compatible
+@pytest.mark.multiple_runs
+def test_subexpressions():
+    '''
+    Make sure that the integration of a (non-stochastic) differential equation
+    does not depend on whether it's formulated using subexpressions.
+    '''
+    # no subexpression
+    eqs1 = 'dv/dt = (-v + sin(2*pi*100*Hz*t)) / (10*ms) : 1'
+    # same with subexpression
+    eqs2 = '''dv/dt = I / (10*ms) : 1
+              I = -v + sin(2*pi*100*Hz*t): 1'''
+
+    objects = {}
+    methods = ['exponential_euler', 'rk2', 'rk4']  # euler is tested in test_subexpressions_basic
+    for method in methods:
+        G1 = NeuronGroup(1, eqs1, method=method)
+        G1.v = 1
+        G2 = NeuronGroup(1, eqs2, method=method)
+        G2.v = 1
+        mon1 = StateMonitor(G1, 'v', record=True)
+        mon2 = StateMonitor(G2, 'v', record=True)
+        net = Network(G1, mon1, G2, mon2)
+        net.run(10*ms)
+        objects[method] = (G1, G2, mon1, mon2)
+
+    device.build(direct_call=False, **device.build_options)
+
+    for method in methods:
+        G1, G2, mon1, mon2 = objects[method]
+        assert_equal(mon1.v, mon2.v, 'Results for method %s differed!' % method)
+
+
+@pytest.mark.standalone_compatible
+@pytest.mark.multiple_runs
+def test_refractory():
+    # Compare integration with and without the addition of refractoriness --
+    # note that the cell here is not spiking, so it should never be in the
+    # refractory period and therefore the results should be exactly identical
+    # with and without (unless refractory)
+    objects = {}
+    eqs_base = 'dv/dt = -v/(10*ms) : 1'
+    for method in ['linear', 'exact', 'independent', 'euler', 'exponential_euler', 'rk2', 'rk4']:
+        G_no_ref = NeuronGroup(10, eqs_base, method=method)
+        G_no_ref.v = '(i+1)/11.'
+        G_ref = NeuronGroup(10, eqs_base + '(unless refractory)',
+                            refractory=1*ms, method=method)
+        G_ref.v = '(i+1)/11.'
+        net = Network(G_ref, G_no_ref)
+        net.run(10*ms)
+        objects[method] = (G_no_ref, G_ref)
+
+    device.build(direct_call=False, **device.build_options)
+
+    for method in ['linear', 'exact', 'independent', 'euler', 'exponential_euler', 'rk2', 'rk4']:
+        G_no_ref, G_ref = objects[method]
+        assert_allclose(G_no_ref.v[:], G_ref.v[:],
+                        err_msg=('Results with and without refractoriness '
+                                 'differ for method %s.') % method)
+
+
+@pytest.mark.standalone_compatible
+@pytest.mark.multiple_runs
+def test_refractory_stochastic(fake_randn_randn_fixture):
+
+    eqs_base = 'dv/dt = -v/(10*ms) + second**-.5*xi : 1'
+
+    objects = {}
+    for method in ['euler', 'heun', 'milstein']:
+        G_no_ref = NeuronGroup(10, eqs_base, method=method)
+        G_no_ref.v = '(i+1)/11.'
+        G_ref = NeuronGroup(10, eqs_base + ' (unless refractory)',
+                            refractory=1*ms, method=method)
+        G_ref.v = '(i+1)/11.'
+        net = Network(G_ref, G_no_ref)
+        net.run(10*ms)
+        objects[method] = (G_no_ref, G_ref)
+
+    device.build(direct_call=False, **device.build_options)
+
+    for method in ['euler', 'heun', 'milstein']:
+        G_no_ref, G_ref = objects[method]
+        assert_allclose(G_no_ref.v[:], G_ref.v[:],
+                        err_msg=('Results with and without refractoriness '
+                                 'differ for method %s.') % method)
+
+
+if __name__ == '__main__':
+    import brian2cuda
+    from brian2cuda.tests.conftest import fake_randn
+    for test in [
+            test_multiple_noise_variables_extended,
+            test_multiple_noise_variables_deterministic_noise,
+            test_pure_noise_deterministic,
+            test_subexpressions,
+            test_refractory,
+            test_refractory_stochastic,
+    ]:
+        print(test.__name__)
+        pytestmarks = [mark.name for mark in test.pytestmark]
+        build_on_run = True
+        if 'multiple_runs' in pytestmarks:
+            build_on_run = False
+        set_device('cuda_standalone', build_on_run=build_on_run, directory=None)
+        try:
+            test()
+        except  TypeError:
+            # Functions using fake_randn_randn_fixture, set fake randn manually here
+            orig_randn = DEFAULT_FUNCTIONS['randn']
+            DEFAULT_FUNCTIONS['randn'] = fake_randn
+            test(None)
+            DEFAULT_FUNCTIONS['randn'] = orig_randn
+
+        reinit_and_delete()

--- a/brian2cuda/tools/test_suite/run_single_test.py
+++ b/brian2cuda/tools/test_suite/run_single_test.py
@@ -66,7 +66,14 @@ additional_args = []
 additional_args += ['-vvv']
 # Set rootdir to directory that has brian2's conftest.py, such that it is laoded for all
 # tests (even when outside the brian2 folder)
-additional_args += ['--rootdir={}'.format(os.path.dirname(brian2.__file__))]
+additional_args += [
+    # Set rootdir to directory that has brian2's conftest.py, such that it is laoded for
+    # all tests (even when outside the brian2 folder)
+    '--rootdir={}'.format(os.path.dirname(brian2.__file__)),
+    # Set confcutdir, such that `conftest.py` inside `brian2cuda` are also loaded
+    # (overwrites confcutdir set in brian2's `make_argv`)
+    '--confcutdir={}'.format(os.path.dirname(brian2cuda.__file__))
+]
 
 brian2_dir = os.path.join(os.path.abspath(os.path.dirname(brian2.__file__)))
 b2c_dir = os.path.join(os.path.abspath(os.path.dirname(brian2cuda.__file__)), 'tests')

--- a/brian2cuda/tools/test_suite/run_test_suite.py
+++ b/brian2cuda/tools/test_suite/run_test_suite.py
@@ -66,11 +66,15 @@ stored_prefs = prefs.as_file
 # all tests (else each conftest.py applies only to the tests in its own directory).
 # To use brian2's conftest.py also for our brian2cuda tests, we set `rootdir` to the
 # `brian2` directory, where `brian2/conftest.py` is located.
-# XXX: If we ever want to have an own conftest.py, we need to pass `--confcutdir` here
-# (which overwrites the `--confcutdir` default option in `make_argv`), such that the
-# search of conftest.py files does not stop at `brian2` but at a higher directory, which
-# should include the conftest.py we want to load.
-additional_args = ['--rootdir={}'.format(os.path.dirname(brian2.__file__))]
+additional_args = [
+    # Set rootdir to directory that has brian2's conftest.py, such that it is laoded for
+    # all tests (even when outside the brian2 folder)
+    '--rootdir={}'.format(os.path.dirname(brian2.__file__)),
+    # Set confcutdir, such that `conftest.py` inside `brian2cuda` are also loaded
+    # (overwrites confcutdir set in brian2's `make_argv`, which stops searching for
+    # `conftest.py` files outside the `brian2` directory)
+    '--confcutdir={}'.format(os.path.dirname(brian2cuda.__file__))
+]
 
 if args.verbosity is not None:
    additional_args += ['-{}'.format(args.verbosity * 'v')]


### PR DESCRIPTION
See #183, I didn't check yet for all tests that could be converted, just did the `test_stateupdater.py`.

This PR also introduces a `brian2cuda/tests/conftest.py` file that updates the `fake_randn_randn_fixture` with a CUDA Standalone function implementation, which is needed for the added tests.

For the new `conftest.py` to be loaded, I had to set a new `--confcutdir` since our tests reside outside the `brian2` folder (and brian2 test suite sets `--confcutdir=/path/to/brian2`.