### PR TITLE
[MRG] Fix pytest fixture loading for brian2cuda tests

### DIFF
--- a/brian2cuda/cuda_prefs.py
+++ b/brian2cuda/cuda_prefs.py
@@ -2,7 +2,7 @@
 Preferences that relate to the brian2cuda interface.
 '''
 
-from brian2.core.preferences import prefs, BrianPreference, PreferenceError
+from brian2.core.preferences import prefs, BrianPreference
 from brian2.core.core_preferences import default_float_dtype_validator, dtype_repr
 import numpy as np
 

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -1129,9 +1129,6 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
             run_args = []
         if directory is None:
             directory = tempfile.mkdtemp(prefix='brian_standalone_')
-
-        cpp_compiler, cpp_extra_compile_args = get_compiler_and_args()
-        cpp_compiler_flags = ' '.join(cpp_extra_compile_args)
         self.project_dir = directory
         ensure_directory(directory)
 

--- a/brian2cuda/tests/conftest.py
+++ b/brian2cuda/tests/conftest.py
@@ -1,11 +1,8 @@
 '''
 Module containing fixtures and hooks used by the pytest test suite.
 '''
-# We set `--rootidr=/path/to/brian`, such that `brian2/conftest.py` is loaded for all
-# tests run in the test suite. This `conftest.py` will only be loaded for all tests in
-# this directory
-
-from brian2.conftest import fake_randn, fake_randn_randn_fixture
+# Use brian2's pytest configuration for the brian2cuda tests (see PR #232 for details)
+from brian2.conftest import *
 
 # Add a cuda implementation for the fake_randn_randn_fixture,
 # used in test_stateupdaters.py

--- a/brian2cuda/tests/test_gpu_detection.py
+++ b/brian2cuda/tests/test_gpu_detection.py
@@ -8,36 +8,60 @@ from brian2 import prefs, ms, run, set_device
 from brian2.utils.logger import catch_logs
 from brian2.core.preferences import PreferenceError
 from brian2cuda.utils.gputools import (
-    reset_cuda_installation, get_cuda_installation, restore_cuda_installation
+    reset_cuda_installation,
+    get_cuda_installation,
+    restore_cuda_installation,
+    reset_gpu_selection,
+    get_gpu_selection,
+    restore_gpu_selection
 )
 
 
+### Pytest fixtures ###
+# Detecting the CUDA installation and GPU to use is happening only once and sets global
+# variables, such that requesting information will not repeat the detection process. For
+# testing the detection process, we need to reset the global variables with fixtures.
+@pytest.fixture()
+def reset_cuda_detection():
+    # these function store, reset and restore the global _cuda_installation dictionary
+    backup = get_cuda_installation()
+    reset_cuda_installation()
+    yield
+    restore_cuda_installation(backup)
+
+
+@pytest.fixture()
+def reset_gpu_detection():
+    # these function store, reset and restore the global _cuda_installation dictionary
+    backup = get_gpu_selection()
+    reset_gpu_selection()
+    yield
+    restore_gpu_selection(backup)
+
+
+### Tests ###
 @pytest.mark.cuda_standalone
 @pytest.mark.standalone_only
-def test_wrong_cuda_path_error():
+def test_wrong_cuda_path_error(reset_cuda_detection):
     set_device("cuda_standalone", directory=None)
     # store global _cuda_installation and environment variable before changing them
-    cuda_installation_backup = get_cuda_installation()
     cuda_path_env = os.environ.get('CUDA_PATH', failobj=None)
-    # reset cuda installation, such that it will be detected again during `run()`
-    reset_cuda_installation()
 
     # Set wrong CUDA_PATH
     os.environ['CUDA_PATH'] = '/tmp'
     with pytest.raises(RuntimeError):
         run(0*ms)
 
-    # restore the cuda installation
-    restore_cuda_installation(cuda_installation_backup)
     # reset env variable
     if cuda_path_env is None:
         del os.environ['CUDA_PATH']
     else:
         os.environ['CUDA_PATH'] = cuda_path_env
 
+
 @pytest.mark.cuda_standalone
 @pytest.mark.standalone_only
-def test_manual_setting_compute_capability():
+def test_manual_setting_compute_capability(reset_gpu_detection):
     set_device("cuda_standalone", directory=None)
     compute_capability_pref = '3.5'
     prefs.devices.cuda_standalone.cuda_backend.compute_capability = float(compute_capability_pref)
@@ -50,9 +74,10 @@ def test_manual_setting_compute_capability():
             compute_capability = log[2][log_start_num_chars:log_start_num_chars + 3]
             assert_equal(compute_capability_pref, compute_capability)
 
+
 @pytest.mark.cuda_standalone
 @pytest.mark.standalone_only
-def test_unsupported_compute_capability_error():
+def test_unsupported_compute_capability_error(reset_gpu_detection):
     set_device("cuda_standalone", directory=None)
     prefs.devices.cuda_standalone.cuda_backend.compute_capability = 2.0
     with pytest.raises(NotImplementedError):
@@ -61,7 +86,7 @@ def test_unsupported_compute_capability_error():
 
 @pytest.mark.cuda_standalone
 @pytest.mark.standalone_only
-def test_warning_compute_capability_set_twice():
+def test_warning_compute_capability_set_twice(reset_gpu_detection):
     set_device("cuda_standalone", directory=None)
     prefs.devices.cuda_standalone.cuda_backend.compute_capability = 3.5
     prefs.devices.cuda_standalone.cuda_backend.extra_compile_args_nvcc.append('-arch=sm_37')
@@ -77,8 +102,9 @@ def test_warning_compute_capability_set_twice():
 
 @pytest.mark.cuda_standalone
 @pytest.mark.standalone_only
-def test_no_gpu_detection_preference_error():
+def test_no_gpu_detection_preference_error(reset_gpu_detection):
     set_device("cuda_standalone", directory=None)
+    # reset cuda installation, such that it will be detected again during `run()`
     prefs.devices.cuda_standalone.cuda_backend.detect_gpus = False
     # needs setting gpu_id and compute_capability as well
     with pytest.raises(PreferenceError):
@@ -87,7 +113,7 @@ def test_no_gpu_detection_preference_error():
 
 @pytest.mark.cuda_standalone
 @pytest.mark.standalone_only
-def test_no_gpu_detection_preference():
+def test_no_gpu_detection_preference(reset_gpu_detection):
     set_device("cuda_standalone", directory=None)
     # Test that disabling gpu detection works when setting gpu_id and compute_capability
     prefs.devices.cuda_standalone.cuda_backend.detect_gpus = False

--- a/brian2cuda/tests/test_gpu_detection.py
+++ b/brian2cuda/tests/test_gpu_detection.py
@@ -4,7 +4,7 @@ import logging
 import pytest
 from numpy.testing import assert_equal
 
-from brian2 import prefs, ms, run
+from brian2 import prefs, ms, run, set_device
 from brian2.utils.logger import catch_logs
 from brian2.core.preferences import PreferenceError
 from brian2cuda.utils.gputools import (
@@ -15,6 +15,7 @@ from brian2cuda.utils.gputools import (
 @pytest.mark.cuda_standalone
 @pytest.mark.standalone_only
 def test_wrong_cuda_path_error():
+    set_device("cuda_standalone", directory=None)
     # store global _cuda_installation and environment variable before changing them
     cuda_installation_backup = get_cuda_installation()
     cuda_path_env = os.environ.get('CUDA_PATH', failobj=None)
@@ -37,6 +38,7 @@ def test_wrong_cuda_path_error():
 @pytest.mark.cuda_standalone
 @pytest.mark.standalone_only
 def test_manual_setting_compute_capability():
+    set_device("cuda_standalone", directory=None)
     compute_capability_pref = '3.5'
     prefs.devices.cuda_standalone.cuda_backend.compute_capability = float(compute_capability_pref)
     with catch_logs(log_level=logging.INFO) as logs:
@@ -51,6 +53,7 @@ def test_manual_setting_compute_capability():
 @pytest.mark.cuda_standalone
 @pytest.mark.standalone_only
 def test_unsupported_compute_capability_error():
+    set_device("cuda_standalone", directory=None)
     prefs.devices.cuda_standalone.cuda_backend.compute_capability = 2.0
     with pytest.raises(NotImplementedError):
         run(0*ms)
@@ -59,6 +62,7 @@ def test_unsupported_compute_capability_error():
 @pytest.mark.cuda_standalone
 @pytest.mark.standalone_only
 def test_warning_compute_capability_set_twice():
+    set_device("cuda_standalone", directory=None)
     prefs.devices.cuda_standalone.cuda_backend.compute_capability = 3.5
     prefs.devices.cuda_standalone.cuda_backend.extra_compile_args_nvcc.append('-arch=sm_37')
     with catch_logs() as logs:
@@ -74,6 +78,7 @@ def test_warning_compute_capability_set_twice():
 @pytest.mark.cuda_standalone
 @pytest.mark.standalone_only
 def test_no_gpu_detection_preference_error():
+    set_device("cuda_standalone", directory=None)
     prefs.devices.cuda_standalone.cuda_backend.detect_gpus = False
     # needs setting gpu_id and compute_capability as well
     with pytest.raises(PreferenceError):
@@ -83,6 +88,7 @@ def test_no_gpu_detection_preference_error():
 @pytest.mark.cuda_standalone
 @pytest.mark.standalone_only
 def test_no_gpu_detection_preference():
+    set_device("cuda_standalone", directory=None)
     # Test that disabling gpu detection works when setting gpu_id and compute_capability
     prefs.devices.cuda_standalone.cuda_backend.detect_gpus = False
     prefs.devices.cuda_standalone.cuda_backend.gpu_id = 0

--- a/brian2cuda/tests/test_monitor.py
+++ b/brian2cuda/tests/test_monitor.py
@@ -7,6 +7,7 @@ from brian2 import *
 @pytest.mark.cuda_standalone
 @pytest.mark.standalone_only
 def test_state_monitor_more_threads_than_single_block():
+    set_device("cuda_standalone", directory=None)
     # Currently, statemonitor only works for <=1024 recorded variables (#201).
     # This is a test is to remind us of the issue.
     G = NeuronGroup(1025, 'v:1')

--- a/brian2cuda/tools/test_suite/run_single_test.py
+++ b/brian2cuda/tools/test_suite/run_single_test.py
@@ -20,6 +20,12 @@ parser.add_argument('-k', default=None, type=str,
                     help=("Passed to pytest's ``-k`` option. This overwrites ``tests`` "
                           "if ``--brian2`` or `--brian2cuda`` is set."))
 
+parser.add_argument('-q', '--quiet', action='store_true',
+                    help="Disable all verbosity")
+
+parser.add_argument('-d', '--debug', action='store_true',
+                    help=("Debug mode, set pytest to not capture outputs."))
+
 mutual_exclusive = parser.add_mutually_exclusive_group(required=False)
 mutual_exclusive.add_argument(
     '--brian2',
@@ -63,7 +69,9 @@ pref_plugin = PreferencePlugin(prefs, fail_for_not_implemented=True)
 
 additional_args = []
 # Increase verbosity such that the paths and names of executed tests are shown
-additional_args += ['-vvv']
+if not args.quiet:
+    # set verbosity to max(?)
+    additional_args += ['-vvv']
 # Set confcutdir, such that all `conftest.py` files inside the brian2 and brian2cuda
 # directories are loaded (this overwrites confcutdir set in brian2's `make_argv`, which
 # stops searching for `conftest.py` files outside the `brian2` directory)
@@ -76,7 +84,6 @@ additional_args += [
 
 brian2_dir = os.path.join(os.path.abspath(os.path.dirname(brian2.__file__)))
 b2c_dir = os.path.join(os.path.abspath(os.path.dirname(brian2cuda.__file__)), 'tests')
-
 
 if args.brian2:
     tests = [brian2_dir]
@@ -100,6 +107,13 @@ if args.k:
 
 if test_patterns is not None:
     additional_args += ['-k {}'.format(test_patterns)]
+
+with_output = False
+if args.debug:
+    # disable output capture
+    additional_args += ['-s']
+    # enable brian2 output
+    with_output = True
 
 all_successes = []
 for target in args.targets:
@@ -136,7 +150,7 @@ for target in args.targets:
             print ("Running standalone-compatible standard tests "
                    "(single run statement)\n")
             sys.stdout.flush()
-            pref_plugin.device_options = {'directory': None, 'with_output': False}
+            pref_plugin.device_options = {'directory': None, 'with_output': with_output}
             argv = make_argv(tests, markers='standalone_compatible and not multiple_runs')
             exit_code = pytest.main(argv + additional_args, plugins=[pref_plugin])
             pref_success = pref_success and (exit_code == 0)
@@ -148,7 +162,7 @@ for target in args.targets:
             print ("Running standalone-compatible standard tests "
                    "(multiple run statements)\n")
             sys.stdout.flush()
-            pref_plugin.device_options = {'directory': None, 'with_output': False,
+            pref_plugin.device_options = {'directory': None, 'with_output': with_output,
                                           'build_on_run': False}
             argv = make_argv(tests, markers='standalone_compatible and multiple_runs')
             exit_code = pytest.main(argv + additional_args, plugins=[pref_plugin])
@@ -160,7 +174,7 @@ for target in args.targets:
         if args.only is None or args.only == 'standalone-only':
             print "Running standalone-specific tests\n"
             sys.stdout.flush()
-            pref_plugin.device_options = {'directory': None, 'with_output': False,
+            pref_plugin.device_options = {'directory': None, 'with_output': with_output,
                                           # same as in brian2.tests()
                                           'build_on_run': False}
             argv = make_argv(tests, markers=target)

--- a/brian2cuda/tools/test_suite/run_single_test.py
+++ b/brian2cuda/tools/test_suite/run_single_test.py
@@ -64,15 +64,14 @@ pref_plugin = PreferencePlugin(prefs, fail_for_not_implemented=True)
 additional_args = []
 # Increase verbosity such that the paths and names of executed tests are shown
 additional_args += ['-vvv']
-# Set rootdir to directory that has brian2's conftest.py, such that it is laoded for all
-# tests (even when outside the brian2 folder)
+# Set confcutdir, such that all `conftest.py` files inside the brian2 and brian2cuda
+# directories are loaded (this overwrites confcutdir set in brian2's `make_argv`, which
+# stops searching for `conftest.py` files outside the `brian2` directory)
 additional_args += [
-    # Set rootdir to directory that has brian2's conftest.py, such that it is laoded for
-    # all tests (even when outside the brian2 folder)
-    '--rootdir={}'.format(os.path.dirname(brian2.__file__)),
-    # Set confcutdir, such that `conftest.py` inside `brian2cuda` are also loaded
-    # (overwrites confcutdir set in brian2's `make_argv`)
-    '--confcutdir={}'.format(os.path.dirname(brian2cuda.__file__))
+    # TODO (Python 3): Use `os.path.commonpath`
+    '--confcutdir={}'.format(
+        os.path.dirname(os.path.commonprefix([brian2.__file__, brian2cuda.__file__]))
+    )
 ]
 
 brian2_dir = os.path.join(os.path.abspath(os.path.dirname(brian2.__file__)))

--- a/brian2cuda/tools/test_suite/run_single_test.py
+++ b/brian2cuda/tools/test_suite/run_single_test.py
@@ -49,7 +49,7 @@ import numpy as np
 
 import brian2
 import brian2cuda
-from brian2.devices.device import set_device, reset_device
+from brian2.devices.device import reset_device
 from brian2.tests import clear_caches, make_argv, PreferencePlugin
 from brian2 import prefs
 import brian2cuda
@@ -104,6 +104,7 @@ if test_patterns is not None:
 all_successes = []
 for target in args.targets:
 
+    pref_plugin.device = target
     if target == 'cuda_standalone':
         preference_dictionaries = all_prefs_combinations
     else:
@@ -135,7 +136,7 @@ for target in args.targets:
             print ("Running standalone-compatible standard tests "
                    "(single run statement)\n")
             sys.stdout.flush()
-            set_device(target, directory=None, with_output=False)
+            pref_plugin.device_options = {'directory': None, 'with_output': False}
             argv = make_argv(tests, markers='standalone_compatible and not multiple_runs')
             exit_code = pytest.main(argv + additional_args, plugins=[pref_plugin])
             pref_success = pref_success and (exit_code == 0)
@@ -147,8 +148,8 @@ for target in args.targets:
             print ("Running standalone-compatible standard tests "
                    "(multiple run statements)\n")
             sys.stdout.flush()
-            set_device(target, directory=None, with_output=False,
-                       build_on_run=False)
+            pref_plugin.device_options = {'directory': None, 'with_output': False,
+                                          'build_on_run': False}
             argv = make_argv(tests, markers='standalone_compatible and multiple_runs')
             exit_code = pytest.main(argv + additional_args, plugins=[pref_plugin])
             pref_success = pref_success and (exit_code == 0)
@@ -159,7 +160,9 @@ for target in args.targets:
         if args.only is None or args.only == 'standalone-only':
             print "Running standalone-specific tests\n"
             sys.stdout.flush()
-            set_device(target, directory=None, with_output=False)
+            pref_plugin.device_options = {'directory': None, 'with_output': False,
+                                          # same as in brian2.tests()
+                                          'build_on_run': False}
             argv = make_argv(tests, markers=target)
             exit_code = pytest.main(argv + additional_args, plugins=[pref_plugin])
             pref_success = pref_success and (exit_code == 0)

--- a/brian2cuda/tools/test_suite/run_test_suite.py
+++ b/brian2cuda/tools/test_suite/run_test_suite.py
@@ -62,18 +62,14 @@ if args.test_parallel is None:
 
 stored_prefs = prefs.as_file
 
-# Only the conftest.py located in the `rootdir` of a pytest run is loaded and used for
-# all tests (else each conftest.py applies only to the tests in its own directory).
-# To use brian2's conftest.py also for our brian2cuda tests, we set `rootdir` to the
-# `brian2` directory, where `brian2/conftest.py` is located.
+# Set confcutdir, such that all `conftest.py` files inside the brian2 and brian2cuda
+# directories are loaded (this overwrites confcutdir set in brian2's `make_argv`, which
+# stops searching for `conftest.py` files outside the `brian2` directory)
 additional_args = [
-    # Set rootdir to directory that has brian2's conftest.py, such that it is laoded for
-    # all tests (even when outside the brian2 folder)
-    '--rootdir={}'.format(os.path.dirname(brian2.__file__)),
-    # Set confcutdir, such that `conftest.py` inside `brian2cuda` are also loaded
-    # (overwrites confcutdir set in brian2's `make_argv`, which stops searching for
-    # `conftest.py` files outside the `brian2` directory)
-    '--confcutdir={}'.format(os.path.dirname(brian2cuda.__file__))
+    # TODO (Python 3): Use `os.path.commonpath`
+    '--confcutdir={}'.format(
+        os.path.dirname(os.path.commonprefix([brian2.__file__, brian2cuda.__file__]))
+    )
 ]
 
 if args.verbosity is not None:

--- a/brian2cuda/tools/test_suite/run_test_suite.py
+++ b/brian2cuda/tools/test_suite/run_test_suite.py
@@ -27,8 +27,11 @@ parser.add_argument('-k', default=None, type=str,
                          "some tests, e.g. `-k 'test_functions` or `-k 'not "
                          "test_funcions'`")
 
-parser.add_argument('-v', '--verbosity', action='count', default=None,
-                    help="Increase pytest verbosity.")
+parser.add_argument('-q', '--quiet', action='store_true',
+                    help="Disable all verbosity")
+
+parser.add_argument('-d', '--debug', action='store_true',
+                    help=("Debug mode, set pytest to not capture outputs."))
 
 args = utils.parse_arguments(parser)
 
@@ -72,11 +75,19 @@ additional_args = [
     )
 ]
 
-if args.verbosity is not None:
-   additional_args += ['-{}'.format(args.verbosity * 'v')]
+if not args.quiet:
+    # set verbosity to max(?)
+    additional_args += ['-vvv']
 
 if args.k is not None:
     additional_args += ['-k {}'.format(args.k)]
+
+build_options = None
+if args.debug:
+    # disable output capture
+    additional_args += ['-s']
+    # enable brian2 output
+    build_options = {'with_output': True}
 
 all_successes = []
 for target in args.targets:
@@ -114,7 +125,8 @@ for target in args.targets:
                        test_in_parallel=test_in_parallel,
                        extra_test_dirs=extra_test_dirs,
                        float_dtype=None,
-                       additional_args=additional_args)
+                       additional_args=additional_args,
+                       build_options=build_options)
 
         successes.append(success)
 

--- a/brian2cuda/tools/test_suite/run_test_suite.sh
+++ b/brian2cuda/tools/test_suite/run_test_suite.sh
@@ -62,6 +62,6 @@ done
 test_suite_args=$@
 
 # add timestemp to name
-task_name="$(date +%y-%m-%d_%H-%M-%S)"__"$task_name".log
+task_name="$task_name"_"$(date +%y-%m-%d_%H-%M-%S)".log
 
 bash _run_test_suite.sh "$task_name" "$logdir" "$test_suite_args"

--- a/brian2cuda/tools/test_suite/utils.py
+++ b/brian2cuda/tools/test_suite/utils.py
@@ -11,7 +11,7 @@ def powerset(iterable):
     return chain.from_iterable(combinations(s, r) for r in range(len(s)+1))
 
 
-def parse_arguments(parser):
+def parse_arguments(parser, parse_unknown=False):
 
     parser.add_argument('--targets', '-t', nargs='*',
                         default=['cuda_standalone'], type=str,
@@ -46,14 +46,20 @@ def parse_arguments(parser):
                         help=("Exit script after argument parsing. Used to check "
                               "validity of arguments"))
 
-    args = parser.parse_args()
+    if parse_unknown:
+        args, unknown_args = parser.parse_known_args()
+    else:
+        args = parser.parse_args()
 
     if args.dry_run:
         import sys
         print("Dry run completed, {} arguments valid.".format(__file__))
         sys.exit()
 
-    return args
+    if parse_unknown:
+        return args, unknown_args
+    else:
+        return args
 
 
 def print_single_prefs(prefs_dict, set_prefs=None, return_lines=False):

--- a/brian2cuda/utils/gputools.py
+++ b/brian2cuda/utils/gputools.py
@@ -92,7 +92,9 @@ def get_gpu_selection():
         'selected_gpu_compute_capability': compute_capability,
     }
     global _gpu_selection
-    assert gpu_selection.keys() == _gpu_selection.keys()
+    assert (
+        sorted(gpu_selection.keys()) == sorted(_gpu_selection.keys())
+    ), "{} != {}".format(gpu_selection.keys(), _gpu_selection.keys())
     return gpu_selection
 
 
@@ -145,10 +147,12 @@ def reset_gpu_selection():
 def restore_cuda_installation(cuda_installation):
     """Set global cuda installation dictionary to `cuda_installation`"""
     global _cuda_installation
-    if _cuda_installation.keys() != cuda_installation.keys():
+    if sorted(_cuda_installation.keys()) != sorted(cuda_installation.keys()):
         raise KeyError(
             "`cuda_installation` has to have the following keys: {}. Got instead: "
-            "{}".format(cuda_installation.keys(), _cuda_installation.keys())
+            "{}".format(
+                sorted(cuda_installation.keys()), sorted(_cuda_installation.keys())
+            )
         )
     _cuda_installation.update(cuda_installation)
 
@@ -156,10 +160,10 @@ def restore_cuda_installation(cuda_installation):
 def restore_gpu_selection(gpu_selection):
     """Set global gpu selection dictionary to `gpu_selection`"""
     global _gpu_selection
-    if _gpu_selection.keys() != gpu_selection.keys():
+    if sorted(_gpu_selection.keys()) != sorted(gpu_selection.keys()):
         raise KeyError(
             "`gpu_selection` has to have the following keys: {}. Got instead: "
-            "{}".format(gpu_selection.keys(), _gpu_selection.keys())
+            "{}".format(sorted(gpu_selection.keys()), sorted(_gpu_selection.keys()))
         )
     _gpu_selection.update(gpu_selection)
 

--- a/frozen_repos/brian2.diff
+++ b/frozen_repos/brian2.diff
@@ -1,8 +1,8 @@
 diff --git a/brian2/devices/cpp_standalone/device.py b/brian2/devices/cpp_standalone/device.py
-index a2666799..7d671f5e 100644
+index a378e649..64c784a6 100644
 --- a/brian2/devices/cpp_standalone/device.py
 +++ b/brian2/devices/cpp_standalone/device.py
-@@ -1038,6 +1038,7 @@ def run(self, directory, with_output, run_args):
+@@ -1066,6 +1066,7 @@ def run(self, directory, with_output, run_args):
                  run_time, completed_fraction = last_run_info.split()
                  self._last_run_time = float(run_time)
                  self._last_run_completed_fraction = float(completed_fraction)
@@ -10,7 +10,7 @@ index a2666799..7d671f5e 100644
  
          # Make sure that integration did not create NaN or very large values
          owners = [var.owner for var in self.arrays]
-@@ -1362,6 +1363,14 @@ def network_run(self, net, duration, report=None, report_period=10*second,
+@@ -1390,6 +1391,14 @@ def network_run(self, net, duration, report=None, report_period=10*second,
          # We store this as an instance variable for later access by the
          # `code_object` method
          self.enable_profiling = profile


### PR DESCRIPTION
Since commit brian-team/brian2@9c239bc1, the brian2cuda tests fail because the `setup_and_teardown` fixtures are not loaded anymore. I didn't why that is the case. Before that commit, the fixtures defined in `brian2/conftest.py` were loaded for all tests (even outside the `brian2` directory), because I set `--rootdir=brian2` (and the `conftest.py` in the `rootdir` should be loaded for all tests).

I don't know why things stopped working now. Maybe the [@pytest.hookimpl](https://github.com/brian-team/brian2/blob/a71abd338a50a916863230b5d648012d3542666b/brian2/conftest.py#L94) is not loaded for all tests? And also wasn't before the commit, which I never tested since I run the test suite with `fail_for_not_implemented=True`? And since the `reinit_and_delete` moved in the hook function, this might be the issue.

Anyways, I changed the setup now such that `brian2cuda/tests/conftest.py` import everything from `brian2/conftest.py` and I set `--confcutdir` such that `brian2cuda/test/conftest.py` is loaded for the brian2cuda tests.

**EDIT**
- Also fixed some missing `set_device` calls in `cuda_standalone` tests. Tests marked as `standalone_only` and `cuda_standalone` are called with `build_on_run=False` (because that is the config that is set before in the test function). As the documentation says, these tests need an explicit `set_device`. But it seems in the nose test setup, they didn't really. Fixed it now.
- Also fixed the gpu detection tests by adding fixtures for resetting the globally detected installation / gpu.