### PR TITLE
[MRG] Support last brian2 version with Python 2 support

### DIFF
--- a/brian2cuda/cuda_generator.py
+++ b/brian2cuda/cuda_generator.py
@@ -244,9 +244,9 @@ class CUDACodeGenerator(CodeGenerator):
         # set clip function to either use all float or all double arguments
         # see #51 for details
         if prefs['core.default_float_dtype'] == np.float64:
-            self.float_dtype = 'float'
-        else:  # np.float32
             self.float_dtype = 'double'
+        else:  # np.float32
+            self.float_dtype = 'float'
 
 
     @property

--- a/brian2cuda/cuda_generator.py
+++ b/brian2cuda/cuda_generator.py
@@ -437,9 +437,10 @@ class CUDACodeGenerator(CodeGenerator):
                             if int64_type is not None:
                                 logger.warn("Detected code statement with default function and 64bit integer type in the same line. "
                                             "Using 64bit integer types as default function arguments is not type safe due to convertion of "
-                                            "integer to 64bit floating-point types in device code. (relevant functions: sin, cos, tan, sinh, "
-                                            "cosh, tanh, exp, log, log10, sqrt, ceil, floor, arcsin, arccos, arctan)\nDetected code "
-                                            "statement:\n\t{}\nGenerated from abstract code statements:\n\t{}\n".format(line, statements),
+                                            "integer to 64bit floating-point types in device code. (relevant functions: {})\nDetected code "
+                                            "statement:\n\t{}\nGenerated from abstract code statements:\n\t{}\n".format(
+                                                ', '.join(functions_C99), line, statements
+                                            ),
                                             once=True)
                                 self.warned_integral_convertion = True
                                 self.previous_convertion_pref = np.float64
@@ -450,9 +451,10 @@ class CUDACodeGenerator(CodeGenerator):
                                 logger.warn("Detected code statement with default function and 32bit or 64bit integer type in the same line and the "
                                             "preference for default_functions_integral_convertion is 'float32'. "
                                             "Using 32bit or 64bit integer types as default function arguments is not type safe due to convertion of "
-                                            "integer to single-precision floating-point types in device code. (relevant functions: sin, cos, tan, sinh, "
-                                            "cosh, tanh, exp, log, log10, sqrt, ceil, floor, arcsin, arccos, arctan)\nDetected code "
-                                            "statement:\n\t{}\nGenerated from abstract code statements:\n\t{}\n".format(line, statements),
+                                            "integer to single-precision floating-point types in device code. (relevant functions: {})\nDetected code "
+                                            "statement:\n\t{}\nGenerated from abstract code statements:\n\t{}\n".format(
+                                                ', '.join(functions_C99), line, statements
+                                            ),
                                             once=True)
                                 self.warned_integral_convertion = True
                                 self.previous_convertion_pref = np.float32
@@ -797,7 +799,7 @@ functions_C99 = []
 func_translations = []
 # Functions that exist under the same name in C++
 for func in ['sin', 'cos', 'tan', 'sinh', 'cosh', 'tanh', 'exp', 'log',
-             'log10', 'sqrt', 'ceil', 'floor']:
+             'log10', 'expm1', 'log1p', 'sqrt', 'ceil', 'floor']:
     func_translations.append((func, func))
 
 # Functions that exist under a different name in C++

--- a/brian2cuda/tests/test_random_number_generation.py
+++ b/brian2cuda/tests/test_random_number_generation.py
@@ -7,7 +7,7 @@ from brian2 import *
 from brian2.monitors.statemonitor import StateMonitor
 from brian2.core.clocks import defaultclock
 from brian2.utils.logger import catch_logs
-from brian2.devices.device import device
+from brian2.devices.device import device, reinit_and_delete
 
 import brian2cuda
 from brian2cuda.device import prepare_codeobj_code_for_rng
@@ -1215,12 +1215,60 @@ def test_poisson_variable_lambda_set_template_random_seed():
 
 
 if __name__ == '__main__':
-    test_rand()
-    test_random_number_generation_with_multiple_runs()
-    test_random_values_fixed_and_random()
-    test_random_values_codeobject_every_tick()
-    test_rand_randn_regex()
-    test_poisson_regex()
+    import brian2cuda
+    from brian2cuda.tests.conftest import fake_randn
+    for test in [
+        test_rand_randn_regex,
+        test_poisson_regex,
+        test_rng_occurrence_counting,
+        test_binomial_occurrence,
+        test_rand,
+        test_random_number_generation_with_multiple_runs,
+        test_random_values_fixed_and_random_seed,
+        test_poisson_scalar_values_fixed_and_random_seed,
+        test_poisson_vectorized_values_fixed_and_random_seed,
+        test_random_values_codeobject_every_tick,
+        test_binomial_values,
+        test_random_values_set_synapses_random_seed,
+        test_random_values_set_synapses_fixed_seed,
+        test_random_values_synapse_dynamics_fixed_and_random_seed,
+        test_random_values_init_synapses_fixed_and_random_seed,
+        test_binomial_values_random_seed,
+        test_binomial_values_fixed_seed,
+        test_binomial_values_fixed_and_random_seed,
+        test_binomial_values_set_synapses_random_seed,
+        test_binomial_values_set_synapses_fixed_seed,
+        test_binomial_values_synapse_dynamics_fixed_and_random_seed,
+        test_binomial_values_init_synapses_fixed_and_random_seed,
+        test_random_binomial_set_template_random_seed,
+        test_random_binomial_poisson_scalar_lambda_values_set_synapses_fixed_seed,
+        test_random_binomial_poisson_variable_lambda_values_set_synapses_fixed_seed,
+        test_poisson_scalar_lambda_values_random_seed,
+        test_poisson_variable_lambda_values_random_seed,
+        test_poisson_scalar_lambda_values_fixed_seed,
+        test_poisson_variable_lambda_values_fixed_seed,
+        test_poisson_scalar_lambda_values_fixed_and_random_seed,
+        test_poisson_variable_lambda_values_fixed_and_random_seed,
+        test_poisson_scalar_lambda_values_set_synapses_random_seed,
+        test_poisson_variable_lambda_values_set_synapses_random_seed,
+        test_poisson_scalar_lambda_values_set_synapses_fixed_seed,
+        test_poisson_variable_lambda_values_set_synapses_fixed_seed,
+        test_poisson_scalar_lambda_values_synapse_dynamics_fixed_and_random_seed,
+        test_poisson_variable_lambda_values_synapse_dynamics_fixed_and_random_seed,
+        test_poisson_values_init_synapses_fixed_and_random_seed,
+        test_poisson_scalar_lambda_set_template_random_seed,
+        test_poisson_variable_lambda_set_template_random_seed,
+    ]:
+        print
+        print(test.__name__)
+        pytestmarks = [mark.name for mark in test.pytestmark]
+        build_on_run = True
+        if 'multiple_runs' in pytestmarks:
+            build_on_run = False
+        set_device('cuda_standalone', build_on_run=build_on_run, directory=None)
+        test()
+
+        reinit_and_delete()
 
 
 

--- a/frozen_repos/brian2.diff
+++ b/frozen_repos/brian2.diff
@@ -1,8 +1,8 @@
 diff --git a/brian2/devices/cpp_standalone/device.py b/brian2/devices/cpp_standalone/device.py
-index a378e649..64c784a6 100644
+index f06c12a3..325e6139 100644
 --- a/brian2/devices/cpp_standalone/device.py
 +++ b/brian2/devices/cpp_standalone/device.py
-@@ -1066,6 +1066,7 @@ def run(self, directory, with_output, run_args):
+@@ -1068,6 +1068,7 @@ def run(self, directory, with_output, run_args):
                  run_time, completed_fraction = last_run_info.split()
                  self._last_run_time = float(run_time)
                  self._last_run_completed_fraction = float(completed_fraction)
@@ -10,7 +10,7 @@ index a378e649..64c784a6 100644
  
          # Make sure that integration did not create NaN or very large values
          owners = [var.owner for var in self.arrays]
-@@ -1390,6 +1391,14 @@ def network_run(self, net, duration, report=None, report_period=10*second,
+@@ -1392,6 +1393,14 @@ def network_run(self, net, duration, report=None, report_period=10*second,
          # We store this as an instance variable for later access by the
          # `code_object` method
          self.enable_profiling = profile


### PR DESCRIPTION
See #200 

This adds CUDA implementations for default functions `expm1`, `log1p` and `exprel`, while `exprel` is not type-safe in single-precision mode yet, see #233.

The brian2 update also included a change of integer types to `site_t` types, which I haven't implemented yet, see #230 .