### PR TITLE
Template overhaul

### DIFF
--- a/brian2cuda/templates/common_group.cu
+++ b/brian2cuda/templates/common_group.cu
@@ -1,3 +1,4 @@
+{# USES_VARIABLES { N } #}
 {% macro cu_file() %}
 #include "code_objects/{{codeobj_name}}.h"
 #include "brianlib/common_math.h"
@@ -70,7 +71,6 @@ kernel_{{codeobj_name}}(
     %KERNEL_PARAMETERS%
     )
 {
-    {# USES_VARIABLES { N } #}
     using namespace brian;
 
     int tid = threadIdx.x;
@@ -114,7 +114,6 @@ kernel_{{codeobj_name}}(
 
 void _run_{{codeobj_name}}()
 {
-    {# USES_VARIABLES { N } #}
     using namespace brian;
 
     {% block profiling_start %}

--- a/brian2cuda/templates/common_group.cu
+++ b/brian2cuda/templates/common_group.cu
@@ -57,6 +57,7 @@ namespace {
     {% endblock random_functions %}
 }
 
+////// hashdefine_lines ///////
 {{hashdefine_lines|autoindent}}
 
 {% block kernel %}

--- a/brian2cuda/templates/common_synapses.cu
+++ b/brian2cuda/templates/common_synapses.cu
@@ -1,5 +1,5 @@
-{% extends 'common_group.cu' %}
 {# USES_VARIABLES { N, no_delay_mode } #}
+{% extends 'common_group.cu' %}
 {% block extra_headers %}
 #include <stdint.h>
 #include "synapses_classes.h"

--- a/brian2cuda/templates/group_variable_set.cu
+++ b/brian2cuda/templates/group_variable_set.cu
@@ -1,3 +1,4 @@
+{# USES_VARIABLES { _group_idx } #}
 {% extends 'common_group.cu' %}
 
 {% block extra_headers %}
@@ -5,7 +6,6 @@
 {% endblock %}
 
 {% block kernel_maincode %}
-    {# USES_VARIABLES { _group_idx } #}
     ///// block kernel_maincode /////
 
     ///// scalar code /////

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -1,3 +1,5 @@
+{# USES_VARIABLES { N } #}
+{# ALLOWS_SCALAR_WRITE #}
 {% macro cu_file() %}
 #include "code_objects/{{codeobj_name}}.h"
 #include "rand.h"
@@ -49,7 +51,6 @@ __global__ void kernel_{{codeobj_name}}(
     %KERNEL_PARAMETERS%
     )
 {
-    {# USES_VARIABLES { N } #}
     using namespace brian;
 
     int tid = threadIdx.x;
@@ -89,8 +90,6 @@ __global__ void kernel_{{codeobj_name}}(
 
 void _run_{{codeobj_name}}()
 {
-    {# USES_VARIABLES { N } #}
-    {# ALLOWS_SCALAR_WRITE #}
     using namespace brian;
 
     {# N is a constant in most cases (NeuronGroup, etc.), but a scalar array for

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -1,73 +1,10 @@
 {# USES_VARIABLES { N } #}
 {# ALLOWS_SCALAR_WRITE #}
-{% macro cu_file() %}
-#include "code_objects/{{codeobj_name}}.h"
-#include "rand.h"
-#include "brianlib/common_math.h"
-#include "brianlib/stdint_compat.h"
-#include "brianlib/cuda_utils.h"
-#include<math.h>
-#include<stdint.h>
-#include<iostream>
-#include<fstream>
+{% extends 'common_group.cu' %}
 
-{% block extra_headers %}
-{% endblock %}
 
-{% for name in user_headers %}
-#include {{name}}
-{%endfor %}
-
-////// SUPPORT CODE ///////
-namespace {
-    // Implement dummy functions such that the host compiled code of binomial
-    // functions works. Hacky, hacky ...
-    double _host_rand(const int _vectorisation_idx)
-    {
-        printf("ERROR: Called dummy function `_host_rand` in %s:%d\n", __FILE__,
-                __LINE__);
-        exit(EXIT_FAILURE);
-    }
-    double _host_randn(const int _vectorisation_idx)
-    {
-        printf("ERROR: Called dummy function `_host_rand` in %s:%d\n", __FILE__,
-                __LINE__);
-        exit(EXIT_FAILURE);
-    }
-    int32_t _host_poisson(double _lambda, const int _vectorisation_idx)
-    {
-        printf("ERROR: Called dummy function `_host_poisson` in %s:%d\n", __FILE__,
-                __LINE__);
-        exit(EXIT_FAILURE);
-    }
-
-    {{support_code_lines|autoindent}}
-}
-
-__global__ void kernel_{{codeobj_name}}(
-    int _N,
-    int THREADS_PER_BLOCK,
-    ///// KERNEL_PARAMETERS /////
-    %KERNEL_PARAMETERS%
-    )
-{
-    using namespace brian;
-
-    int tid = threadIdx.x;
-    int bid = blockIdx.x;
-    int _idx = bid * THREADS_PER_BLOCK + tid;
-    int _vectorisation_idx = _idx;
-
-    ///// KERNEL_CONSTANTS /////
-    %KERNEL_CONSTANTS%
-
-    ///// kernel_lines /////
-    {{kernel_lines|autoindent}}
-
-    if(_idx >= _N)
-    {
-        return;
-    }
+{% block kernel_maincode %}
+    ///// block kernel_maincode /////
 
     ///// scalar_code['condition'] /////
     {{scalar_code['condition']|autoindent}}
@@ -83,105 +20,12 @@ __global__ void kernel_{{codeobj_name}}(
         ///// vector_code['statement'] /////
         {{vector_code['statement']|autoindent}}
     }
-}
 
-////// HASH DEFINES ///////
-{{hashdefine_lines|autoindent}}
+    ///// endblock kernel_maincode /////
+{% endblock kernel_maincode %}
 
-void _run_{{codeobj_name}}()
-{
-    using namespace brian;
 
-    {# N is a constant in most cases (NeuronGroup, etc.), but a scalar array for
-       synapses, we therefore have to take care to get its value in the right
-       way. #}
-    const int _N = {{constant_or_scalar('N', variables['N'])}};
-
-    ///// HOST_CONSTANTS ///////////
-    %HOST_CONSTANTS%
-
-    static int num_threads, num_blocks;
-    static bool first_run = true;
-    if (first_run)
-    {
-        // get number of blocks and threads
-        {% if calc_occupancy %}
-        int min_num_threads; // The minimum grid size needed to achieve the
-                             // maximum occupancy for a full device launch
-
-        CUDA_SAFE_CALL(
-                cudaOccupancyMaxPotentialBlockSize(&min_num_threads, &num_threads,
-                    kernel_{{codeobj_name}}, 0, 0)  // last args: dynamicSMemSize, blockSizeLimit
-                );
-
-        // Round up according to array size
-        num_blocks = (_N + num_threads - 1) / num_threads;
-
-        // calculate theoretical occupancy
-        int max_active_blocks;
-        CUDA_SAFE_CALL(
-                cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_active_blocks,
-                    kernel_{{codeobj_name}}, num_threads, 0)
-                );
-
-        float occupancy = (max_active_blocks * num_threads / num_threads_per_warp) /
-                          (float)(max_threads_per_sm / num_threads_per_warp);
-
-        {% else %}
-        num_blocks = num_parallel_blocks;
-        while(num_blocks * max_threads_per_block < _N)
-        {
-            num_blocks *= 2;
-        }
-        num_threads = min(max_threads_per_block, (int)ceil(_N/(double)num_blocks));
-        {% endif %}
-
-        // check if we have enough ressources to call kernel with given number
-        // of blocks and threads
-        struct cudaFuncAttributes funcAttrib;
-        CUDA_SAFE_CALL(
-                cudaFuncGetAttributes(&funcAttrib, kernel_{{codeobj_name}})
-                );
-        if (num_threads > funcAttrib.maxThreadsPerBlock)
-        {
-            // use the max num_threads before launch failure
-            num_threads = funcAttrib.maxThreadsPerBlock;
-            printf("WARNING Not enough ressources available to call "
-                   "kernel_{{codeobj_name}} "
-                   "with maximum possible threads per block (%u). "
-                   "Reducing num_threads to %u. (Kernel needs %i "
-                   "registers per block, %i bytes of "
-                   "statically-allocated shared memory per block, %i "
-                   "bytes of local memory per thread and a total of %i "
-                   "bytes of user-allocated constant memory)\n",
-                   max_threads_per_block, num_threads, funcAttrib.numRegs,
-                   funcAttrib.sharedSizeBytes, funcAttrib.localSizeBytes,
-                   funcAttrib.constSizeBytes);
-        }
-        else
-        {
-            printf("INFO kernel_{{codeobj_name}}\n"
-                   "\t%u blocks\n"
-                   "\t%u threads\n"
-                   "\t%i registers per block\n"
-                   "\t%i bytes statically-allocated shared memory per block\n"
-                   "\t%i bytes local memory per thread\n"
-                   "\t%i bytes user-allocated constant memory\n",
-                   num_blocks, num_threads, funcAttrib.numRegs,
-                   funcAttrib.sharedSizeBytes, funcAttrib.localSizeBytes,
-                   funcAttrib.constSizeBytes);
-        }
-        first_run = false;
-    }
-
-    kernel_{{codeobj_name}}<<<num_blocks, num_threads>>>(
-        _N,
-        num_threads,
-        ///// HOST_PARAMETERS /////
-        %HOST_PARAMETERS%
-    );
-
-    CUDA_CHECK_ERROR("kernel_{{codeobj_name}}");
+{% block extra_kernel_call_post %}
     {% for var in variables.values() %}
     {# We want to copy only those variables that were potentially modified in aboves kernel call. #}
     {% if var is not callable and var.array and not var.constant and not var.dynamic %}
@@ -191,27 +35,12 @@ void _run_{{codeobj_name}}()
             );
     {% endif %}
     {% endfor %}
-}
-
-{% block extra_functions_cu %}
 {% endblock %}
 
-{% endmacro %}
 
-
-{% macro h_file() %}
-#ifndef _INCLUDED_{{codeobj_name}}
-#define _INCLUDED_{{codeobj_name}}
-
-#include "objects.h"
-
-void _run_{{codeobj_name}}();
-
-{% block extra_functions_h %}
+{% block profiling_start %}
 {% endblock %}
 
-#endif
-{% endmacro %}
 
-
-
+{% block profiling_stop %}
+{% endblock %}

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -1,7 +1,7 @@
-{% extends 'common_group.cu' %}
 {# USES_VARIABLES { N, rate, t, _spikespace, _clock_t, _clock_dt,
                     _num_source_neurons, _source_start, _source_stop } #}
 {# WRITES_TO_READ_ONLY_VARIABLES { N } #}
+{% extends 'common_group.cu' %}
 
 {% block define_N %}
 {% endblock %}

--- a/brian2cuda/templates/reset.cu
+++ b/brian2cuda/templates/reset.cu
@@ -1,6 +1,6 @@
+{# USES_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
 {% block kernel_maincode %}
-    {# USES_VARIABLES { N } #}
 
     {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
     {% set _eventspace = get_array_name(eventspace_variable) %}

--- a/brian2cuda/templates/spatialstateupdate.cu
+++ b/brian2cuda/templates/spatialstateupdate.cu
@@ -129,7 +129,6 @@ __global__ void kernel_{{codeobj_name}}_coupling(
     %KERNEL_PARAMETERS%
     )
 {
-    {# USES_VARIABLES { N } #}
     using namespace brian;
 
     int tid = threadIdx.x;
@@ -247,7 +246,6 @@ __global__ void kernel_{{codeobj_name}}_combine(
     %KERNEL_PARAMETERS%
     )
 {
-    {# USES_VARIABLES { N } #}
     using namespace brian;
 
     int tid = threadIdx.x;
@@ -294,7 +292,6 @@ __global__ void kernel_{{codeobj_name}}_currents(
     %KERNEL_PARAMETERS%
     )
 {
-    {# USES_VARIABLES { N } #}
     using namespace brian;
 
     int tid = threadIdx.x;

--- a/brian2cuda/templates/spikegenerator.cu
+++ b/brian2cuda/templates/spikegenerator.cu
@@ -1,5 +1,5 @@
-{% extends 'common_group.cu' %}
-{#
+{# TEMPLATE INFO
+
     Notes: This codeobject is run every time step and fills the spikespace of
            the spikegenerator neurongroup with the neuron IDs of the neurons that
            spike in this time step. If there are multiple circular spikespaces
@@ -34,9 +34,10 @@
     - For additional optimizations, see #193.
 #}
 
-{# USES_VARIABLES {_spikespace, neuron_index, _timebins, _period_bins, _lastindex, t_in_timesteps, N} #}
-
-
+{# USES_VARIABLES {_spikespace, neuron_index, _timebins, _period_bins, _lastindex,
+                   t_in_timesteps, N}
+#}
+{% extends 'common_group.cu' %}
 {% block kernel_maincode %}
     // The period in multiples of dt
     const int32_t _the_period = {{_period_bins}};

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -1,7 +1,6 @@
-{% extends 'common_group.cu' %}
-{# USES_VARIABLES { N, count,
-                    _source_start, _source_stop} #}
+{# USES_VARIABLES { N, count, _source_start, _source_stop} #}
 {# WRITES_TO_READ_ONLY_VARIABLES { N, count } #}
+{% extends 'common_group.cu' %}
 {% block extra_device_helper %}
     {% for varname, var in record_variables.items() %}
     // declare monitor cudaVectors

--- a/brian2cuda/templates/statemonitor.cu
+++ b/brian2cuda/templates/statemonitor.cu
@@ -1,6 +1,6 @@
-{% extends 'common_group.cu' %}
 {# USES_VARIABLES { t, N } #}
 {# WRITES_TO_READ_ONLY_VARIABLES { t, N } #}
+{% extends 'common_group.cu' %}
 
 {% block define_N %}
 {% endblock %}

--- a/brian2cuda/templates/stateupdate.cu
+++ b/brian2cuda/templates/stateupdate.cu
@@ -1,3 +1,3 @@
-{% extends 'common_group.cu' %}
 {# USES_VARIABLES { N } #}
 {# ALLOWS_SCALAR_WRITE #}
+{% extends 'common_group.cu' %}

--- a/brian2cuda/templates/summed_variable.cu
+++ b/brian2cuda/templates/summed_variable.cu
@@ -1,3 +1,4 @@
+{# USES_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
 
 
@@ -21,7 +22,6 @@ CUDA_SAFE_CALL(
 
 
 {% block extra_vector_code %}
-{# USES_VARIABLES { N } #}
 {# For the vector_code, get the _ptr array #}
 {% set _target_var_ptr = get_array_name(_target_var) %}
 {% set _index_array = get_array_name(_index_var) %}

--- a/brian2cuda/templates/synapses.cu
+++ b/brian2cuda/templates/synapses.cu
@@ -1,3 +1,4 @@
+{# USES_VARIABLES { N, _synaptic_pre} #}
 {% extends 'common_synapses.cu' %}
 
 {% set _non_synaptic = [] %}
@@ -33,7 +34,6 @@ kernel_{{codeobj_name}}(
     %KERNEL_PARAMETERS%
     )
 {
-    {# USES_VARIABLES { N, _synaptic_pre} #}
     using namespace brian;
 
     assert(THREADS_PER_BLOCK == blockDim.x);

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -46,12 +46,11 @@ std::cout << std::endl;
 
 {% block host_maincode %}
 {# USES_VARIABLES { _synaptic_pre, _synaptic_post, sources, targets
-                N_incoming, N_outgoing, N,
-                N_pre, N_post, _source_offset, _target_offset } #}
+                    N_incoming, N_outgoing, N, N_pre, N_post, _source_offset,
+                    _target_offset } #}
 
-{# WRITES_TO_READ_ONLY_VARIABLES { _synaptic_pre, _synaptic_post,
-                                   N_incoming, N_outgoing, N}
-#}
+{# WRITES_TO_READ_ONLY_VARIABLES { _synaptic_pre, _synaptic_post, N_incoming,
+                                   N_outgoing, N} #}
 
 {# Get N_post and N_pre in the correct way, regardless of whether they are
 constants or scalar arrays#}

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -1,3 +1,10 @@
+{# TODO: get rid of the variables we don't actually use #}
+{# USES_VARIABLES { _synaptic_pre, _synaptic_post, rand,
+                    N_incoming, N_outgoing, N,
+                    N_pre, N_post, _source_offset, _target_offset } #}
+
+{# WRITES_TO_READ_ONLY_VARIABLES { _synaptic_pre, _synaptic_post,
+                                   N_incoming, N_outgoing, N} #}
 {% extends 'common_synapses.cu' %}
 
 {% block extra_headers %}
@@ -158,14 +165,6 @@ std::cout << std::endl;
 {% endblock %}
 
 {% block host_maincode %}
-    {# // TODO: get rid of the variables we don't actually use
-       USES_VARIABLES { _synaptic_pre, _synaptic_post, rand,
-                        N_incoming, N_outgoing, N,
-                        N_pre, N_post, _source_offset, _target_offset } #}
-
-    {# WRITES_TO_READ_ONLY_VARIABLES { _synaptic_pre, _synaptic_post,
-                                       N_incoming, N_outgoing, N}
-    #}
 
     ///// pointers_lines /////
     {{pointers_lines|autoindent}}

--- a/brian2cuda/templates/synapses_initialise_queue.cu
+++ b/brian2cuda/templates/synapses_initialise_queue.cu
@@ -28,8 +28,8 @@
  # sorted by their delay (if they have any).
  #}
 
-{% macro cu_file() %}
 {# USES_VARIABLES { delay, N, _n_sources, _n_targets, _source_dt } #}
+{% macro cu_file() %}
 #include <thrust/sort.h>
 #include <thrust/reduce.h>
 #include <thrust/unique.h>

--- a/brian2cuda/templates/threshold.cu
+++ b/brian2cuda/templates/threshold.cu
@@ -1,6 +1,6 @@
+{# USES_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
 
-{# USES_VARIABLES { N } #}
 {# not_refractory and lastspike are added as needed_variables in the
    Thresholder class, we cannot use the USES_VARIABLE mechanism
    conditionally


### PR DESCRIPTION
See https://github.com/brian-team/brian2/pull/1155

I tried to keep the template format similar to cpp_standalone. Just a few minor changes.

One could probably also let our `synaspes_push` tempalte extend `common_group`, but that needs a bit of restructuring. What we would get though is removing the duplicate occupancy calculation code. Didn't do that yet.