### PR TITLE
Fix uneven curand rng

### DIFF
--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -646,19 +646,21 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     if k == "randn":
                         num_calls = codeobj.rng_calls["randn"]
                         code = f'''
-                            // genenerate an array of random numbers on the device
+                            // Genenerate an array of random numbers on the device
+                            // Make sure we generate an even number of random numbers
+                            int32_t _randn_N = ({number_elements} % 2 == 0) ? {number_elements} : {number_elements} + 1;
                             {c_float_dtype}* dev_array_randn;
                             CUDA_SAFE_CALL(
                                 cudaMalloc(
                                     (void**)&dev_array_randn,
-                                    sizeof({c_float_dtype})*{number_elements}*{num_calls}
+                                    sizeof({c_float_dtype})*_randn_N*{num_calls}
                                 )
                             );
                             CUDA_SAFE_CALL(
                                 curandGenerateNormal{curand_suffix}(
                                     curand_generator,
                                     dev_array_randn,
-                                    {number_elements}*{num_calls},
+                                    _randn_N*{num_calls},
                                     0,  // mean
                                     1   // stddev
                                 )
@@ -672,19 +674,21 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     elif k == "rand":
                         num_calls = codeobj.rng_calls["rand"]
                         code = f'''
-                            // genenerate an array of random numbers on the device
+                            // Genenerate an array of random numbers on the device
+                            // Make sure we generate an even number of random numbers
+                            int32_t _rand_N = ({number_elements} % 2 == 0) ? {number_elements} : {number_elements} + 1;
                             {c_float_dtype}* dev_array_rand;
                             CUDA_SAFE_CALL(
                                 cudaMalloc(
                                     (void**)&dev_array_rand,
-                                    sizeof({c_float_dtype})*{number_elements}*{num_calls}
+                                    sizeof({c_float_dtype})*_rand_N*{num_calls}
                                 )
                             );
                             CUDA_SAFE_CALL(
                                 curandGenerateUniform{curand_suffix}(
                                     curand_generator,
                                     dev_array_rand,
-                                    {number_elements}*{num_calls}
+                                    _rand_N*{num_calls}
                                 )
                             );
                         '''
@@ -713,19 +717,21 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                             num_calls = codeobj.rng_calls[poisson_name]
                             lamda = codeobj.poisson_lamdas[poisson_name]
                             code = f'''
-                                // genenerate an array of random numbers on the device
+                                // Genenerate an array of random numbers on the device
+                                // Make sure we generate an even number of random numbers
+                                int32_t _{poisson_name}_N = ({number_elements} % 2 == 0) ? {number_elements} : {number_elements} + 1;
                                 {c_int_dtype}* dev_array_{poisson_name};
                                 CUDA_SAFE_CALL(
                                     cudaMalloc(
                                         (void**)&dev_array_{poisson_name},
-                                        sizeof(unsigned int)*{number_elements}*{num_calls}
+                                        sizeof(unsigned int)*_{poisson_name}_N*{num_calls}
                                     )
                                 );
                                 CUDA_SAFE_CALL(
                                     curandGeneratePoisson(
                                         curand_generator,
                                         dev_array_{poisson_name},
-                                        {number_elements}*{num_calls},
+                                        _{poisson_name}_N*{num_calls},
                                         {lamda}
                                     )
                                 );

--- a/brian2cuda/tests/test_random_number_generation.py
+++ b/brian2cuda/tests/test_random_number_generation.py
@@ -1221,6 +1221,20 @@ def test_poisson_variable_lambda_set_template_random_seed():
     assert np.var(G.v1[:] - G.v2[:]) > 0
 
 
+@pytest.mark.standalone_compatible
+def test_single_tick_rng_uneven_group_size():
+    # cuRAND host API fails when generating an uneven number random numbers, make sure
+    # we take care of that (just test for run not failing)
+    G = NeuronGroup(9, '''dv1/dt = rand() * randn() * poisson(l) / ms : 1
+                          dv2/dt = rand() * randn() * poisson(5) / ms : 1
+                          l  : 1''')
+
+    G.l = arange(9)
+    G.v1[:7] = 'rand() + randn() + poisson(l)'
+    G.v2[:7] = 'rand() + randn() + poisson(5)'
+    run(defaultclock.dt)
+
+
 if __name__ == '__main__':
     import brian2cuda
     from brian2cuda.tests.conftest import fake_randn
@@ -1265,6 +1279,7 @@ if __name__ == '__main__':
         test_poisson_values_init_synapses_fixed_and_random_seed,
         test_poisson_scalar_lambda_set_template_random_seed,
         test_poisson_variable_lambda_set_template_random_seed,
+        test_single_tick_rng_uneven_group_size,
     ]:
         print()
         print(test.__name__)


### PR DESCRIPTION
The curand host API can only generate an even number of random numbers. For codeobjects that run only once, we didn't round up the number to even, now we do.