### PR TITLE
Fix spikemonitor for subgroups

### DIFF
--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -360,8 +360,8 @@ void _write_arrays()
                 or var in dynamic_array_2d_specs
                 or var in static_array_specs
               ) %}
-    {# Don't copy StateMonitor's N variables, which are modified on host only #}
-    {% if not (var.owner.__class__.__name__ == 'StateMonitor' and var.name == 'N') %}
+    {# Don't copy State- & SpikeMonitor's N variables, which are modified on host only #}
+    {% if not (var.owner.__class__.__name__ in ['StateMonitor', 'SpikeMonitor'] and var.name == 'N') %}
     CUDA_SAFE_CALL(
             cudaMemcpy({{varname}}, dev{{varname}}, sizeof({{c_data_type(var.dtype)}})*_num_{{varname}}, cudaMemcpyDeviceToHost)
             );

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -73,7 +73,7 @@ CUDA_SAFE_CALL(
             )
         );
 
-{# TODO: Use isintance instead (needs to be made available in Jinja templates #}
+{# TODO: Use isintance instead (needs to be made available in Jinja templates) #}
 {% if owner.source.__class__.__name__ == 'Subgroup' %}
 // Count the elements in eventspace that are in the subgroup
 thrust::device_ptr<int32_t> _dev_eventspace(_eventspace);

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -43,7 +43,7 @@ int num_events, num_blocks;
 {% if record_variables %}
 // Initialize device vector for subgroup eventspace
 THRUST_CHECK_ERROR(
-    _dev_{{owner.source.name}}_subgroup_eventspace.resize(_num_source_idx)
+    _dev_{{owner.source.name}}_eventspace.resize(_num_source_idx)
 );
 {% endif %}{# not record_variables #}
 {% endif %}{# Subgroup #}
@@ -90,12 +90,12 @@ THRUST_CHECK_ERROR(
     thrust::copy_if(
         _dev_eventspace,
         _dev_eventspace + _num_events,
-        _dev_{{owner.source.name}}_subgroup_eventspace.begin(),
+        _dev_{{owner.source.name}}_eventspace.begin(),
         is_in_subgroup()
     )
 );
 // Use same kernel as without subgroups on copied subgroup eventspace
-_eventspace = thrust::raw_pointer_cast(&_dev_{{owner.source.name}}_subgroup_eventspace[0]);
+_eventspace = thrust::raw_pointer_cast(&_dev_{{owner.source.name}}_eventspace[0]);
 {% endif %}{# not record_variables #}
 {% else %}{# not is_subgroup #}
 // Get the number of events

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -165,13 +165,12 @@ _array_{{owner.name}}_N[0] += _N;
 
 
 {% block kernel_maincode %}
-{% set _eventspace = get_array_name(eventspace_variable) %}
 {# We pass as _eventspace the filtered eventspace, such that all neuron IDs are
    within the subgroup (if this is one). We take care of that with the
    thrust::copy_if above. #}
 
 // Eventspace is filled from left with all neuron IDs that triggered an event, rest -1
-int32_t spiking_neuron = {{_eventspace}}[_idx];
+int32_t spiking_neuron = _eventspace[_idx];
 assert(spiking_neuron != -1);
 
 int _monitor_idx = _vectorisation_idx + _monitor_size;

--- a/brian2cuda/tests/test_monitor.py
+++ b/brian2cuda/tests/test_monitor.py
@@ -1,6 +1,6 @@
 import pytest
 
-from numpy.testing import assert_equal
+from numpy.testing import assert_allclose, assert_equal
 from brian2 import *
 
 
@@ -39,7 +39,7 @@ def test_spike_monitor_subgroups_all_attr():
     assert_allclose(spikes_1.i, [0])
     assert_allclose(spikes_1.t, [0]*ms)
     assert_allclose(spikes_1.count, [1, 0])
-    assert_allclose(spikes_1.N, 2)
+    assert_allclose(spikes_1.N, 1)
 
     assert len(spikes_2.i) == 0
     assert len(spikes_2.t) == 0
@@ -48,8 +48,8 @@ def test_spike_monitor_subgroups_all_attr():
 
     assert_allclose(spikes_3.i, [0, 1])  # recorded spike indices are relative
     assert_allclose(spikes_3.t, [0, 0] * ms)
-    assert_allclose(spikes_1.count, [1, 1])
-    assert_allclose(spikes_1.N, 2)
+    assert_allclose(spikes_3.count, [1, 1])
+    assert_allclose(spikes_3.N, 2)
 
 if __name__ == '__main__':
     import brian2cuda

--- a/brian2cuda/tests/test_monitor.py
+++ b/brian2cuda/tests/test_monitor.py
@@ -20,6 +20,37 @@ def test_state_monitor_more_threads_than_single_block():
         assert_equal(mon.v[:, t], v_init)
 
 
+@pytest.mark.standalone_compatible
+def test_spike_monitor_subgroups_all_attr():
+    G = NeuronGroup(6, '''do_spike : boolean''', threshold='do_spike')
+    G.do_spike = [True, False, False, False, True, True]
+    spikes_all = SpikeMonitor(G)
+    spikes_1 = SpikeMonitor(G[:2])
+    spikes_2 = SpikeMonitor(G[2:4])
+    spikes_3 = SpikeMonitor(G[4:])
+
+    run(defaultclock.dt)
+
+    assert_allclose(spikes_all.i, [0, 4, 5])
+    assert_allclose(spikes_all.t, [0, 0, 0]*ms)
+    assert_allclose(spikes_all.count, [1, 0, 0, 0, 1, 1])
+    assert_allclose(spikes_all.N, 3)
+
+    assert_allclose(spikes_1.i, [0])
+    assert_allclose(spikes_1.t, [0]*ms)
+    assert_allclose(spikes_1.count, [1, 0])
+    assert_allclose(spikes_1.N, 2)
+
+    assert len(spikes_2.i) == 0
+    assert len(spikes_2.t) == 0
+    assert_allclose(spikes_2.count, [0, 0])
+    assert spikes_2.N == 0
+
+    assert_allclose(spikes_3.i, [0, 1])  # recorded spike indices are relative
+    assert_allclose(spikes_3.t, [0, 0] * ms)
+    assert_allclose(spikes_1.count, [1, 1])
+    assert_allclose(spikes_1.N, 2)
+
 if __name__ == '__main__':
     import brian2cuda
     set_device('cuda_standalone', directory=None)


### PR DESCRIPTION
Fixes #286 

This implementation is a quick solution that does the following when recording with `SpikeMonitor` from a `Subgroup`.
- In Brian2CUDA, each `NeuronGroup` has its own spikespace, which is filled with the neuron IDs of spiking neurons. In `cpp_standalone`, this spiekspace is sorted by neuron IDs. In Brian2CUDA, it is not, which is why we can't just read a consecutive subsection of the spikespace, where all neuron IDs belong to one `Subgroup`.
- Instead, this implementation calls `thruds::count_if` to get the number of spiking neurons in the `Subgroup` and then calls `thrust::copy_if` to copy those IDs into another array (spikespace for subgroup).
- This means we can use the same spikemonitor kernel for `NeuronGroup` and `Subgroup` recordings, but passing a different spikepace pointer.

This implementation is surely not the most performant, but was instead easy to implement.  I added #293 with suggestions for a better implementation.