### PR TITLE
Fix `StateMonitr` illegal access

### DIFF
--- a/brian2cuda/templates/common_group.cu
+++ b/brian2cuda/templates/common_group.cu
@@ -120,10 +120,8 @@ _run_kernel_{{codeobj_name}}(
     int tid = threadIdx.x;
     int bid = blockIdx.x;
 
-    {% block indices %}
     int _idx = bid * THREADS_PER_BLOCK + tid;
     int _vectorisation_idx = _idx;
-    {% endblock %}
 
     ///// KERNEL_CONSTANTS /////
     %KERNEL_CONSTANTS%
@@ -140,6 +138,9 @@ _run_kernel_{{codeobj_name}}(
     {
         return;
     }
+
+    {% block after_return_N %}
+    {% endblock %}
 
     {% block kernel_maincode %}
 

--- a/brian2cuda/templates/statemonitor.cu
+++ b/brian2cuda/templates/statemonitor.cu
@@ -71,9 +71,9 @@ if (_num__array_{{owner.name}}__indices > 0)
 {% endblock %}
 
 
-{% block indices %}
-    int _vectorisation_idx = bid * THREADS_PER_BLOCK + tid;
-    int _idx = {{_indices}}[_vectorisation_idx];
+{# Need to set _idx here, after threads >= N returend, else this fails #}
+{% block after_return_N %}
+    _idx = {{_indices}}[_vectorisation_idx];
 {% endblock %}
 
 

--- a/brian2cuda/tests/test_neurongroup.py
+++ b/brian2cuda/tests/test_neurongroup.py
@@ -1,0 +1,49 @@
+import os
+import numpy as np
+import pytest
+from numpy.testing import assert_equal
+
+from brian2.core.clocks import defaultclock
+from brian2.core.magic import run
+from brian2.groups.neurongroup import NeuronGroup
+from brian2.tests import make_argv
+from brian2.tests.utils import assert_allclose
+from brian2.utils.logger import catch_logs
+
+# Adapted from brian2/tests/test_neurongroup.py::test_semantics_floor_division
+# (brian2 test asserts for 0 warnings, brian2cuda warns for int to float64 conversion)
+@pytest.mark.standalone_compatible
+def test_semantics_floor_division():
+    # See github issues #815 and #661
+    G = NeuronGroup(11, '''a : integer
+                           b : integer
+                           x : 1
+                           y : 1
+                           fvalue : 1
+                           ivalue : integer''',
+                    dtype={'a': np.int32, 'b': np.int64,
+                           'x': np.float, 'y': np.double})
+    int_values = np.arange(-5, 6)
+    float_values = np.arange(-5.0, 6.0, dtype=np.double)
+    G.ivalue = int_values
+    G.fvalue = float_values
+    with catch_logs() as l:
+        G.run_regularly('''
+        a = ivalue//3
+        b = ivalue//3
+        x = fvalue//3
+        y = fvalue//3
+        ''')
+        run(defaultclock.dt)
+    # XXX: brian2 test adapted here for 1 warning
+    assert len(l) == 1
+    assert_equal(G.a[:], int_values // 3)
+    assert_equal(G.b[:], int_values // 3)
+    assert_allclose(G.x[:], float_values // 3)
+    assert_allclose(G.y[:], float_values // 3)
+
+
+if __name__ == '__main__':
+    import brian2
+    brian2.set_device('cuda_standalone')
+    test_semantics_floor_division()

--- a/brian2cuda/tools/test_suite/run_test_suite.py
+++ b/brian2cuda/tools/test_suite/run_test_suite.py
@@ -10,8 +10,8 @@ parser = argparse.ArgumentParser(description='Run the brian2 testsuite on GPU.')
 parser.add_argument('--no-long-tests', action='store_false',
                     help="Set to not run long tests. By default they are run.")
 
-parser.add_argument('--skip-not-implemented', action='store_true',
-                    help="Weather to reset prefs between tests or not.")
+parser.add_argument('--fail-not-implemented', action='store_true',
+                    help="Fail tests that raise a `NotImplementedError`.")
 
 parser.add_argument('--test-parallel', nargs='?', const=None, default=[],
                     help="Weather to use multiple cores for testing. Optionally the "
@@ -185,7 +185,7 @@ for target in args.targets:
                        test_codegen_independent=False,
                        test_standalone=target,
                        reset_preferences=False,
-                       fail_for_not_implemented=not args.skip_not_implemented,
+                       fail_for_not_implemented=args.fail_not_implemented,
                        test_in_parallel=test_in_parallel,
                        extra_test_dirs=extra_test_dirs,
                        float_dtype=None,


### PR DESCRIPTION
Fix bug where reading `StateMonitor` indices failed because threads had not returned yet and performed illegal memory accesses.

EDIT: Looks like I also added two commits here that ignore a Brian2 test in the test suite (which fails because of a Brian2CUDA warning which is caught in the test). I added a Brian2CUDA compatible test to the test suite.