### PR TITLE
Copy variables modified on device correctly to host

### DIFF
--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -330,6 +330,16 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                                                owner=owner))
                 if idx == '_syaptic_post':
                     self.delete_synaptic_post[synaptic_post_array_name] = False
+
+        if template_name in ['group_variable_set_conditional', 'group_variable_set']:
+            read, write = self.get_array_read_write(abstract_code, variables)
+            written_variables = {}
+            for variable_name in write:
+                var = variables[variable_name]
+                varname = self.get_array_name(var, access_data=False)
+                written_variables[var] = varname
+            template_kwds['written_variables'] = written_variables
+
         if template_name == "synapses":
             prepost = template_kwds['pathway'].prepost
             synaptic_effects = "synapse"

--- a/brian2cuda/templates/group_variable_set.cu
+++ b/brian2cuda/templates/group_variable_set.cu
@@ -20,6 +20,28 @@
     ///// endblock kernel_maincode /////
 {% endblock %}
 
+{% block extra_kernel_call_post %}
+    {# We need to copy modifed variables back to host in case they are used in
+       codeobjects that run on the host, which are synapse connect calls (e.g. in the
+       connect condition) and before run synapses push spikes, which initialized
+       synaptic variables.
+    #}
+    {% for var, varname in written_variables.items() %}
+    {% if var.dynamic %}
+    {{varname}} = dev{{varname}};
+    {% else %}
+    CUDA_SAFE_CALL(
+        cudaMemcpy(
+            {{varname}},
+            dev{{varname}},
+            sizeof({{c_data_type(var.dtype)}})*_num_{{varname}},
+            cudaMemcpyDeviceToHost
+        )
+    );
+    {% endif %}
+    {% endfor %}
+{% endblock %}
+
 {# _num_group_idx is defined in HOST_CONSTANTS, so we can't set _N before #}
 {% block define_N %}
 {% endblock %}

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -26,13 +26,19 @@
 
 
 {% block extra_kernel_call_post %}
-    {% for var in variables.values() %}
     {# We want to copy only those variables that were potentially modified in aboves kernel call. #}
-    {% if var is not callable and var.array and not var.constant and not var.dynamic %}
-    {% set varname = get_array_name(var, access_data=False) %}
+    {% for var, varname in written_variables.items() %}
+    {% if var.dynamic %}
+    {{varname}} = dev{{varname}};
+    {% else %}
     CUDA_SAFE_CALL(
-            cudaMemcpy({{varname}}, dev{{varname}}, sizeof({{c_data_type(var.dtype)}})*_num_{{varname}}, cudaMemcpyDeviceToHost)
-            );
+        cudaMemcpy(
+            {{varname}},
+            dev{{varname}},
+            sizeof({{c_data_type(var.dtype)}})*_num_{{varname}},
+            cudaMemcpyDeviceToHost
+        )
+    );
     {% endif %}
     {% endfor %}
 {% endblock %}

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -26,7 +26,11 @@
 
 
 {% block extra_kernel_call_post %}
-    {# We want to copy only those variables that were potentially modified in aboves kernel call. #}
+    {# We need to copy modifed variables back to host in case they are used in
+       codeobjects that run on the host, which are synapse connect calls (e.g. in the
+       connect condition) and before run synapses push spikes, which initialized
+       synaptic variables.
+    #}
     {% for var, varname in written_variables.items() %}
     {% if var.dynamic %}
     {{varname}} = dev{{varname}};

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -184,12 +184,6 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
     // number of neurons in target group
     int target_N = {{constant_or_scalar('_n_targets', variables['_n_targets'])}};
 
-    // TODO: for multiple SynapticPathways for the same Synapses object (on_pre and on_post) the following copy is identical in both pathways initialise templates
-    {% if not no_or_const_delay_mode %}
-    // delay (on device) was potentially set in group_variable_set_conditional and needs to be copied to host
-    {{_dynamic_delay}} = dev{{_dynamic_delay}};
-    {% endif %}
-
     //////////////////////
     // Scalar variables //
     //////////////////////


### PR DESCRIPTION
When setting variables via `group_variables_set` or `group_variable_set_conditional` templates, these are only modified on the device. But sometimes we also need them on the host, which is the case when codeobjects running on the host require them (e.g. synapses connect calls with condition or synapse variables in before run synapses push spikes).

This PR makes sure all variables modified in `group_variable_set(_conditional)` are always copied back to host.