### PR TITLE
Get test suite to pass

### DIFF
--- a/brian2cuda/cuda_prefs.py
+++ b/brian2cuda/cuda_prefs.py
@@ -23,11 +23,11 @@ def validate_bundle_size_expression(string):
         return False
 
     # Replase names from C++ std with numpy version for eval test below
-    replaced = formatted.replace("ceil", "np.ceil")
-    replaced = formatted.replace("floor", "np.floor")
+    formatted = formatted.replace("ceil", "np.ceil")
+    formatted = formatted.replace("floor", "np.floor")
 
     try:
-        eval(replaced)
+        eval(formatted)
     except Exception:
         logger.error(f"Can't evaluate expression '{string}'")
         return False
@@ -114,7 +114,7 @@ prefs.register_preferences(
         lower ``int`` (e.g. ``1.9`` will be cast to ``1.0``). Examples: ``'{mean} + 2 *
         {std}'`` will use the mean bunde size + 2 times the standard deviation over
         bundle sizes and round it to the next lower integer. If you want to round up
-        instead, use ``'ceil({mean} + 2 * {std}'``.''',
+        instead, use ``'ceil({mean} + 2 * {std})'``.''',
         default="{max}",
         validator=validate_bundle_size_expression),
 

--- a/brian2cuda/tests/test_cuda_generator.py
+++ b/brian2cuda/tests/test_cuda_generator.py
@@ -223,6 +223,7 @@ def test_default_function_convertion_warnings():
 @pytest.mark.parametrize('code', permutation_analysis_good_examples)
 @pytest.mark.cuda_standalone
 @pytest.mark.standalone_only
+@pytest.mark.long
 def test_atomics_parallelisation(code):
     should_be_able_to_use_ufunc_at = not 'NOT_UFUNC_AT_VECTORISABLE' in code
     if should_be_able_to_use_ufunc_at:

--- a/brian2cuda/tests/test_cuda_generator.py
+++ b/brian2cuda/tests/test_cuda_generator.py
@@ -285,7 +285,7 @@ def test_atomics_parallelisation(code):
                     fullvar = var+G.name
                     val = G.state(var)[:].copy()
                     if fullvar in endvals:
-                        assert_allclose(val, endvals[fullvar], rtol=1e-5)
+                        assert_allclose(val, endvals[fullvar])
                     else:
                         endvals[fullvar] = val
             device.reinit()

--- a/brian2cuda/tests/test_network_multiple_runs.py
+++ b/brian2cuda/tests/test_network_multiple_runs.py
@@ -26,8 +26,11 @@ def test_multiple_runs_with_scalar_delay():
     assert_equal(mon.v[:], [[0, 0, 1, 2]])
 
 
-# XXX: Known issue, see Brian2CUDA issue #302
-@pytest.mark.xfail
+@pytest.mark.xfail(
+    reason='See Brian2CUDA issue #302',
+    condition="config.device == 'cuda_standalone'",
+    raises=AssertionError
+)
 @pytest.mark.standalone_compatible
 @pytest.mark.multiple_runs
 def test_increasing_delay_scalar():
@@ -53,8 +56,11 @@ def test_increasing_delay_scalar():
     assert_allclose(mon.v[:], [[0, 0, 1, 1, 2, 3]])
 
 
-# XXX: Known issue, see Brian2CUDA issue #302
-@pytest.mark.xfail
+@pytest.mark.xfail(
+    reason='See Brian2CUDA issue #302',
+    condition="config.device == 'cuda_standalone'",
+    raises=AssertionError
+)
 @pytest.mark.standalone_compatible
 @pytest.mark.multiple_runs
 def test_decreasing_delay_scalar():
@@ -147,8 +153,11 @@ def test_reducing_delay_heterogeneous():
     assert_allclose(mon.v[1, :], [0, 0, 0, 2, 3, 4])
 
 
-# XXX: Known issue, see Brian2CUDA issue #136
-@pytest.mark.xfail
+@pytest.mark.xfail(
+    reason='See Brian2CUDA issue #136',
+    condition="config.device == 'cuda_standalone'",
+    raises=AssertionError
+)
 @pytest.mark.standalone_compatible
 @pytest.mark.multiple_runs
 def test_changed_dt_spikes_in_queue_heterogenenous_delay():

--- a/brian2cuda/tests/test_stringtools.py
+++ b/brian2cuda/tests/test_stringtools.py
@@ -83,6 +83,10 @@ def test_replace_floating_point_literals():
     eq_(code_replaced, solution)
 
 
+@pytest.mark.xfail(
+    reason='See Brian2CUDA issue #254',
+    raises=AssertionError
+)
 @pytest.mark.standalone_only
 @pytest.mark.cuda_standalone
 def test_regex_bug():

--- a/brian2cuda/tests/test_synaptic_propagations.py
+++ b/brian2cuda/tests/test_synaptic_propagations.py
@@ -223,6 +223,11 @@ def test_circular_eventspaces_spikegenerator():
     assert_allclose(sorted(mon.t[mon.i[:] == 4]), arange(5, n_timesteps + 5) * default_dt)
 
 
+@pytest.mark.xfail(
+    reason='See Brian2CUDA issue #222',
+    condition="config.device == 'cuda_standalone'",
+    raises=AssertionError
+)
 @pytest.mark.standalone_compatible
 def test_circular_eventspaces_different_clock_spikegenerator():
     # same test as test_circular_eventspaces_spikegenerator() but with a
@@ -261,6 +266,11 @@ def test_circular_eventspaces_different_clock_spikegenerator():
     assert_allclose(sorted(mon.t[mon.i[:] == 4]), arange(9, n_timesteps + 9, clock_multiplier) * default_dt)
 
 
+@pytest.mark.xfail(
+    reason='See Brian2CUDA issue #222',
+    condition="config.device == 'cuda_standalone'",
+    raises=AssertionError
+)
 @pytest.mark.standalone_compatible
 def test_circular_eventspaces_different_clock_neurongroup():
     # same test as test_circular_eventspaces_different_clock_spikegenerator() but with a

--- a/brian2cuda/tests/test_synaptic_propagations.py
+++ b/brian2cuda/tests/test_synaptic_propagations.py
@@ -330,21 +330,20 @@ def test_synaptic_effect_modes():
     assert_allclose(mon.v[:], 0)
 
 
-@pytest.mark.cuda_standalone
-@pytest.mark.standalone_only
-def test_threads_per_synapse_bundle_prefs():
-
-    expressions = [
+@pytest.mark.parametrize(
+    'expression',
+    [
         'ceil({mean} + 2*{std})',
         '{max}',
         '{min}',
         '5',
     ]
-    for expression in expressions:
+)
+@pytest.mark.cuda_standalone
+@pytest.mark.standalone_only
+def test_threads_per_synapse_bundle_prefs(expression):
 
-        set_device('cuda_standalone', build_on_run=False, with_output=False)
-        Synapses.__instances__().clear()
-        reinit_devices()
+        set_device('cuda_standalone', directory=None, with_output=False)
 
         prefs.devices.cuda_standalone.threads_per_synapse_bundle = expression
 
@@ -359,7 +358,6 @@ def test_threads_per_synapse_bundle_prefs():
         mon = SpikeMonitor(G)
 
         run(6*default_dt)
-        device.build(directory=None, with_output=False)
 
         # neurons should spike in the timestep after effect application
         assert_allclose(mon.t[mon.i[:] == 3], 4*default_dt)

--- a/docs_sphinx/introduction/known_issues.rst
+++ b/docs_sphinx/introduction/known_issues.rst
@@ -16,7 +16,6 @@ Known issues when using multiple ``run`` calls
 
 Changing the integration time step of ``Synapses`` with delays between ``run`` calls
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 Changing the integration time step of `Synapses` objects with transmission
 delays between successive ``run`` calls currently leads to the loss of spikes.
 This is the case for spikes that are queued for effect application but haven't
@@ -28,7 +27,6 @@ been applied yet when the first ``run`` call terminates. See `Brian2CUDA issue
 
 Changing delays between ``run`` calls
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 Changing the delay of ``Synapses`` objects between ``run`` calls currently
 leads to the loss of spikes. This is the case when changing homogenenous delays
 or when switching between homogeneous and heterogeneous delays (e.g.
@@ -43,13 +41,12 @@ See `Brian2CUDA issue #302`_ for progress on this issue.
 
 Using a different integration time for ``Synapses`` and its source ``NeuronGroup``
 ----------------------------------------------------------------------------------
-
 There is currently a bug when using ``Synapses`` with homogeneous delays and
 choosing a different integration time step (``dt``) for any of its
 ``SynapticPathway`` and its associated source ``NeuronGroup``. This bug does
 not occur when the delays are heterogenenous or when only the target
-``NeuronGroup`` has a different clock. See `Brian2CUDA issue #222`_. Any of the
-following examples has this bug::
+``NeuronGroup`` has a different clock. See `Brian2CUDA issue #222`_ for
+progress on the issue. Any of the following examples has this bug::
 
     from brian2 import *
 
@@ -103,3 +100,19 @@ by time but not always by index given a fixed time point. See `Brian2CUDA issue
 #46`_ for progress on this issue.
 
 .. _Brian2CUDA issue #46: https://github.com/brian-team/brian2cuda/issues/46
+
+
+Single precision mode fails when using variable names with double digit and dot or scientific notations in name
+---------------------------------------------------------------------------------------------------------------
+In single precision mode (set via ``prefs.core.default_float_dtype``),
+Brian2CUDA replaces floating point literals like ``.2``, ``1.`` or ``.4`` in generated code with
+single precision versions ``1.2f``, ``1.f`` and ``.4f``. Under some
+circumstances, the search/replace algorithm fails and performs a wrong string
+replacement. This is the case e.g. for variable name with double digit and a
+dot in their name, such as ``variable12.attribute`` or when variable names have
+a substring that can be interpreted as a scientific number, e.g.
+`variable28e2`, which has `28e2` as substring. If such a wrong replacement
+occurs, compilation typically fails due to not declared variables. See
+`Brian2CUDA issue #254`_ for progress on the issue.
+
+.. _Brian2CUDA issue #254: https://github.com/brian-team/brian2cuda/issues/254


### PR DESCRIPTION
This PR fixes some remaining minor issues that led to some test fails and marks tests failing for known issues as `xfail`, such that the test suite doesn't fail (since these tests fail expectedly).

I just ran the test suite via
```python
import brian2cuda
brian2cuda.test(long_tests=True)
```
And for the first time, I got
```
Running Brian2CUDA version 0.post0.dev1157 from /cognition/home/denis/projects/brian2cuda/brian2cuda_repository/brian2cuda
Resetting to default preferences
Running tests in /cognition/home/denis/projects/brian2cuda/brian2cuda_repository/frozen_repos/brian2/brian2, /cognition/home/denis/projects/brian2cuda/brian2cuda_repository/brian2cuda/tests  (including long tests)
Running Brian version 2.4.2 from '/cognition/home/denis/projects/brian2cuda/brian2cuda_repository/frozen_repos/brian2/brian2'
Testing standalone

Testing standalone device "cuda_standalone"
Running standalone-compatible standard tests (single run statement)
============================= test session starts ==============================
...
= 236 passed, 1 skipped, 603 deselected, 2 xfailed, 5150 warnings in 3803.24s (1:03:23) =

Running standalone-compatible standard tests (multiple run statements)
============================= test session starts ==============================
...
=== 39 passed, 800 deselected, 3 xfailed, 330 warnings in 684.94s (0:11:24) ====

Running standalone-specific tests
============================= test session starts ==============================
...
== 89 passed, 752 deselected, 1 xfailed, 1311 warnings in 2087.32s (0:34:47) ===

OK: 3/3 test suite(s) did complete successfully.
OK: Test suit(s) for 1/1 standalone targets did complete successfully
```

🥳🥳🥳