### PR TITLE
Update logging and reporting

### DIFF
--- a/brian2cuda/brianlib/cudaVector.h
+++ b/brian2cuda/brianlib/cudaVector.h
@@ -3,6 +3,7 @@
 
 #include <cstdio>
 #include <assert.h>
+#include "cuda_utils.h"
 
 /*
  * current memory allocation strategy:
@@ -35,7 +36,8 @@ public:
             }
             else
             {
-                printf("ERROR while creating cudaVector with size %ld in cudaVector.h (constructor)\n", sizeof(scalar)*INITIAL_SIZE);
+                LOG_CUDA_ERROR("While creating cudaVector with size %ld in cudaVector.h"
+                               "(constructor)\n", sizeof(scalar)*INITIAL_SIZE);
                 assert(m_data != NULL);
             }
         }
@@ -56,7 +58,8 @@ public:
         if (index < 0 || index >= m_size)
         {
             // TODO: check for proper exception throwing in cuda kernels
-            printf("ERROR returning a reference to index %d in cudaVector::at() (size = %u)\n", index, m_size);
+            LOG_CUDA_ERROR("Returning a reference to index %d in cudaVector::at()"
+                           "(size = %u)\n", index, m_size);
             assert(index < m_size);
         }
         return m_data[index];
@@ -85,7 +88,7 @@ public:
         }
         else
         {
-            printf("ERROR invalid index %d, must be in range 0 - %d\n", pos, m_size);
+            LOG_CUDA_ERROR("Invalid index %d, must be in range 0 - %d\n", pos, m_size);
             assert(pos <= m_size);
         }
     };
@@ -134,7 +137,8 @@ public:
             }
             else
             {
-                printf("ERROR while allocating %ld bytes in cudaVector.h/reserve()\n", sizeof(scalar)*new_capacity);
+                LOG_CUDA_ERROR("While allocating %ld bytes in cudaVector.h/reserve()\n",
+                               sizeof(scalar)*new_capacity);
                 assert(new_data != NULL);
             }
         }

--- a/brian2cuda/brianlib/curand_buffer.h
+++ b/brian2cuda/brianlib/curand_buffer.h
@@ -39,9 +39,9 @@ private:
     {
         if (current_idx != buffer_size && memory_allocated)
         {
-            printf("WARNING: CurandBuffer::generate_numbers() called before "
-                    "buffer was empty (current_idx = %u, buffer_size = %u)",
-                    current_idx, buffer_size);
+            LOG_WARNING("CurandBuffer::generate_numbers() called before "
+                        "buffer was empty (current_idx = %u, buffer_size = %u)",
+                        current_idx, buffer_size);
         }
         // TODO: should we allocate the memory in the constructor (even if we end up not using it)?
         if (!memory_allocated)
@@ -50,16 +50,16 @@ private:
             host_data = new randomNumber_t[buffer_size];
             if (!host_data)
             {
-                printf("ERROR allocating host_data for CurandBuffer (size %ld)\n", sizeof(randomNumber_t)*buffer_size);
+                LOG_ERROR("Allocating host_data for CurandBuffer (size %ld)\n", sizeof(randomNumber_t)*buffer_size);
                 exit(EXIT_FAILURE);
             }
             // allocate device memory
             cudaError_t status = cudaMalloc((void **)&dev_data, buffer_size*sizeof(randomNumber_t));
             if (status != cudaSuccess)
             {
-                printf("ERROR allocating memory on device (size = %ld) in %s(%d):\n\t%s\n",
-                        buffer_size*sizeof(randomNumber_t), __FILE__, __LINE__,
-                        cudaGetErrorString(status));
+                LOG_ERROR("Allocating memory on device (size = %ld) in %s(%d):\n\t\t\t%s\n",
+                          buffer_size*sizeof(randomNumber_t), __FILE__, __LINE__,
+                          cudaGetErrorString(status));
                 exit(EXIT_FAILURE);
             }
             memory_allocated = true;
@@ -70,7 +70,7 @@ private:
             curandStatus_t status = generateUniform(*generator, dev_data, buffer_size);
             if (status != CURAND_STATUS_SUCCESS)
             {
-                printf("ERROR generating random numbers in %s(%d):\n", __FILE__, __LINE__);
+                LOG_ERROR("Generating random numbers in %s(%d):\n", __FILE__, __LINE__);
                 exit(EXIT_FAILURE);
             }
         }
@@ -79,8 +79,8 @@ private:
             curandStatus_t status = generateNormal(*generator, dev_data, buffer_size, 0, 1);
             if (status != CURAND_STATUS_SUCCESS)
             {
-                printf("ERROR generating normal distributed random numbers in %s(%d):\n",
-                        __FILE__, __LINE__);
+                LOG_ERROR("Generating normal distributed random numbers in %s(%d):\n",
+                          __FILE__, __LINE__);
                 exit(EXIT_FAILURE);
             }
         }
@@ -88,9 +88,9 @@ private:
         cudaError_t status = cudaMemcpy(host_data, dev_data, buffer_size*sizeof(randomNumber_t), cudaMemcpyDeviceToHost);
         if (status != cudaSuccess)
         {
-            printf("ERROR copying device to host memory (size = %ld) in %s(%d):\n\t%s\n",
-                    buffer_size*sizeof(randomNumber_t), __FILE__, __LINE__,
-                    cudaGetErrorString(status));
+            LOG_ERROR("Copying device to host memory (size = %ld) in %s(%d):\n\t\t\t%s\n",
+                      buffer_size*sizeof(randomNumber_t), __FILE__, __LINE__,
+                      cudaGetErrorString(status));
             exit(EXIT_FAILURE);
         }
         // reset buffer index
@@ -99,14 +99,14 @@ private:
 
     curandStatus_t generateUniform(curandGenerator_t generator, randomNumber_t *outputPtr, size_t num)
     {
-        printf("ERROR curand can only generate random numbers as 'float' or 'double' types.\n");
+        LOG_ERROR("%s", "Curand can only generate random numbers as 'float' or 'double' types.\n");
         exit(EXIT_FAILURE);
     }
 
     curandStatus_t generateNormal(curandGenerator_t generator, randomNumber_t *outputPtr,
             size_t n, randomNumber_t mean, randomNumber_t stddev)
     {
-        printf("ERROR curand can only generate random numbers as 'float' or 'double' types.\n");
+        LOG_ERROR("%s", "Curand can only generate random numbers as 'float' or 'double' types.\n");
         exit(EXIT_FAILURE);
     }
 
@@ -140,7 +140,7 @@ public:
         cudaError_t status = cudaFree(dev_data);
         if (status != cudaSuccess)
         {
-            printf("ERROR freeing device memory in %s(%d):%s\n",
+            LOG_ERROR("Freeing device memory in %s(%d):%s\n",
                     __FILE__, __LINE__, cudaGetErrorString(status));
             exit(EXIT_FAILURE);
         }

--- a/brian2cuda/brianlib/spikequeue.h
+++ b/brian2cuda/brianlib/spikequeue.h
@@ -118,9 +118,9 @@ public:
                 synapses_queue = new cuda_vector*[required_num_queues];
                 if (!synapses_queue)
                 {
-                    printf("ERROR while allocating memory with size %ld in"
-                           " spikequeue.h/prepare()\n",
-                           sizeof(cuda_vector*) * required_num_queues);
+                    LOG_CUDA_ERROR("While allocating memory with size %ld in"
+                                   " spikequeue.h/prepare()\n",
+                                   sizeof(cuda_vector*) * required_num_queues);
                 }
                 // only reset queue offset if we require new queues, in which
                 // case we copy the old queues such that the offset is reset
@@ -191,9 +191,9 @@ public:
                     synapses_queue[i] = new cuda_vector[num_blocks];
                     if (!synapses_queue[i])
                     {
-                        printf("ERROR while allocating memory with size %ld in"
-                                " spikequeue.h/prepare()\n",
-                                sizeof(cuda_vector)*num_blocks);
+                        LOG_CUDA_ERROR("While allocating memory with size %ld in"
+                                       " spikequeue.h/prepare()\n",
+                                       sizeof(cuda_vector)*num_blocks);
                     }
                 }
             }

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -1731,31 +1731,21 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
             self.insert_code("before_start", SETUP_TIMER.format(fname=self.timers_file))
             self.insert_code("before_start", TIME_DIFF.format(name="before_start"))
             self.insert_code(
-                "before_start",
-                r'LOG_INFO("%s", "Initializing standalone simulation...\n");'
-            )
-            self.insert_code(
                 "before_network_run", TIME_DIFF.format(name="before_network_run")
             )
             self.insert_code(
-                "before_network_run",
-                r'LOG_INFO("%s", "Starting simulation loop...\n");'
-            )
-            self.insert_code(
                 "after_network_run", TIME_DIFF.format(name="after_network_run")
-            )
-            self.insert_code(
-                "before_network_run",
-                r'LOG_INFO("%s", "Finalizing standalone simulation...\n");'
             )
             self.insert_code("after_end", TIME_DIFF.format(name="after_end"))
             self.insert_code("after_end", CLOSE_TIMER)
 
         run_lines.extend(self.code_lines['before_network_run'])
+        run_lines.append(r'LOG_INFO("%s", "Starting simulation loop...\n");')
         # run everything that is run on a clock
         run_lines.append(
             f'{net.name}.run({float(duration)!r}, {report_call}, {float(report_period)!r});'
         )
+        run_lines.append(r'LOG_INFO("%s", "Finalizing standalone simulation...\n");')
         run_lines.extend(self.code_lines['after_network_run'])
         # for multiple runs, the random number buffer needs to be reset
         run_lines.append('random_number_buffer.run_finished();')

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -1174,14 +1174,14 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
 
         # Log compiled GPU architecture
         if self.compute_capability is None:
-            logger.info(
+            logger.debug(
                 f"Compiling device code with manually set architecture flags "
                 f"({gpu_arch_flags}). Be aware that the minimal supported compute "
                 f"capability is {self.minimal_compute_capability} "
                 "(we are not checking your compile flags)"
             )
         else:
-            logger.info(
+            logger.debug(
                 f"Compiling device code for compute capability "
                 f"{self.compute_capability} (compiler flags: {gpu_arch_flags})"
             )
@@ -1469,10 +1469,10 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
         for net in self.networks:
             net.after_run()
 
-        logger.info("Using the following preferences for CUDA standalone:")
+        logger.debug("Using the following preferences for CUDA standalone:")
         for pref_name in prefs:
             if "devices.cuda_standalone" in pref_name:
-                logger.info(f"\t{pref_name} = {prefs[pref_name]}")
+                logger.debug(f"\t{pref_name} = {prefs[pref_name]}")
 
         logger.debug("Using the following brian preferences:")
         for pref_name in prefs:

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -80,10 +80,6 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
         self.include_dirs.remove('brianlib/randomkit')
         self.library_dirs.remove('brianlib/randomkit')
 
-        # Add code line slots used in our benchmarks
-        # TODO: Add to brian2 and remove here
-        self.code_lines.update({'before_network_run': [],
-                                'after_network_run': []})
         ### Attributes specific to CUDAStandaloneDevice:
         # only true during first run call (relevant for synaptic pre/post ID deletion)
         self.first_run = True

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -1208,6 +1208,9 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 # NDEBUG precompiler macro disables asserts (both for C++ and CUDA)
                 nvcc_compiler_flags += ['-NDEBUG']
 
+            # Set brian2cuda standalone log leven based ot Brian2 log level
+            nvcc_compiler_flags += [f'-DLOG_LEVEL_{prefs["logging.console_log_level"].upper()}']
+
             makefile_tmp = self.code_object_class().templater.makefile(
                 None, None,
                 source_files=' '.join(sorted(writer.source_files)),

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -1480,8 +1480,10 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 logger.debug(f"\t{pref_name} = {prefs[pref_name]}")
 
         if compile:
+            logger.info("Compiling CUDA standalone project...")
             self.compile_source(directory, cpp_compiler, debug, clean)
             if run:
+                logger.info("Running CUDA standalone simulation...")
                 self.run(directory, with_output, run_args)
 
     def network_run(self, net, duration, report=None, report_period=10*second,

--- a/brian2cuda/templates/common_group.cu
+++ b/brian2cuda/templates/common_group.cu
@@ -79,19 +79,19 @@ namespace {
     // functions works. Hacky, hacky ...
     randomNumber_t _host_rand(const int _vectorisation_idx)
     {
-        printf("ERROR: Called dummy function `_host_rand` in %s:%d\n", __FILE__,
+        LOG_ERROR("Called dummy function `_host_rand` in %s:%d\n", __FILE__,
                 __LINE__);
         exit(EXIT_FAILURE);
     }
     randomNumber_t _host_randn(const int _vectorisation_idx)
     {
-        printf("ERROR: Called dummy function `_host_rand` in %s:%d\n", __FILE__,
+        LOG_ERROR("Called dummy function `_host_rand` in %s:%d\n", __FILE__,
                 __LINE__);
         exit(EXIT_FAILURE);
     }
     int32_t _host_poisson(double _lambda, const int _vectorisation_idx)
     {
-        printf("ERROR: Called dummy function `_host_poisson` in %s:%d\n", __FILE__,
+        LOG_ERROR("Called dummy function `_host_poisson` in %s:%d\n", __FILE__,
                 __LINE__);
         exit(EXIT_FAILURE);
     }
@@ -246,17 +246,17 @@ void _run_{{codeobj_name}}()
         {
             // use the max num_threads before launch failure
             num_threads = funcAttrib.maxThreadsPerBlock;
-            printf("WARNING Not enough ressources available to call "
-                   "_run_kernel_{{codeobj_name}} "
-                   "with maximum possible threads per block (%u). "
-                   "Reducing num_threads to %u. (Kernel needs %i "
-                   "registers per block, %i bytes of "
-                   "statically-allocated shared memory per block, %i "
-                   "bytes of local memory per thread and a total of %i "
-                   "bytes of user-allocated constant memory)\n",
-                   max_threads_per_block, num_threads, funcAttrib.numRegs,
-                   funcAttrib.sharedSizeBytes, funcAttrib.localSizeBytes,
-                   funcAttrib.constSizeBytes);
+            LOG_WARNING("Not enough ressources available to call "
+                        "_run_kernel_{{codeobj_name}} "
+                        "with maximum possible threads per block (%u). "
+                        "Reducing num_threads to %u. (Kernel needs %i "
+                        "registers per block, %i bytes of "
+                        "statically-allocated shared memory per block, %i "
+                        "bytes of local memory per thread and a total of %i "
+                        "bytes of user-allocated constant memory)\n",
+                        max_threads_per_block, num_threads, funcAttrib.numRegs,
+                        funcAttrib.sharedSizeBytes, funcAttrib.localSizeBytes,
+                        funcAttrib.constSizeBytes);
 
             {% block update_occupancy %}
             // calculate theoretical occupancy for new num_threads
@@ -276,26 +276,26 @@ void _run_{{codeobj_name}}()
         {% block kernel_info %}
         else
         {
-            printf("INFO _run_kernel_{{codeobj_name}}\n"
-                   {% block kernel_info_num_blocks_str %}
-                   "\t%u blocks\n"
-                   {% endblock %}
-                   "\t%u threads\n"
-                   "\t%i registers per thread\n"
-                   "\t%i bytes statically-allocated shared memory per block\n"
-                   "\t%i bytes local memory per thread\n"
-                   "\t%i bytes user-allocated constant memory\n"
-                   {% if calc_occupancy %}
-                   "\t%.3f theoretical occupancy\n",
-                   {% else %}
-                   "",
-                   {% endif %}
-                   {% block kernel_info_num_blocks_var %}
-                   num_blocks,
-                   {% endblock %}
-                   num_threads, funcAttrib.numRegs,
-                   funcAttrib.sharedSizeBytes, funcAttrib.localSizeBytes,
-                   funcAttrib.constSizeBytes{% if calc_occupancy %}, occupancy{% endif %});
+            LOG_DEBUG("_run_kernel_{{codeobj_name}}\n"
+                      {% block kernel_info_num_blocks_str %}
+                      "\t\t\t%u blocks\n"
+                      {% endblock %}
+                      "\t\t\t%u threads\n"
+                      "\t\t\t%i registers per thread\n"
+                      "\t\t\t%i bytes statically-allocated shared memory per block\n"
+                      "\t\t\t%i bytes local memory per thread\n"
+                      "\t\t\t%i bytes user-allocated constant memory\n"
+                      {% if calc_occupancy %}
+                      "\t\t\t%.3f theoretical occupancy\n",
+                      {% else %}
+                      "",
+                      {% endif %}
+                      {% block kernel_info_num_blocks_var %}
+                      num_blocks,
+                      {% endblock %}
+                      num_threads, funcAttrib.numRegs,
+                      funcAttrib.sharedSizeBytes, funcAttrib.localSizeBytes,
+                      funcAttrib.constSizeBytes{% if calc_occupancy %}, occupancy{% endif %});
         }
         {% endblock %}
         first_run = false;

--- a/brian2cuda/templates/main.cu
+++ b/brian2cuda/templates/main.cu
@@ -27,6 +27,7 @@
 
 int main(int argc, char **argv)
 {
+    LOG_INFO("%s", "Initializing standalone simulation...\n");
     {{'\n'.join(code_lines['before_start'])|autoindent}}
 
     // seed variable set in Python through brian2.seed() calls can use this

--- a/brian2cuda/templates/main.cu
+++ b/brian2cuda/templates/main.cu
@@ -33,8 +33,6 @@ int main(int argc, char **argv)
     // variable (see device.py CUDAStandaloneDevice.generate_main_source())
     unsigned long long seed;
 
-    //const std::clock_t _start_time = std::clock();
-
     CUDA_SAFE_CALL(
             cudaSetDevice({{gpu_id}})
             );
@@ -51,9 +49,6 @@ int main(int argc, char **argv)
             cudaDeviceSynchronize()
             );
 
-    //const double _run_time2 = (double)(std::clock() -_start_time)/CLOCKS_PER_SEC;
-    //printf("INFO: setting cudaDevice stuff took %f seconds\n", _run_time2);
-
     brian_start();
 
     {{'\n'.join(code_lines['after_start'])|autoindent}}
@@ -65,16 +60,9 @@ int main(int argc, char **argv)
         {{main_lines|autoindent}}
     }
 
-    //const double _run_time3 = (double)(std::clock() -_start_time3)/CLOCKS_PER_SEC;
-    //printf("INFO: main_lines took %f seconds\n", _run_time3);
-
     {{'\n'.join(code_lines['before_end'])|autoindent}}
     brian_end();
     {{'\n'.join(code_lines['after_end'])|autoindent}}
-
-    // Profiling
-    //const double _run_time = (double)(std::clock() -_start_time)/CLOCKS_PER_SEC;
-    //printf("INFO: main function took %f seconds\n", _run_time);
 
     return 0;
 }

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -326,13 +326,15 @@ void _init_arrays()
     {% endfor %}
 
     CUDA_CHECK_MEMORY();
+#ifdef DEF_LOG_DEBUG
     const double to_MB = 1.0 / (1024.0 * 1024.0);
     double tot_memory_MB = (used_device_memory - used_device_memory_start) * to_MB;
     double time_passed = (double)(std::clock() - start_timer) / CLOCKS_PER_SEC;
-    std::cout << "INFO: _init_arrays() took " <<  time_passed << "s";
+    std::cout << "CUDA DEBUG: _init_arrays() took " <<  time_passed << "s";
     if (tot_memory_MB > 0)
         std::cout << " and used " << tot_memory_MB << "MB of device memory.";
     std::cout << std::endl;
+#endif
 }
 
 void _load_arrays()
@@ -351,7 +353,7 @@ void _load_arrays()
         {% endif %}
     } else
     {
-        std::cout << "Error opening static array {{name}}." << endl;
+        LOG_ERROR("%s", "Error opening static array {{name}}.\n");
     }
     {% if not (name in dynamic_array_specs.values()) %}
     CUDA_SAFE_CALL(
@@ -389,7 +391,7 @@ void _write_arrays()
         outfile_{{varname}}.close();
     } else
     {
-        std::cout << "Error writing output file for {{varname}}." << endl;
+        LOG_ERROR("%s", "Error writing output file for {{varname}}.\n");
     }
     {% endif %}
     {% endfor %}
@@ -406,7 +408,7 @@ void _write_arrays()
         outfile_{{varname}}.close();
     } else
     {
-        std::cout << "Error writing output file for {{varname}}." << endl;
+        LOG_ERROR("%s", "Error writing output file for {{varname}}.\n");
     }
     {% endfor %}
 
@@ -443,7 +445,7 @@ void _write_arrays()
             outfile_{{varname}}.close();
         } else
         {
-            std::cout << "Error writing output file for {{varname}}." << endl;
+            LOG_ERROR("%s", "Error writing output file for {{varname}}.\n");
         }
     {% endfor %}
 
@@ -471,7 +473,7 @@ void _write_arrays()
     outfile_profiling_info.close();
     } else
     {
-        std::cout << "Error writing profiling info to file." << std::endl;
+        LOG_ERROR("%s", "Error writing profiling info to file.\n");
     }
     {% endif %}
     // Write last run info to disk
@@ -483,7 +485,7 @@ void _write_arrays()
         outfile_last_run_info.close();
     } else
     {
-        std::cout << "Error writing last run info to file." << std::endl;
+        LOG_ERROR("%s", "Error writing last run info to file.\n");
     }
 }
 

--- a/brian2cuda/templates/rand.cu
+++ b/brian2cuda/templates/rand.cu
@@ -116,16 +116,16 @@ void RandomNumberBuffer::init()
             num_per_gen_{{type}}_{{co.name}} = num_per_gen_{{type}}_{{co.name}} + 1;
         }
 
-        // make sure that we don't use more memory then available
+        // make sure that we don't use more memory than available
         // this checks per codeobject the number of generated floats against total available floats
         while (num_free_floats < num_per_gen_{{type}}_{{co.name}})
         {
-            printf("INFO not enough memory available to generate %i random numbers for {{co.name}}, reducing the buffer size\n", num_free_floats);
+            LOG_DEBUG("Not enough memory available to generate %i random numbers for {{co.name}}, reducing the buffer size\n", num_free_floats);
             if (num_per_gen_{{type}}_{{co.name}} < num_per_cycle_{{type}}_{{co.name}})
             {
                 if (num_free_floats < num_per_cycle_{{type}}_{{co.name}})
                 {
-                    printf("ERROR not enough memory to generate random numbers for {{co.name}} %s:%d\n", __FILE__, __LINE__);
+                    LOG_ERROR("Not enough memory to generate random numbers for {{co.name}} %s:%d\n", __FILE__, __LINE__);
                     _dealloc_arrays();
                     exit(1);
                 }
@@ -137,7 +137,7 @@ void RandomNumberBuffer::init()
             }
             num_per_gen_{{type}}_{{co.name}} /= 2;
         }
-        printf("INFO generating %i {{type}} every %i clock cycles for {{co.name}}\n", num_per_gen_{{type}}_{{co.name}}, {{type}}_interval_{{co.name}});
+        LOG_DEBUG("Generating %i {{type}} every %i clock cycles for {{co.name}}\n", num_per_gen_{{type}}_{{co.name}}, {{type}}_interval_{{co.name}});
 
         {% if type in ['rand', 'randn'] %}
         {% set dtype = "randomNumber_t" %}
@@ -162,9 +162,9 @@ void RandomNumberBuffer::init()
         {
             // TODO: find a way to deal with this? E.g. looping over buffers sorted
             // by buffer size and reducing them until it fits.
-            printf("MEMORY ERROR: Trying to generate more random numbers than fit "
-                   "into available memory. Please report this as an issue on "
-                   "GitHub: https://github.com/brian-team/brian2cuda/issues/new");
+            LOG_ERROR("%s", "MEMORY ERROR: Trying to generate more random numbers than fit "
+                      "into available memory. Please report this as an issue on "
+                      "GitHub: https://github.com/brian-team/brian2cuda/issues/new");
             _dealloc_arrays();
             exit(1);
         }
@@ -384,7 +384,6 @@ void RandomNumberBuffer::refill_poisson_numbers(
 {
     // generate poisson distributed random numbers and reset buffer index
 
-    printf("num_per_gen_poisson %d, lambda %f\n", num_per_gen_poisson, lambda);
     CUDA_SAFE_CALL(
             curandGeneratePoisson(curand_generator, dev_poisson_allocator, num_per_gen_poisson, lambda)
             );

--- a/brian2cuda/templates/spatialstateupdate.cu
+++ b/brian2cuda/templates/spatialstateupdate.cu
@@ -510,14 +510,14 @@ __global__ void _currents_kernel_{{codeobj_name}}(
             float occupancy_currents = (max_active_blocks_currents * num_threads_currents / num_threads_per_warp) /
                               (float)(max_threads_per_sm / num_threads_per_warp);
 
-            printf("INFO _currents\n_kernel_{{codeobj_name}}"
-                       "\t%u blocks\n"
-                       "\t%u threads\n"
-                       "\t%i registers per thread\n"
-                       "\t%i bytes statically-allocated shared memory per block\n"
-                       "\t%i bytes local memory per thread\n"
-                       "\t%i bytes user-allocated constant memory\n"
-                       "\t%.3f theoretical occupancy\n",
+            LOG_DEBUG("_currents\n_kernel_{{codeobj_name}}"
+                       "\t\t\t%u blocks\n"
+                       "\t\t\t%u threads\n"
+                       "\t\t\t%i registers per thread\n"
+                       "\t\t\t%i bytes statically-allocated shared memory per block\n"
+                       "\t\t\t%i bytes local memory per thread\n"
+                       "\t\t\t%i bytes user-allocated constant memory\n"
+                       "\t\t\t%.3f theoretical occupancy\n",
                        num_blocks_currents, num_threads_currents, funcAttrib_currents.numRegs,
                        funcAttrib_currents.sharedSizeBytes, funcAttrib_currents.localSizeBytes,
                        funcAttrib_currents.constSizeBytes, occupancy_currents);

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -204,7 +204,7 @@ void _debugmsg_{{codeobj_name}}()
     // HOST_CONSTANTS
     %HOST_CONSTANTS%
 
-    printf("Number of spikes: %d\n", _array_{{owner.name}}_N[0]);
+    LOG_DEBUG("Number of spikes: %d\n", _array_{{owner.name}}_N[0]);
 }
 {% endblock %}
 

--- a/brian2cuda/templates/synapses.cu
+++ b/brian2cuda/templates/synapses.cu
@@ -211,7 +211,7 @@ num_threads = max_threads_per_block;
 {% if bundle_mode %}
 //num_threads_per_bundle = {{pathway.name}}_bundle_size_max;
 num_threads_per_bundle = getThreadsPerBundle();
-printf("INFO _run_kernel_{{codeobj_name}}: Using %d threads per bundle\n", num_threads_per_bundle);
+LOG_DEBUG("_run_kernel_{{codeobj_name}}: Using %d threads per bundle\n", num_threads_per_bundle);
 {% endif %}
 num_loops = 1;
 
@@ -231,12 +231,12 @@ if (!{{owner.name}}_multiple_pre_post){
     {% endif %}
 }
 else {
-    printf("WARNING: Detected multiple synapses for same (pre, post) neuron "
-           "pair in Synapses object ``{{owner.name}}`` and no atomic operations are used. "
-           "Falling back to serialised effect application for SynapticPathway "
-           "``{{pathway.name}}``. This will be slow. You can avoid serialisation "
-           "by separating this Synapses object into multiple Synapses objects "
-           "with at most one connection between the same (pre, post) neuron pair.\n");
+    LOG_WARNING("%s", "Detected multiple synapses for same (pre, post) neuron "
+                "pair in Synapses object ``{{owner.name}}`` and no atomic operations are used. "
+                "Falling back to serialised effect application for SynapticPathway "
+                "``{{pathway.name}}``. This will be slow. You can avoid serialisation "
+                "by separating this Synapses object into multiple Synapses objects "
+                "with at most one connection between the same (pre, post) neuron pair.\n");
 }
 if (num_threads > max_threads_per_block)
     num_threads = max_threads_per_block;
@@ -255,7 +255,7 @@ num_threads_per_bundle = 1;
 num_loops = num_parallel_blocks;
 
 {% else %}
-printf("ERROR: got unknown 'synaptic_effects' mode ({{synaptic_effects}})\n");
+LOG_ERROR("%s", "Got unknown 'synaptic_effects' mode ({{synaptic_effects}})\n");
 _dealloc_arrays();
 exit(1);
 {% endif %}
@@ -265,7 +265,7 @@ exit(1);
 {% block extra_info_msg %}
 else if ({{pathway.name}}_max_size <= 0)
 {
-    printf("INFO there are no synapses in the {{pathway.name}} pathway. Skipping synapses_push and synapses kernels.\n");
+    LOG_DEBUG("%s", "There are no synapses in the {{pathway.name}} pathway. Skipping synapses_push and synapses kernels.\n");
 }
 {% endblock %}
 
@@ -325,7 +325,7 @@ if ({{pathway.name}}_max_size > 0)
 void _debugmsg_{{codeobj_name}}()
 {
     using namespace brian;
-    std::cout << "Number of synapses: " << {{constant_or_scalar('N', variables['N'])}} << endl;
+    LOG_DEBUG("Number of synapses: %d\n", {{constant_or_scalar('N', variables['N'])}});
 }
 {% endblock %}
 

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -35,13 +35,15 @@ size_t used_device_memory_start = used_device_memory;
 
 {% block profiling_stop %}
 CUDA_CHECK_MEMORY();
+#ifdef DEF_LOG_DEBUG
 const double to_MB = 1.0 / (1024.0 * 1024.0);
 double tot_memory_MB = (used_device_memory - used_device_memory_start) * to_MB;
 double time_passed = (double)(std::clock() - start_timer) / CLOCKS_PER_SEC;
-std::cout << "INFO: {{owner.name}} creation took " <<  time_passed << "s";
+std::cout << "CUDA DEBUG: {{owner.name}} creation took " <<  time_passed << "s";
 if (tot_memory_MB > 0)
     std::cout << " and used " << tot_memory_MB << "MB of device memory.";
 std::cout << std::endl;
+#endif
 {% endblock %}
 
 {% block host_maincode %}
@@ -112,7 +114,6 @@ for (int _i=0; _i<newsize; _i++)
     {{dynamic_multisynaptic_idx}}[_i] = source_target_count[source_target];
     {% endif %}
     source_target_count[source_target]++;
-    //printf("source target count = %i\n", source_target_count[source_target]);
     if (source_target_count[source_target] > 1)
     {
         {{owner.name}}_multiple_pre_post = true;

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -152,13 +152,15 @@ size_t used_device_memory_start = used_device_memory;
 
 {% block profiling_stop %}
 CUDA_CHECK_MEMORY();
+#ifdef DEF_LOG_DEBUG
 const double to_MB = 1.0 / (1024.0 * 1024.0);
 double tot_memory_MB = (used_device_memory - used_device_memory_start) * to_MB;
 double time_passed = (double)(std::clock() - start_timer) / CLOCKS_PER_SEC;
-std::cout << "INFO: {{owner.name}} creation took " <<  time_passed << "s";
+std::cout << "CUDA DEBUG: {{owner.name}} creation took " <<  time_passed << "s";
 if (tot_memory_MB > 0)
     std::cout << " and used " << tot_memory_MB << "MB of memory.";
 std::cout << std::endl;
+#endif
 {% endblock %}
 
 {% block host_maincode %}
@@ -260,8 +262,8 @@ std::cout << std::endl;
             {% if skip_if_invalid %}
             _uiter_size = _n_total;
             {% else %}
-            cout << "Error: Requested sample size " << _uiter_size << " is bigger than the " <<
-                    "population size " << _n_total << "." << endl;
+            LOG_ERROR("Error: Requested sample size %ld is bigger than the population "
+                      "size %d.\n", _uiter_size, _n_total);
             exit(1);
             {% endif %}
         } else if (_uiter_size < 0)
@@ -269,7 +271,7 @@ std::cout << std::endl;
             {% if skip_if_invalid %}
             continue;
             {% else %}
-            cout << "Error: Requested sample size " << _uiter_size << " is negative." << endl;
+            LOG_ERROR("Error: Requested sample size %ld is negative.\n", _uiter_size);
             exit(1);
             {% endif %}
         } else if (_uiter_size == 0)
@@ -352,8 +354,9 @@ std::cout << std::endl;
                     {% if skip_if_invalid %}
                     continue;
                     {% else %}
-                    cout << "Error: tried to create synapse to neuron {{result_index}}=" << _{{result_index}} << " outside range 0 to " <<
-                                            _{{result_index_size}}-1 << endl;
+                    LOG_ERROR("Error: tried to create synapse to neuron "
+                              "{{result_index}}=%ld outside range 0 to %d\n",
+                              _{{result_index}}, _{{result_index_size}}-1);
                     exit(1);
                     {% endif %}
                 }
@@ -376,8 +379,9 @@ std::cout << std::endl;
                 {% if skip_if_invalid %}
                 continue;
                 {% else %}
-                cout << "Error: tried to create synapse to neuron {{result_index}}=" << _{{result_index}} <<
-                        " outside range 0 to " << _{{result_index_size}}-1 << endl;
+                LOG_ERROR("Error: tried to create synapse to neuron "
+                          "{{result_index}}=%ld outside range 0 to %d\n",
+                          _{{result_index}}, _{{result_index_size}}-1);
                 exit(1);
                 {% endif %}
             }
@@ -438,7 +442,6 @@ std::cout << std::endl;
         {{dynamic_multisynaptic_idx}}[_i] = source_target_count[source_target];
         {% endif %}
         source_target_count[source_target]++;
-        //printf("source target count = %i\n", source_target_count[source_target]);
         if (source_target_count[source_target] > 1)
         {
             {{owner.name}}_multiple_pre_post = true;

--- a/brian2cuda/tests/features/cuda_configuration.py
+++ b/brian2cuda/tests/features/cuda_configuration.py
@@ -164,7 +164,7 @@ class BenchmarkConfiguration(Configuration):
         with open(python_benchmark_path, "w") as file:
             # Timer for `brian.run()` call recorded in `TimedSpeedTest.timed_run()`
             file.write(f"run_brian {self.feature_test.runtime}\n")
-            # Timers for compilcation and binary execution recorded in
+            # Timers for compilation and binary execution recorded in
             # `device.compile_source()` and `device.run()`
             for key, value in device.timers.items():
                 if isinstance(value, float):

--- a/brian2cuda/utils/gputools.py
+++ b/brian2cuda/utils/gputools.py
@@ -178,7 +178,7 @@ def _get_cuda_path():
     # Use preference if set
     cuda_path_pref = prefs.devices.cuda_standalone.cuda_backend.cuda_path
     if cuda_path_pref is not None:
-        logger.info(
+        logger.debug(
             f"CUDA installation directory given via preference "
             f"`prefs.devices.cuda_standalone.cuda_backend.cuda_path={cuda_path_pref}`"
         )
@@ -189,7 +189,7 @@ def _get_cuda_path():
     # Use environment variable if set
     cuda_path = os.environ.get("CUDA_PATH", "")  # Nvidia default on Windows
     if os.path.exists(cuda_path):
-        logger.info(
+        logger.debug(
             "CUDA installation directory given via environment variable `CUDA_PATH={}`"
             "".format(cuda_path)
         )
@@ -199,7 +199,7 @@ def _get_cuda_path():
     nvcc_path = shutil.which("nvcc")
     if nvcc_path is not None:
         cuda_path_nvcc = os.path.dirname(os.path.dirname(nvcc_path))
-        logger.info(
+        logger.debug(
             "CUDA installation directory detected via location of `nvcc` binary: {}"
             "".format(cuda_path_nvcc)
         )
@@ -208,7 +208,7 @@ def _get_cuda_path():
     # Use standard location /usr/local/cuda
     if os.path.exists("/usr/local/cuda"):
         cuda_path_usr = "/usr/local/cuda"
-        logger.info(
+        logger.debug(
             f"CUDA installation directory found in standard location: {cuda_path_usr}"
         )
         return (cuda_path_usr, 'default')
@@ -216,7 +216,7 @@ def _get_cuda_path():
     # Use standard location /opt/cuda
     if os.path.exists("/opt/cuda"):
         cuda_path_opt = "/opt/cuda"
-        logger.info(
+        logger.debug(
             f"CUDA installation directory found in standard location: {cuda_path_opt}"
         )
         return (cuda_path_opt, 'default')
@@ -317,7 +317,7 @@ def _select_gpu():
             compute_capability = get_compute_capability(gpu_id)
         gpu_list = get_available_gpus()
     else:
-        logger.info(
+        logger.debug(
             "Automatic detection of GPU names and compute capabilities disabled, using "
             "manual preferences"
         )
@@ -336,7 +336,7 @@ def _select_gpu():
     if gpu_list is not None:
         gpu_name = f" ({gpu_list[gpu_id]})"
 
-    logger.info(
+    logger.debug(
         f"Compiling device code for GPU {gpu_id}{gpu_name}"
     )
 
@@ -485,7 +485,7 @@ def _get_compute_capability_with_device_query(gpu_id):
                 f"Brian2CUDA documentations for more details."
             )
     else:
-        logger.info(
+        logger.debug(
             "Path to `deviceQuery` binary set via "
             "`prefs.devices.cuda_standalone.cuda_backend.device_query_path = "
             f"{device_query_path}`"


### PR DESCRIPTION
This PR
1. Removes most of the INFO prints during `cuda_standalone` simulations. They are now debug prints.
2. Adds a simple logging system for the generated code, with the same log levels as the brian logger. All the information that was printed before is now also debug information and only shown when the brian log level is set to debug. The generated code does not print to the log file (even though this could easily be implemented).
3. Implements a `ComputationTimeSummary` class, which is very similar to the `ProfilingSummary` class, but reporting the times for compilation, initialization, simulation loop and finalization. In the current implementation, this information is printed via `set_device('cuda_standalone', report_timers=True)`. This implementation belongs into brian2 though, but I want it in the brian2cuda release I'm preparing this week, hence it will be in brian2cuda for now.

TODO after:
[ ] Give user access to the macro settings in `cuda_utils.h` for debugging
[ ] Decide on what is printed out by default (I want by default some information to be shown so users understand what is going on, but also a preference to disable all information)
[ ] Write standalone logs into the Brian2 log file based on the brian2 file log level.
[ ] Make Brian2 PR for `ComputationTimeSummary`