### PR TITLE
Remove check for occurrences of multiple pre-post synapses

### DIFF
--- a/brian2cuda/templates/synapses.cu
+++ b/brian2cuda/templates/synapses.cu
@@ -216,6 +216,8 @@ printf("INFO _run_kernel_{{codeobj_name}}: Using %d threads per bundle\n", num_t
 num_loops = 1;
 
 {% elif synaptic_effects == "target" %}{# not uses_atomics #}
+LOG_ERROR("Internal error, check this line with git blame in brian2cuda source code: %s(%d)\n", __FILE__, __LINE__);
+exit(1);
 // Synaptic effects modify target group variables but NO source group variables.
 num_blocks = num_parallel_blocks;
 num_loops = 1;

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -99,6 +99,13 @@ CUDA_CHECK_MEMORY();
 // update the total number of synapses
 {{N}} = newsize;
 
+{# We don't care about ocurrences of multiple source-target pairs if we have
+   not multisynaptic indices in the model and are using atomics in
+   synapses.cu. Unfortunately, we don't know here if we are using atomics
+   in synapses.cu. Need to find a way to expose that boolean here via
+   CudaGenerator, where it is set. But for now, we assume, synapses.cu uses
+   atomics (else there an error is raised there) #}
+{% if multisynaptic_index %}
 // Check for occurrence of multiple source-target pairs in synapses ("synapse number")
 std::map<std::pair<int32_t, int32_t>, int32_t> source_target_count;
 for (int _i=0; _i<newsize; _i++)
@@ -121,7 +128,8 @@ for (int _i=0; _i<newsize; _i++)
         {% endif %}
     }
 }
-// Check
+{% endif %}
+
 // copy changed host data to device
 dev{{_dynamic_N_incoming}} = {{_dynamic_N_incoming}};
 dev{{_dynamic_N_outgoing}} = {{_dynamic_N_outgoing}};

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -425,6 +425,13 @@ std::cout << std::endl;
     // Also update the total number of synapses
     {{N}} = newsize;
 
+    {# We don't care about ocurrences of multiple source-target pairs if we have
+       not multisynaptic indices in the model and are using atomics in
+       synapses.cu. Unfortunately, we don't know here if we are using atomics
+       in synapses.cu. Need to find a way to expose that boolean here via
+       CudaGenerator, where it is set. But for now, we assume, synapses.cu uses
+       atomics (else there an error is raised there) #}
+    {% if multisynaptic_index %}
     // Check for occurrence of multiple source-target pairs in synapses ("synapse number")
     std::map<std::pair<int32_t, int32_t>, int32_t> source_target_count;
     for (int _i=0; _i<newsize; _i++)
@@ -447,6 +454,7 @@ std::cout << std::endl;
             {% endif %}
         }
     }
+    {% endif %}
 
     // copy changed host data to device
     dev{{_dynamic_N_incoming}} = {{_dynamic_N_incoming}};


### PR DESCRIPTION
This check is only required when one of the `SynapticPathway` objects of the `Synapses` object does not use atomics and has synaptic effect mode `target`. Since we use atomics by default now, I removed the check. If we ever want to be able to not use atomics, we need to reactivate the multi occurrence check here accordingly (see comments in code of this commit).

This partially closes #88 (not sure about the random number generation though, so I'm keeping that open).