### PR TITLE
Update for Brian 2.7

### DIFF
--- a/brian2cuda/tests/test_neurongroup.py
+++ b/brian2cuda/tests/test_neurongroup.py
@@ -1,48 +1,9 @@
-import numpy as np
 import pytest
-from numpy.testing import assert_equal
 
-from brian2.core.clocks import defaultclock
 from brian2.core.magic import run
 from brian2.groups.neurongroup import NeuronGroup
 from brian2.synapses import Synapses
-from brian2.tests.utils import assert_allclose
-from brian2.utils.logger import catch_logs
 from brian2.units import second
-
-# Adapted from brian2/tests/test_neurongroup.py::test_semantics_floor_division
-# (brian2 test asserts for 0 warnings, brian2cuda warns for int to float64 conversion)
-# Can be removed with the next version that includes brian-team/brian2#1519
-@pytest.mark.standalone_compatible
-def test_semantics_floor_division():
-    # See Brian2 github issues #815 and #661
-    G = NeuronGroup(11, '''a : integer
-                           b : integer
-                           x : 1
-                           y : 1
-                           fvalue : 1
-                           ivalue : integer''',
-                    dtype={'a': np.int32, 'b': np.int64,
-                           'x': np.float32, 'y': np.float64})
-    int_values = np.arange(-5, 6)
-    float_values = np.arange(-5.0, 6.0, dtype=np.float64)
-    G.ivalue = int_values
-    G.fvalue = float_values
-    with catch_logs() as l:
-        G.run_regularly('''
-        a = ivalue//3
-        b = ivalue//3
-        x = fvalue//3
-        y = fvalue//3
-        ''')
-        run(defaultclock.dt)
-    # XXX: brian2 test adapted here for 1 warning
-    assert len(l) == 1
-    assert_equal(G.a[:], int_values // 3)
-    assert_equal(G.b[:], int_values // 3)
-    assert_allclose(G.x[:], float_values // 3)
-    assert_allclose(G.y[:], float_values // 3)
-
 
 @pytest.mark.standalone_compatible
 def test_group_variable_set_copy_to_host():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,11 @@ name = "Brian2Cuda"
 authors = [
     {name = 'Denis Alevi'},
     {name = 'Moritz Augustin'},
-    {name ='Marcel Stimberg'}
+    {name = 'Marcel Stimberg'}
 ]
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 dependencies = [
-    'brian2==2.6.0',
+    'brian2==2.7.0',
 ]
 dynamic = ["version", "readme"]
 description = 'A Brian2 extension to simulate spiking neural networks on GPUs'
@@ -52,4 +52,3 @@ requires = [
     "setuptools_scm[toml]>=6.2"
 ]
 build-backend = "setuptools.build_meta"
-


### PR DESCRIPTION
Updates the Brian dependency to version 2.7 – nothing affecting Brian2CUDA happened in this release, except that we no longer have to overwrite `test_semantics_floor_division`, since brian-team/brian2#1519 fixed the `catch_logs` context manager.

The main reason for the Brian 2.7 release is its numpy 2.0 compatibility. It would be nice to have a Brian2CUDA release alongside it.