### PR TITLE
Issue 179 compilation speedup

### DIFF
--- a/brian2cuda/binomial.py
+++ b/brian2cuda/binomial.py
@@ -8,13 +8,6 @@ from brian2.utils.stringtools import replace
 from brian2.input.binomial import (BinomialFunction, _pre_calc_constants,
                                    _pre_calc_constants_approximated)
 from brian2 import prefs
-#ths can be removed when brian2 is updated to forward compiler_kwds from target generators
-_CUDA_BINOMIAL_COMPILER_KWDS = {
-    "headers": [
-        '"rand.h"',
-        "<curand_kernel.h>",
-    ],
-}
 
 
 def _generate_cuda_code(n, p, use_normal, name):
@@ -105,19 +98,11 @@ def _generate_cuda_code(n, p, use_normal, name):
                                         '%SUFFIX%': float_suffix})
         dependencies = {'_rand': DEFAULT_FUNCTIONS['rand']}
 
-    return {'support_code': cuda_code}, dependencies
+    return (
+        {'support_code': cuda_code},
+        dependencies,
+        {"headers": ['"rand.h"', "<curand_kernel.h>"]},
+    )
 
 
 BinomialFunction.implementations['cuda'] = _generate_cuda_code
-
-_original_binomial_init = BinomialFunction.__init__
-
-
-def _binomial_init_with_cuda_headers(self, n, p, approximate=True, name="_binomial*"):
-    _original_binomial_init(self, n, p, approximate=approximate, name=name)
-    cuda_impl = self.implementations._implementations.get("cuda")
-    if cuda_impl is not None:
-        cuda_impl.compiler_kwds = dict(_CUDA_BINOMIAL_COMPILER_KWDS)
-
-
-BinomialFunction.__init__ = _binomial_init_with_cuda_headers

--- a/brian2cuda/binomial.py
+++ b/brian2cuda/binomial.py
@@ -4,11 +4,17 @@ CUDA implementation of `BinomialFunction`
 import numpy as np
 
 from brian2.core.functions import DEFAULT_FUNCTIONS
-from brian2.units.fundamentalunits import check_units
 from brian2.utils.stringtools import replace
 from brian2.input.binomial import (BinomialFunction, _pre_calc_constants,
                                    _pre_calc_constants_approximated)
 from brian2 import prefs
+#ths can be removed when brian2 is updated to forward compiler_kwds from target generators
+_CUDA_BINOMIAL_COMPILER_KWDS = {
+    "headers": [
+        '"rand.h"',
+        "<curand_kernel.h>",
+    ],
+}
 
 
 def _generate_cuda_code(n, p, use_normal, name):
@@ -103,3 +109,15 @@ def _generate_cuda_code(n, p, use_normal, name):
 
 
 BinomialFunction.implementations['cuda'] = _generate_cuda_code
+
+_original_binomial_init = BinomialFunction.__init__
+
+
+def _binomial_init_with_cuda_headers(self, n, p, approximate=True, name="_binomial*"):
+    _original_binomial_init(self, n, p, approximate=approximate, name=name)
+    cuda_impl = self.implementations._implementations.get("cuda")
+    if cuda_impl is not None:
+        cuda_impl.compiler_kwds = dict(_CUDA_BINOMIAL_COMPILER_KWDS)
+
+
+BinomialFunction.__init__ = _binomial_init_with_cuda_headers

--- a/brian2cuda/brianlib/clocks.h
+++ b/brian2cuda/brianlib/clocks.h
@@ -1,7 +1,6 @@
 #ifndef _BRIAN_CLOCKS_H
 #define _BRIAN_CLOCKS_H
 #include<stdlib.h>
-#include<iostream>
 #include<algorithm>
 #include<brianlib/stdint_compat.h>
 #include<math.h>

--- a/brian2cuda/brianlib/cuda_utils.h
+++ b/brian2cuda/brianlib/cuda_utils.h
@@ -1,9 +1,11 @@
 #ifndef BRIAN2CUDA_ERROR_CHECK_H
 #define BRIAN2CUDA_ERROR_CHECK_H
 #include <stdio.h>
-#include <thrust/system_error.h>
-#include "objects.h"
-#include "curand.h"
+#include <cuda_runtime.h>
+
+namespace brian{
+  extern size_t used_device_memory;
+}
 
 // Define this to turn on error checking
 #define BRIAN2CUDA_ERROR_CHECK
@@ -23,9 +25,9 @@
 #define THRUST_CHECK_ERROR(code)  { try {code;} \
     catch(...) {_thrustCheckError(__FILE__, __LINE__, #code);} }
 
-
+#ifdef BRIAN2CUDA_CURAND_HOST
+#include <curand.h>
 // adapted from NVIDIA cuda samples, shipped with cuda 10.1 (common/inc/helper_cuda.h)
-#ifdef CURAND_H_
 // cuRAND API errors
 static const char *_curandGetErrorEnum(curandStatus_t error) {
   switch (error) {
@@ -71,7 +73,21 @@ static const char *_curandGetErrorEnum(curandStatus_t error) {
 
   return "<unknown>";
 }
+
+inline void _cudaSafeCall(curandStatus_t err, const char *file, const int line, const char *call = "")
+{
+#ifdef BRIAN2CUDA_ERROR_CHECK
+    if (CURAND_STATUS_SUCCESS != err)
+    {
+        fprintf(stderr, "ERROR: %s failed at %s:%i : %s\n",
+                call, file, line, _curandGetErrorEnum(err));
+        exit(-1);
+    }
 #endif
+
+    return;
+}
+#endif // BRIAN2CUDA_CURAND_HOST
 
 
 inline void _cudaSafeCall(cudaError err, const char *file, const int line, const char *call = "")
@@ -87,22 +103,6 @@ inline void _cudaSafeCall(cudaError err, const char *file, const int line, const
 
     return;
 }
-
-
-inline void _cudaSafeCall(curandStatus_t err, const char *file, const int line, const char *call = "")
-{
-#ifdef BRIAN2CUDA_ERROR_CHECK
-    if (CURAND_STATUS_SUCCESS != err)
-    {
-        fprintf(stderr, "ERROR: %s failed at %s:%i : %s\n",
-                call, file, line, _curandGetErrorEnum(err));
-        exit(-1);
-    }
-#endif
-
-    return;
-}
-
 
 inline void _cudaCheckError(const char *file, const int line, const char *msg)
 {
@@ -176,5 +176,4 @@ inline void _thrustCheckError(const char *file, const int line,
             code, file, line);
     throw;
 }
-
 #endif  // BRIAN2CUDA_ERROR_CHECK_H

--- a/brian2cuda/brianlib/curand_buffer.cu
+++ b/brian2cuda/brianlib/curand_buffer.cu
@@ -1,0 +1,126 @@
+#define BRIAN2CUDA_CURAND_HOST
+#include "brianlib/curand_buffer.h"
+#include "objects_api.h"
+#include "brianlib/cuda_utils.h"
+#include <cstdio>
+#include <cstdlib>
+
+using namespace brian;
+
+namespace {
+
+// define generator functions depending on curand float type
+
+// uniform (RAND)
+template <class T>
+void cb_uniform(curandGenerator_t gen, T* out, size_t n);
+template <>
+void cb_uniform<float>(curandGenerator_t gen, float* out, size_t n)
+{
+    curand_generate_uniform_float(gen, out, n);
+}
+template <>
+void cb_uniform<double>(curandGenerator_t gen, double* out, size_t n)
+{
+    curand_generate_uniform_double(gen, out, n);
+}
+
+// normal (RANDN)
+template <class T>
+void cb_normal(curandGenerator_t gen, T* out, size_t n);
+template <>
+void cb_normal<float>(curandGenerator_t gen, float* out, size_t n)
+{
+    curand_generate_normal_float(gen, out, n, 0.f, 1.f);
+}
+template <>
+void cb_normal<double>(curandGenerator_t gen, double* out, size_t n)
+{
+    curand_generate_normal_double(gen, out, n, 0., 1.);
+}
+
+}  // namespace
+
+template <class randomNumber_t>
+void CurandBuffer<randomNumber_t>::generate_numbers()
+{
+    if (current_idx != buffer_size && memory_allocated)
+    {
+        printf("WARNING: CurandBuffer::generate_numbers() called before "
+               "buffer was empty (current_idx = %u, buffer_size = %u)",
+               current_idx, buffer_size);
+    }
+    // TODO: should we allocate the memory in the constructor (even if we end up not using it)?
+    if (!memory_allocated)
+    {
+        // allocate host memory
+        host_data = new randomNumber_t[buffer_size];
+        if (!host_data)
+        {
+            printf("ERROR allocating host_data for CurandBuffer (size %ld)\n",
+                   sizeof(randomNumber_t) * buffer_size);
+            exit(EXIT_FAILURE);
+        }
+        // allocate device memory
+        CUDA_SAFE_CALL(cudaMalloc((void**)&dev_data, buffer_size * sizeof(randomNumber_t)));
+        memory_allocated = true;
+    }
+    // generate random numbers on device
+    if (distribution == RAND)
+        cb_uniform<randomNumber_t>(*generator, dev_data, buffer_size);
+    else  // distribution == RANDN
+        cb_normal<randomNumber_t>(*generator, dev_data, buffer_size);
+    // copy random numbers to host
+    CUDA_SAFE_CALL(cudaMemcpy(
+            host_data, dev_data, buffer_size * sizeof(randomNumber_t),
+            cudaMemcpyDeviceToHost));
+    // reset buffer index
+    current_idx = 0;
+}
+
+template <class randomNumber_t>
+CurandBuffer<randomNumber_t>::CurandBuffer(curandGenerator_t* gen, ProbDistr distr)
+{
+    generator = gen;
+    distribution = distr;
+    buffer_size = 10000;
+    current_idx = 0;
+    memory_allocated = false;
+    host_data = nullptr;
+    dev_data = nullptr;
+}
+
+template <class randomNumber_t>
+CurandBuffer<randomNumber_t>::~CurandBuffer()
+{
+    if (memory_allocated)
+        free_memory();
+}
+
+template <class randomNumber_t>
+void CurandBuffer<randomNumber_t>::free_memory()
+{
+    delete[] host_data;
+    host_data = nullptr;
+    if (dev_data)
+    {
+        CUDA_SAFE_CALL(cudaFree(dev_data));
+        dev_data = nullptr;
+    }
+    memory_allocated = false;
+}
+
+template <class randomNumber_t>
+randomNumber_t CurandBuffer<randomNumber_t>::operator[](const int dummy)
+{
+    // we ignore dummy and just return the next number in the buffer
+    (void)dummy;
+    if (current_idx == buffer_size || !memory_allocated)
+        generate_numbers();
+    randomNumber_t number = host_data[current_idx];
+    current_idx += 1;
+    return number;
+}
+
+template class CurandBuffer<float>;
+template class CurandBuffer<double>;

--- a/brian2cuda/brianlib/curand_buffer.h
+++ b/brian2cuda/brianlib/curand_buffer.h
@@ -1,21 +1,19 @@
 #ifndef _CURAND_BUFFER_H
 #define _CURAND_BUFFER_H
 
-#include <stdio.h>
-#include <curand.h>
-#include <cuda.h>
+#include <cstddef>
 
+struct curandGenerator_st;
+typedef struct curandGenerator_st* curandGenerator_t;
 
 // XXX: for some documentation on random number generation, check out our wiki:
 //      https://github.com/brian-team/brian2cuda/wiki/Random-number-generation
-
 
 enum ProbDistr
 {
     RAND,  // uniform distribution over [0,1)
     RANDN  // standard normal distribution with mean 0 and std 1
 };
-
 
 template <class randomNumber_t>  // random number type
 // only float and double are supported as template types
@@ -35,160 +33,20 @@ private:
     curandGenerator_t* generator;
     ProbDistr distribution;
 
-    void generate_numbers()
-    {
-        if (current_idx != buffer_size && memory_allocated)
-        {
-            printf("WARNING: CurandBuffer::generate_numbers() called before "
-                    "buffer was empty (current_idx = %u, buffer_size = %u)",
-                    current_idx, buffer_size);
-        }
-        // TODO: should we allocate the memory in the constructor (even if we end up not using it)?
-        if (!memory_allocated)
-        {
-            // allocate host memory
-            host_data = new randomNumber_t[buffer_size];
-            if (!host_data)
-            {
-                printf("ERROR allocating host_data for CurandBuffer (size %ld)\n", sizeof(randomNumber_t)*buffer_size);
-                exit(EXIT_FAILURE);
-            }
-            // allocate device memory
-            cudaError_t status = cudaMalloc((void **)&dev_data, buffer_size*sizeof(randomNumber_t));
-            if (status != cudaSuccess)
-            {
-                printf("ERROR allocating memory on device (size = %ld) in %s(%d):\n\t%s\n",
-                        buffer_size*sizeof(randomNumber_t), __FILE__, __LINE__,
-                        cudaGetErrorString(status));
-                exit(EXIT_FAILURE);
-            }
-            memory_allocated = true;
-        }
-        // generate random numbers on device
-        if (distribution == RAND)
-        {
-            curandStatus_t status = generateUniform(*generator, dev_data, buffer_size);
-            if (status != CURAND_STATUS_SUCCESS)
-            {
-                printf("ERROR generating random numbers in %s(%d):\n", __FILE__, __LINE__);
-                exit(EXIT_FAILURE);
-            }
-        }
-        else  // distribution == RANDN
-        {
-            curandStatus_t status = generateNormal(*generator, dev_data, buffer_size, 0, 1);
-            if (status != CURAND_STATUS_SUCCESS)
-            {
-                printf("ERROR generating normal distributed random numbers in %s(%d):\n",
-                        __FILE__, __LINE__);
-                exit(EXIT_FAILURE);
-            }
-        }
-        // copy random numbers to host
-        cudaError_t status = cudaMemcpy(host_data, dev_data, buffer_size*sizeof(randomNumber_t), cudaMemcpyDeviceToHost);
-        if (status != cudaSuccess)
-        {
-            printf("ERROR copying device to host memory (size = %ld) in %s(%d):\n\t%s\n",
-                    buffer_size*sizeof(randomNumber_t), __FILE__, __LINE__,
-                    cudaGetErrorString(status));
-            exit(EXIT_FAILURE);
-        }
-        // reset buffer index
-        current_idx = 0;
-    }
-
-    curandStatus_t generateUniform(curandGenerator_t generator, randomNumber_t *outputPtr, size_t num)
-    {
-        printf("ERROR curand can only generate random numbers as 'float' or 'double' types.\n");
-        exit(EXIT_FAILURE);
-    }
-
-    curandStatus_t generateNormal(curandGenerator_t generator, randomNumber_t *outputPtr,
-            size_t n, randomNumber_t mean, randomNumber_t stddev)
-    {
-        printf("ERROR curand can only generate random numbers as 'float' or 'double' types.\n");
-        exit(EXIT_FAILURE);
-    }
+    void generate_numbers();
 
 public:
-    CurandBuffer(curandGenerator_t* gen, ProbDistr distr)
-    {
-        generator = gen;
-        distribution = distr;
-        buffer_size = 10000;
-        current_idx = 0;
-        memory_allocated = false;
-    }
-
-    ~CurandBuffer()
-    {
-        if (memory_allocated)
-        {
-            free_memory();
-        }
-    }
-
+    CurandBuffer(curandGenerator_t* gen, ProbDistr distr);
+    ~CurandBuffer();
     // We declare the CurandBuffer in anonymous namespace (file global
     // variable) in the synapses_create_generator template, therefore its
     // declaration scope only ends at program termination, but then the CUDA
     // device is already detached, which results in an error when freeing the
     // device memory in the destructor. This method can be called to free
     // device memory manually before the destructor is called.
-    void free_memory()
-    {
-        delete[] host_data;
-        cudaError_t status = cudaFree(dev_data);
-        if (status != cudaSuccess)
-        {
-            printf("ERROR freeing device memory in %s(%d):%s\n",
-                    __FILE__, __LINE__, cudaGetErrorString(status));
-            exit(EXIT_FAILURE);
-        }
-        memory_allocated = false;
-    }
-
+    void free_memory();
     // don't return reference to prohibit assignment
-    randomNumber_t operator[](const int dummy)
-    {
-        // we ignore dummy and just return the next number in the buffer
-        if (current_idx == buffer_size || !memory_allocated)
-            generate_numbers();
-        randomNumber_t number = host_data[current_idx];
-        current_idx += 1;
-        return number;
-    }
-};  // class CurandBuffer
-
-
-// define generator functions depending on curand float type
-// normal (RANDN)
-template <> inline
-curandStatus_t CurandBuffer<float>::generateNormal(curandGenerator_t generator,
-        float *outputPtr, size_t n, float mean, float stddev)
-{
-    return curandGenerateNormal(generator, outputPtr, n, mean, stddev);
-}
-
-template <> inline
-curandStatus_t CurandBuffer<double>::generateNormal(curandGenerator_t generator,
-        double *outputPtr, size_t n, double mean, double stddev)
-{
-    return curandGenerateNormalDouble(generator, outputPtr, n, mean, stddev);
-}
-
-// uniform (RAND)
-template <> inline
-curandStatus_t CurandBuffer<float>::generateUniform(curandGenerator_t generator,
-        float *outputPtr, size_t num)
-{
-    return curandGenerateUniform(generator, outputPtr, num);
-}
-
-template <> inline
-curandStatus_t CurandBuffer<double>::generateUniform(curandGenerator_t generator,
-        double *outputPtr, size_t num)
-{
-    return curandGenerateUniformDouble(generator, outputPtr, num);
-}
+    randomNumber_t operator[](const int dummy);
+};
 
 #endif

--- a/brian2cuda/brianlib/spikequeue.h
+++ b/brian2cuda/brianlib/spikequeue.h
@@ -1,4 +1,3 @@
-#include<iostream>
 #include<vector>
 #include<algorithm>
 #include<inttypes.h>

--- a/brian2cuda/brianlib/spikequeue.h
+++ b/brian2cuda/brianlib/spikequeue.h
@@ -1,10 +1,9 @@
-#include<vector>
-#include<algorithm>
-#include<inttypes.h>
+#ifndef _BRIAN_SPIKEQUEUE_H
+#define _BRIAN_SPIKEQUEUE_H
 
+#include <inttypes.h>
 #include "cudaVector.h"
 #include <assert.h>
-
 #include <cstdio>
 
 using namespace std;
@@ -514,3 +513,5 @@ public:
         *(_synapses_queue) =  &(synapses_queue[current_offset][0]);
     }
 };
+
+#endif  // _BRIAN_SPIKEQUEUE_H

--- a/brian2cuda/codeobject.py
+++ b/brian2cuda/codeobject.py
@@ -95,10 +95,13 @@ codegen_targets.add(CUDAStandaloneAtomicsCodeObject)
 rand_code = '''
     #define _rand(vectorisation_idx) (_ptr_array_%CODEOBJ_NAME%_rand[vectorisation_idx])
     '''
+    
+_RAND_HEADERS = {"headers": ['"rand.h"']}
 rand_impls = DEFAULT_FUNCTIONS['rand'].implementations
 rand_impls.add_implementation(CUDAStandaloneCodeObject,
                               code=rand_code,
-                              name='_rand')
+                              name='_rand',
+                              compiler_kwds=_RAND_HEADERS)
 
 randn_code = '''
     #define _randn(vectorisation_idx) (_ptr_array_%CODEOBJ_NAME%_randn[vectorisation_idx])
@@ -106,4 +109,5 @@ randn_code = '''
 randn_impls = DEFAULT_FUNCTIONS['randn'].implementations
 randn_impls.add_implementation(CUDAStandaloneCodeObject,
                                code=randn_code,
-                               name='_randn')
+                               name='_randn',
+                               compiler_kwds=_RAND_HEADERS)

--- a/brian2cuda/codeobject.py
+++ b/brian2cuda/codeobject.py
@@ -27,6 +27,18 @@ from brian2cuda.cuda_generator import (
 __all__ = ['CUDAStandaloneCodeObject',
            'CUDAStandaloneAtomicsCodeObject']
 
+_DYNAMIC_ARRAY_PREFIX = '_dynamic_array_'
+_DEV_DYNAMIC_ARRAY_PREFIX = 'dev_dynamic_array_'
+
+
+def array_basename(arrayname):
+    """Map '_dynamic_array_foo' / 'dev_dynamic_array_foo' -> 'foo', else None."""
+    if arrayname.startswith(_DYNAMIC_ARRAY_PREFIX):
+        return arrayname[len(_DYNAMIC_ARRAY_PREFIX):]
+    if arrayname.startswith(_DEV_DYNAMIC_ARRAY_PREFIX):
+        return arrayname[len(_DEV_DYNAMIC_ARRAY_PREFIX):]
+    return None
+
 
 class CUDAStandaloneCodeObject(CPPStandaloneCodeObject):
     '''
@@ -40,7 +52,8 @@ class CUDAStandaloneCodeObject(CPPStandaloneCodeObject):
                           env_globals={'c_data_type': c_data_type,
                                        'constant_or_scalar': constant_or_scalar,
                                        'prefs': prefs,
-                                       'zip': zip
+                                       'zip': zip,
+                                       'array_basename': array_basename,
                                        })
     generator_class = CUDACodeGenerator
 

--- a/brian2cuda/cuda_generator.py
+++ b/brian2cuda/cuda_generator.py
@@ -989,7 +989,13 @@ DEFAULT_FUNCTIONS['poisson'].implementations.add_implementation(
     CUDACodeGenerator,
     code=poisson_code,
     name='_poisson',
-    compiler_kwds={"headers": ["<curand.h>"]}
+    compiler_kwds={
+        "headers": [
+            "<curand.h>",
+            "<curand_kernel.h>",
+            '"rand.h"',
+        ],
+    }
 )
 
 

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -1160,7 +1160,8 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
         writer.write('network.*', network_tmp)
 
     def generate_synapses_classes_source(self, writer):
-        synapses_classes_tmp = self.code_object_class().templater.synapses_classes(None, None)
+        synapses_classes_tmp = self.code_object_class().templater.synapses_classes(
+            None, None, synapses=self.synapses)
         writer.write('synapses_classes.*', synapses_classes_tmp)
 
     def generate_run_source(self, writer):

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -675,16 +675,10 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
             elif func=='resize_array':
                 array_name, new_size = args
                 short = array_basename(array_name)
-                if short is not None:
-                    code = (
-                        f'resize_host_array_{short}({new_size});\n'
-                        f'resize_dev_array_{short}({new_size});'
-                    )
-                else:
-                    code = f'''
-                    {array_name}.resize({new_size});
-                    THRUST_CHECK_ERROR(dev{array_name}.resize({new_size}));
-                '''
+                code = (
+                    f'resize_host_array_{short}({new_size});\n'
+                    f'resize_dev_array_{short}({new_size});'
+                )
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='insert_code':
                 main_lines.append(args)

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -1007,6 +1007,11 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 code = code.replace('%HOST_CONSTANTS%', '\n\t\t'.join(code_object_defs[codeobj.name]))
                 # ADDITIONAL_HOST_CODE is extra code, which needs `_N`
                 code = code.replace('%ADDITIONAL_HOST_CODE%', '\n\t\t'.join(additional_host_code[codeobj.name]))
+                curand_host_define = (
+                    '#define BRIAN2CUDA_CURAND_HOST\n'
+                    if additional_host_code[codeobj.name] else ''
+                )
+                code = code.replace('%CURAND_HOST_DEFINE%', curand_host_define)
                 # KERNEL_CONSTANTS are the same for inside device kernels
                 code = code.replace('%KERNEL_CONSTANTS%', '\n\t'.join(kernel_constants[codeobj.name]))
                 # HOST_PARAMETERS are parameters that device kernels are called with from host code
@@ -1076,13 +1081,16 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     N_value = co.owner._N
                 needed_number_curand_states[co_name] = (N_ptr, N_value)
 
-        rand_tmp = self.code_object_class().templater.rand(None, None,
-                                                           codeobjects_with_rng_per_run=self.codeobjects_with_rng["host_api"]["per_run"],
-                                                           all_poisson_lamdas=self.all_poisson_lamdas,
-                                                           needed_number_curand_states=needed_number_curand_states,
-                                                           number_run_calls=len(self.codeobjects_with_rng["host_api"]["per_run"]),
-                                                           profiled=self.enable_profiling,
-                                                           curand_float_type=c_data_type(prefs['core.default_float_dtype']))
+        rand_tmp = self.code_object_class().templater.rand(
+            None, None,
+            codeobjects_with_rng_per_run=self.codeobjects_with_rng["host_api"]["per_run"],
+            all_codeobj_with_host_rng=self.codeobjects_with_rng["host_api"]["all_runs"],
+            all_poisson_lamdas=self.all_poisson_lamdas,
+            needed_number_curand_states=needed_number_curand_states,
+            number_run_calls=len(self.codeobjects_with_rng["host_api"]["per_run"]),
+            profiled=self.enable_profiling,
+            curand_float_type=c_data_type(prefs['core.default_float_dtype']),
+        )
         writer.write('rand.*', rand_tmp)
 
     def copy_source_files(self, writer, directory):

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -77,8 +77,10 @@ class CUDAWriter(CPPWriter):
         elif filename.endswith('.*'):
             self.write(filename[:-1]+'cu', contents.cu_file)
             self.write(filename[:-1]+'h', contents.h_file)
-            if hasattr(contents, 'h_thrust_file'):
-                self.write(filename[:-2]+'_thrust.h', contents.h_thrust_file)
+            if hasattr(contents, 'h_storage_file'):
+                self.write(filename[:-2]+'_storage.h', contents.h_storage_file)
+            if hasattr(contents, 'h_api_file'):
+                self.write(filename[:-2]+'_api.h', contents.h_api_file)
             return
         fullfilename = os.path.join(self.project_dir, filename)
         if os.path.exists(fullfilename):
@@ -536,7 +538,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                         # At curand state initalization, synapses are not generated yet.
                         # For codeobjects run every tick, this happens in the init() of
                         # the random number buffer called at first clock cycle of the network
-                        main_lines.append('random_number_buffer.ensure_enough_curand_states();')
+                        main_lines.append('random_number_buffer_ensure_enough_curand_states();')
                 main_lines.append(f'_run_{codeobj.name}();')
             elif func == 'after_run_code_object':
                 codeobj, = args
@@ -551,43 +553,37 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     # TODO: Move this into before_run_synapses_push_spikes
                     for synaptic_pre, delete in self.delete_synaptic_pre.items():
                         if delete:
-                            code = f'''
-                                dev{synaptic_pre}.clear();
-                                dev{synaptic_pre}.shrink_to_fit();
-                            '''
-                            main_lines.extend(stripped_deindented_lines(code))
+                            short = _dynamic_short(synaptic_pre)
+                            main_lines.append(f'clear_dev_array_{short}();')
                     for synaptic_post, delete in self.delete_synaptic_post.items():
                         if delete:
-                            code = f'''
-                                dev{synaptic_post}.clear();
-                                dev{synaptic_post}.shrink_to_fit();
-                            '''
-                            main_lines.extend(stripped_deindented_lines(code))
+                            short = _dynamic_short(synaptic_post)
+                            main_lines.append(f'clear_dev_array_{short}();')
                     for synaptic_delay, delete in self.delete_synaptic_delay.items():
                         if delete:
-                            code = f'''
-                                dev{synaptic_delay}.clear();
-                                dev{synaptic_delay}.shrink_to_fit();
-                            '''
-                            main_lines.extend(stripped_deindented_lines(code))
+                            short = _dynamic_short(synaptic_delay)
+                            main_lines.append(f'clear_dev_array_{short}();')
                 # The actual network code
                 main_lines.extend(netcode)
                 # Increment run counter
                 run_counter += 1
             elif func=='set_by_constant':
                 arrayname, value, is_dynamic = args
-                size_str = f"{arrayname}.size()" if is_dynamic else f"_num_{arrayname}"
+                short = _dynamic_short(arrayname)
+                host_arrayname = f'host_array_{short}' if short is not None else arrayname
+                size_str = (f'_num_host_array_{short}' if (is_dynamic and short is not None)
+                            else f'_num_{arrayname}')
                 rendered_value = CPPNodeRenderer().render_expr(repr(value))
                 pointer_arrayname = f"dev{arrayname}"
                 if arrayname.endswith('space'):  # eventspace
-                    pointer_arrayname += f'[current_idx{arrayname}]'
-                if is_dynamic:
-                    pointer_arrayname = f"thrust::raw_pointer_cast(&dev{arrayname}[0])"
+                    pointer_arrayname += f'_view[current_idx{arrayname}]'
+                if is_dynamic and short is not None:
+                    pointer_arrayname = f'dev_array_{short}'
                 # Set on host
                 code = f'''
                     for(int i=0; i<{size_str}; i++)
                     {{
-                        {arrayname}[i] = {rendered_value};
+                        {host_arrayname}[i] = {rendered_value};
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
@@ -596,8 +592,8 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
                             {pointer_arrayname},
-                            &{arrayname}[0],
-                            sizeof({arrayname}[0])*{size_str},
+                            {host_arrayname},
+                            sizeof({host_arrayname}[0])*{size_str},
                             cudaMemcpyHostToDevice
                         )
                     );
@@ -605,21 +601,23 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_by_single_value':
                 arrayname, item, value = args
+                short = _dynamic_short(arrayname)
+                host_arrayname = f'host_array_{short}' if short is not None else arrayname
                 pointer_arrayname = f"dev{arrayname}"
                 if arrayname.endswith('space'):  # eventspace
-                    pointer_arrayname += f'[current_idx{arrayname}]'
-                if arrayname in self.dynamic_arrays.values():
-                    pointer_arrayname = f"thrust::raw_pointer_cast(&dev{arrayname}[0])"
+                    pointer_arrayname += f'_view[current_idx{arrayname}]'
+                if short is not None:
+                    pointer_arrayname = f'dev_array_{short}'
                 # Set on host
-                code = f"{arrayname}[{item}] = {value};"
+                code = f"{host_arrayname}[{item}] = {value};"
                 if arrayname not in self.variables_on_host_only:
                     # Copy to device
                     code += f'''
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
                             {pointer_arrayname} + {item},
-                            &{arrayname}[{item}],
-                            sizeof({arrayname}[{item}]),
+                            {host_arrayname} + {item},
+                            sizeof({host_arrayname}[{item}]),
                             cudaMemcpyHostToDevice
                         )
                     );
@@ -627,17 +625,18 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_by_array':
                 arrayname, staticarrayname, is_dynamic = args
-                size_str = "_num_" + arrayname
-                if is_dynamic:
-                    size_str = arrayname + ".size()"
+                short = _dynamic_short(arrayname)
+                host_arrayname = f'host_array_{short}' if short is not None else arrayname
+                size_str = (f'_num_host_array_{short}' if (is_dynamic and short is not None)
+                            else f'_num_{arrayname}')
                 pointer_arrayname = f"dev{arrayname}"
-                if arrayname in self.dynamic_arrays.values():
-                    pointer_arrayname = f"thrust::raw_pointer_cast(&dev{arrayname}[0])"
+                if short is not None:
+                    pointer_arrayname = f'dev_array_{short}'
                 # Set on host
                 code = f'''
                     for(int i=0; i<_num_{staticarrayname}; i++)
                     {{
-                        {arrayname}[i] = {staticarrayname}[i];
+                        {host_arrayname}[i] = {staticarrayname}[i];
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
@@ -646,8 +645,8 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
                             {pointer_arrayname},
-                            &{arrayname}[0],
-                            sizeof({arrayname}[0])*{size_str},
+                            {host_arrayname},
+                            sizeof({host_arrayname}[0])*{size_str},
                             cudaMemcpyHostToDevice
                         )
                     );
@@ -655,11 +654,19 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_array_by_array':
                 arrayname, staticarrayname_index, staticarrayname_value = args
+                short = _dynamic_short(arrayname)
+                host_arrayname = f'host_array_{short}' if short is not None else arrayname
+                if short is not None:
+                    dev_ptr = f'dev_array_{short}'
+                    memcpy_size = f'_num_host_array_{short}'
+                else:
+                    dev_ptr = f'dev{arrayname}'
+                    memcpy_size = f'_num_{arrayname}'
                 # Set on host
                 code = f'''
                     for(int i=0; i<_num_{staticarrayname_index}; i++)
                     {{
-                        {arrayname}[{staticarrayname_index}[i]] = {staticarrayname_value}[i];
+                        {host_arrayname}[{staticarrayname_index}[i]] = {staticarrayname_value}[i];
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
@@ -667,9 +674,9 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     code += f'''
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
-                            dev{arrayname},
-                            &{arrayname}[0],
-                            sizeof({arrayname}[0])*_num_{arrayname},
+                            {dev_ptr},
+                            {host_arrayname},
+                            sizeof({host_arrayname}[0])*{memcpy_size},
                             cudaMemcpyHostToDevice
                         )
                     );
@@ -677,7 +684,11 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='resize_array':
                 array_name, new_size = args
-                code = f'''
+                short = _dynamic_short(array_name)
+                if short is not None:
+                    code = f'resize_dev_array_{short}({new_size});'
+                else:
+                    code = f'''
                     {array_name}.resize({new_size});
                     THRUST_CHECK_ERROR(dev{array_name}.resize({new_size}));
                 '''
@@ -700,7 +711,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 if seed is None:
                     # draw random seed in range of possible uint64 numbers
                     seed = np.random.randint(np.iinfo(np.uint64).max, dtype=np.uint64)
-                main_lines.append(f'random_number_buffer.set_seed({seed!r}ULL);')
+                main_lines.append(f'random_number_buffer_set_seed({seed!r}ULL);')
             else:
                 raise NotImplementedError("Unknown main queue function type "+func)
 
@@ -1804,7 +1815,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
         )
         run_lines.extend(self.code_lines["after_network_run"])
         # for multiple runs, the random number buffer needs to be reset
-        run_lines.append('random_number_buffer.run_finished();')
+        run_lines.append('random_number_buffer_run_finished();')
         # nvprof stuff
         run_lines.append('CUDA_SAFE_CALL(cudaDeviceSynchronize());')
         run_lines.append('CUDA_SAFE_CALL(cudaProfilerStop());')

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -46,6 +46,19 @@ logger = get_logger(__name__)
 CUDA_CPP_STD = '-std=c++17'
 CUDA_CPP_STD_MSVC = '/std:c++17'
 
+# Matches objects.cu DYNAMIC_ARRAY_PREFIX_LEN / '_dynamic_array_<name>'
+_DYNAMIC_ARRAY_PREFIX = '_dynamic_array_'
+_DEV_DYNAMIC_ARRAY_PREFIX = 'dev_dynamic_array_'
+
+
+def _dynamic_short(arrayname):
+    """Map '_dynamic_array_foo' or 'dev_dynamic_array_foo' -> 'foo', else None."""
+    if arrayname.startswith(_DYNAMIC_ARRAY_PREFIX):
+        return arrayname[len(_DYNAMIC_ARRAY_PREFIX):]
+    if arrayname.startswith(_DEV_DYNAMIC_ARRAY_PREFIX):
+        return arrayname[len(_DEV_DYNAMIC_ARRAY_PREFIX):]
+    return None
+
 
 class CUDAWriter(CPPWriter):
     def __init__(self, project_dir):
@@ -895,10 +908,24 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                             dtype = c_data_type(v.dtype)
                             if isinstance(v, DynamicArrayVariable):
                                 if v.ndim == 1:
-
-                                    code_object_defs_lines.append(
-                                        f'{dtype}* const {array_name} = thrust::raw_pointer_cast(&{dyn_array_name}[0]);'
-                                    )
+                                    short = _dynamic_short(dyn_array_name)
+                                    if short is not None:
+                                        if prefix == 'dev':
+                                            pimpl_ptr = f'dev_array_{short}'
+                                        else:
+                                            pimpl_ptr = f'host_array_{short}'
+                                        # Avoid `T* const x = x;` when array_name coincides
+                                        # with the global PIMPL pointer name.
+                                        if array_name != pimpl_ptr:
+                                            code_object_defs_lines.append(
+                                                f'{dtype}* const {array_name} = {pimpl_ptr};'
+                                            )
+                                    else:
+                                        code_object_defs_lines.append(
+                                            f'{dtype}* const {array_name} = '
+                                            f'thrust::raw_pointer_cast('
+                                            f'&{dyn_array_name}[0]);'
+                                        )
 
                                     # Add host and kernel parameters only for device pointers
                                     if prefix == 'dev':
@@ -914,11 +941,16 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                         kernel_parameters_lines.append(f"{dtype}* {ptr_array_name}")
 
                                     # Add size variables `_num{array}` only once and if
-                                    # there are two prefixes, base it on host array
-                                    # `{array}.size()`
+                                    # there are two prefixes, base it on host array size
                                     if len(prefixes) == 1 or prefix == '':
+                                        if short is None:
+                                            num_expr = f'{dyn_array_name}.size()'
+                                        elif prefix == '' or len(prefixes) > 1:
+                                            num_expr = f'_num_host_array_{short}'
+                                        else:
+                                            num_expr = f'_num_dev_array_{short}'
                                         code_object_defs_lines.append(
-                                            f'const int _num{k} = {dyn_array_name}.size();'
+                                            f'const int _num{k} = {num_expr};'
                                         )
                                         host_parameters_lines.append(f"_num{k}")
                                         kernel_parameters_lines.append(f"const int _num{k}")
@@ -929,7 +961,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                     idx = ''
                                     if k.endswith('space'):
                                         bare_array_name = self.get_array_name(v)
-                                        idx = f'[current_idx{bare_array_name}]'
+                                        idx = f'_view[current_idx{bare_array_name}]'
                                     host_parameters_lines.append(f"{array_name}{idx}")
                                     kernel_parameters_lines.append(f'{dtype}* {ptr_array_name}')
 

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -64,6 +64,8 @@ class CUDAWriter(CPPWriter):
         elif filename.endswith('.*'):
             self.write(filename[:-1]+'cu', contents.cu_file)
             self.write(filename[:-1]+'h', contents.h_file)
+            if hasattr(contents, 'h_thrust_file'):
+                self.write(filename[:-2]+'_thrust.h', contents.h_thrust_file)
             return
         fullfilename = os.path.join(self.project_dir, filename)
         if os.path.exists(fullfilename):

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -35,29 +35,19 @@ from brian2cuda.utils.stringtools import replace_floating_point_literals
 from brian2cuda.utils.gputools import select_gpu, get_nvcc_path, get_cuda_path
 from brian2cuda.utils.logger import report_issue_message
 
-from .codeobject import CUDAStandaloneCodeObject, CUDAStandaloneAtomicsCodeObject
+from .codeobject import (
+    CUDAStandaloneCodeObject,
+    CUDAStandaloneAtomicsCodeObject,
+    array_basename,
+)
 
 
 __all__ = []
 
 logger = get_logger(__name__)
 
-# Required C++ standard for nvcc; passed to generate_makefile and makefile templates.
 CUDA_CPP_STD = '-std=c++17'
 CUDA_CPP_STD_MSVC = '/std:c++17'
-
-# Matches objects.cu DYNAMIC_ARRAY_PREFIX_LEN / '_dynamic_array_<name>'
-_DYNAMIC_ARRAY_PREFIX = '_dynamic_array_'
-_DEV_DYNAMIC_ARRAY_PREFIX = 'dev_dynamic_array_'
-
-
-def _dynamic_short(arrayname):
-    """Map '_dynamic_array_foo' or 'dev_dynamic_array_foo' -> 'foo', else None."""
-    if arrayname.startswith(_DYNAMIC_ARRAY_PREFIX):
-        return arrayname[len(_DYNAMIC_ARRAY_PREFIX):]
-    if arrayname.startswith(_DEV_DYNAMIC_ARRAY_PREFIX):
-        return arrayname[len(_DEV_DYNAMIC_ARRAY_PREFIX):]
-    return None
 
 
 class CUDAWriter(CPPWriter):
@@ -553,15 +543,15 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     # TODO: Move this into before_run_synapses_push_spikes
                     for synaptic_pre, delete in self.delete_synaptic_pre.items():
                         if delete:
-                            short = _dynamic_short(synaptic_pre)
+                            short = array_basename(synaptic_pre)
                             main_lines.append(f'clear_dev_array_{short}();')
                     for synaptic_post, delete in self.delete_synaptic_post.items():
                         if delete:
-                            short = _dynamic_short(synaptic_post)
+                            short = array_basename(synaptic_post)
                             main_lines.append(f'clear_dev_array_{short}();')
                     for synaptic_delay, delete in self.delete_synaptic_delay.items():
                         if delete:
-                            short = _dynamic_short(synaptic_delay)
+                            short = array_basename(synaptic_delay)
                             main_lines.append(f'clear_dev_array_{short}();')
                 # The actual network code
                 main_lines.extend(netcode)
@@ -569,7 +559,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 run_counter += 1
             elif func=='set_by_constant':
                 arrayname, value, is_dynamic = args
-                short = _dynamic_short(arrayname)
+                short = array_basename(arrayname)
                 host_arrayname = f'host_array_{short}' if short is not None else arrayname
                 size_str = (f'_num_host_array_{short}' if (is_dynamic and short is not None)
                             else f'_num_{arrayname}')
@@ -601,7 +591,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_by_single_value':
                 arrayname, item, value = args
-                short = _dynamic_short(arrayname)
+                short = array_basename(arrayname)
                 host_arrayname = f'host_array_{short}' if short is not None else arrayname
                 pointer_arrayname = f"dev{arrayname}"
                 if arrayname.endswith('space'):  # eventspace
@@ -625,7 +615,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_by_array':
                 arrayname, staticarrayname, is_dynamic = args
-                short = _dynamic_short(arrayname)
+                short = array_basename(arrayname)
                 host_arrayname = f'host_array_{short}' if short is not None else arrayname
                 size_str = (f'_num_host_array_{short}' if (is_dynamic and short is not None)
                             else f'_num_{arrayname}')
@@ -654,7 +644,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_array_by_array':
                 arrayname, staticarrayname_index, staticarrayname_value = args
-                short = _dynamic_short(arrayname)
+                short = array_basename(arrayname)
                 host_arrayname = f'host_array_{short}' if short is not None else arrayname
                 if short is not None:
                     dev_ptr = f'dev_array_{short}'
@@ -684,9 +674,12 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='resize_array':
                 array_name, new_size = args
-                short = _dynamic_short(array_name)
+                short = array_basename(array_name)
                 if short is not None:
-                    code = f'resize_dev_array_{short}({new_size});'
+                    code = (
+                        f'resize_host_array_{short}({new_size});\n'
+                        f'resize_dev_array_{short}({new_size});'
+                    )
                 else:
                     code = f'''
                     {array_name}.resize({new_size});
@@ -919,7 +912,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                             dtype = c_data_type(v.dtype)
                             if isinstance(v, DynamicArrayVariable):
                                 if v.ndim == 1:
-                                    short = _dynamic_short(dyn_array_name)
+                                    short = array_basename(dyn_array_name)
                                     if short is not None:
                                         if prefix == 'dev':
                                             pimpl_ptr = f'dev_array_{short}'
@@ -952,7 +945,8 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                         kernel_parameters_lines.append(f"{dtype}* {ptr_array_name}")
 
                                     # Add size variables `_num{array}` only once and if
-                                    # there are two prefixes, base it on host array size
+                                    # there are two prefixes, base it on host array
+                                    # `{array}.size()`
                                     if len(prefixes) == 1 or prefix == '':
                                         if short is None:
                                             num_expr = f'{dyn_array_name}.size()'
@@ -1270,7 +1264,6 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
         nvcc_flags_str = ' '.join(nvcc_compiler_flags)
         gpu_arch_str = ' '.join(gpu_arch_flags)
         linker_flags_str = ' '.join(cpp_linker_flags)
-        # Determine the C++ standard for the host compiler
         if cpp_compiler == 'msvc':
             host_cpp_std = CUDA_CPP_STD_MSVC
             std_prefixes = ('/std:',)
@@ -1283,7 +1276,6 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
             return any(flag_lower.startswith(prefix) for prefix in std_prefixes)
 
         std_flags = [flag for flag in cpp_compiler_flags if _is_std_flag(flag)]
-        # If the host compiler flag for the C++ standard is set, override it with the CUDA C++ standard
         if std_flags:
             overridden = [flag for flag in std_flags if flag != host_cpp_std]
             if overridden:
@@ -1292,7 +1284,6 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     f"Overriding host compiler flag(s) {overridden!r} from Brian 2 "
                     f"preferences with {host_cpp_std!r}."
                 )
-            # Override the host compiler flag for the C++ standard with the CUDA C++ standard
             cpp_compiler_flags = [
                 host_cpp_std if _is_std_flag(arg) else arg
                 for arg in cpp_compiler_flags

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -926,7 +926,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                         else:
                                             pimpl_ptr = f'host_array_{short}'
                                         # Avoid `T* const x = x;` when array_name coincides
-                                        # with the global PIMPL pointer name.
+                                        # with the global pointer name.
                                         if array_name != pimpl_ptr:
                                             code_object_defs_lines.append(
                                                 f'{dtype}* const {array_name} = {pimpl_ptr};'

--- a/brian2cuda/templates/common_group.cu
+++ b/brian2cuda/templates/common_group.cu
@@ -1,18 +1,22 @@
 {# USES_VARIABLES { N } #}
-
-{### BEFORE RUN ###}
-{% macro before_run_cu_file() %}
-{% block before_run_headers %}
+{% macro co_std_includes() %}
 #include "code_objects/{{codeobj_name}}.h"
 #include "objects.h"
 #include "brianlib/common_math.h"
 #include "brianlib/cuda_utils.h"
 #include "brianlib/stdint_compat.h"
-#include <chrono>
 #include <cmath>
-#include <stdint.h>
+#include <cstdint>
+#include <cstdio>
+#include <cassert>
 #include <ctime>
-#include <stdio.h>
+{% endmacro %}
+
+{### BEFORE RUN ###}
+{% macro before_run_cu_file() %}
+{% block before_run_headers %}
+{{co_std_includes()}}
+#include <chrono>
 {% endblock before_run_headers %}
 
 {% block before_run_defines %}
@@ -44,16 +48,7 @@ void _before_run_{{codeobj_name}}();
 
 {### RUN ###}
 {% macro cu_file() %}
-#include "code_objects/{{codeobj_name}}.h"
-#include "objects.h"
-#include "brianlib/common_math.h"
-#include "brianlib/cuda_utils.h"
-#include "brianlib/stdint_compat.h"
-#include <cmath>
-#include <stdint.h>
-#include <ctime>
-#include <stdio.h>
-
+{{co_std_includes()}}
 {% block extra_headers %}
 {% endblock %}
 
@@ -359,15 +354,7 @@ void _run_{{codeobj_name}}();
 {### AFTER RUN ###}
 {% macro after_run_cu_file() %}
 {% block after_run_headers %}
-#include "code_objects/{{codeobj_name}}.h"
-#include "objects.h"
-#include "brianlib/common_math.h"
-#include "brianlib/cuda_utils.h"
-#include "brianlib/stdint_compat.h"
-#include <cmath>
-#include <stdint.h>
-#include <ctime>
-#include <stdio.h>
+{{ co_std_includes() }}
 {% endblock after_run_headers %}
 
 {% block after_run_defines %}
@@ -386,7 +373,7 @@ void _after_run_{{codeobj_name}}()
 
 {% macro after_run_h_file() %}
 #ifndef _INCLUDED_{{codeobj_name}}_after
-#define _INCLUDED_{{codeobj_name}}_affer
+#define _INCLUDED_{{codeobj_name}}_after
 
 void _after_run_{{codeobj_name}}();
 

--- a/brian2cuda/templates/common_group.cu
+++ b/brian2cuda/templates/common_group.cu
@@ -3,6 +3,7 @@
 #include "code_objects/{{codeobj_name}}.h"
 #include "objects.h"
 #include "brianlib/common_math.h"
+%CURAND_HOST_DEFINE%
 #include "brianlib/cuda_utils.h"
 #include "brianlib/stdint_compat.h"
 #include <cmath>

--- a/brian2cuda/templates/common_synapses.cu
+++ b/brian2cuda/templates/common_synapses.cu
@@ -1,6 +1,7 @@
 {# USES_VARIABLES { N, no_delay_mode } #}
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
+#include "objects_thrust.h"
 #include <stdint.h>
 #include "synapses_classes.h"
 {% endblock %}

--- a/brian2cuda/templates/common_synapses.cu
+++ b/brian2cuda/templates/common_synapses.cu
@@ -1,7 +1,7 @@
 {# USES_VARIABLES { N, no_delay_mode } #}
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 #include <stdint.h>
 #include "synapses_classes.h"
 {% endblock %}

--- a/brian2cuda/templates/common_synapses.cu
+++ b/brian2cuda/templates/common_synapses.cu
@@ -1,7 +1,6 @@
 {# USES_VARIABLES { N, no_delay_mode } #}
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
-#include "objects_storage.h"
-#include <stdint.h>
 #include "synapses_classes.h"
+#include "brianlib/spikequeue.h"
 {% endblock %}

--- a/brian2cuda/templates/group_variable_set.cu
+++ b/brian2cuda/templates/group_variable_set.cu
@@ -2,7 +2,8 @@
 {% extends 'common_group.cu' %}
 
 {% block extra_headers %}
-#include "rand.h"
+#include "objects_thrust.h"
+{# rand.h / curand host API pulled in on demand when this CO uses RNG #}
 {% endblock %}
 
 {% block kernel_maincode %}

--- a/brian2cuda/templates/group_variable_set.cu
+++ b/brian2cuda/templates/group_variable_set.cu
@@ -2,7 +2,8 @@
 {% extends 'common_group.cu' %}
 
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
+#include "objects_api.h"
 {% endblock %}
 
 {% block kernel_maincode %}

--- a/brian2cuda/templates/group_variable_set.cu
+++ b/brian2cuda/templates/group_variable_set.cu
@@ -40,6 +40,7 @@
     );
     {% endif %}
     {% endfor %}
+    sync_all_dev_ptrs();
 {% endblock %}
 
 {# _num_group_idx is defined in HOST_CONSTANTS, so we can't set _N before #}

--- a/brian2cuda/templates/group_variable_set.cu
+++ b/brian2cuda/templates/group_variable_set.cu
@@ -3,7 +3,6 @@
 
 {% block extra_headers %}
 #include "objects_thrust.h"
-{# rand.h / curand host API pulled in on demand when this CO uses RNG #}
 {% endblock %}
 
 {% block kernel_maincode %}

--- a/brian2cuda/templates/group_variable_set.cu
+++ b/brian2cuda/templates/group_variable_set.cu
@@ -2,7 +2,6 @@
 {% extends 'common_group.cu' %}
 
 {% block extra_headers %}
-#include "objects_storage.h"
 #include "objects_api.h"
 {% endblock %}
 
@@ -29,7 +28,7 @@
     #}
     {% for var, varname in written_variables.items() %}
     {% if var.dynamic %}
-    {{varname}} = dev{{varname}};
+    copy_dev_to_host_array_{{ varname[15:] }}();
     {% else %}
     CUDA_SAFE_CALL(
         cudaMemcpy(
@@ -41,7 +40,6 @@
     );
     {% endif %}
     {% endfor %}
-    sync_all_dev_ptrs();
 {% endblock %}
 
 {# _num_group_idx is defined in HOST_CONSTANTS, so we can't set _N before #}

--- a/brian2cuda/templates/group_variable_set.cu
+++ b/brian2cuda/templates/group_variable_set.cu
@@ -28,7 +28,7 @@
     #}
     {% for var, varname in written_variables.items() %}
     {% if var.dynamic %}
-    copy_dev_to_host_array_{{ varname[15:] }}();
+    copy_dev_to_host_array_{{ array_basename(varname) }}();
     {% else %}
     CUDA_SAFE_CALL(
         cudaMemcpy(

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -3,7 +3,6 @@
 {% extends 'common_group.cu' %}
 
 {% block extra_headers %}
-#include "objects_storage.h"
 #include "objects_api.h"
 {% endblock %}
 
@@ -37,7 +36,7 @@
     #}
     {% for var, varname in written_variables.items() %}
     {% if var.dynamic %}
-    {{varname}} = dev{{varname}};
+    copy_dev_to_host_array_{{ varname[15:] }}();
     {% else %}
     CUDA_SAFE_CALL(
         cudaMemcpy(
@@ -49,7 +48,6 @@
     );
     {% endif %}
     {% endfor %}
-    sync_all_dev_ptrs();
 {% endblock %}
 
 

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -36,7 +36,7 @@
     #}
     {% for var, varname in written_variables.items() %}
     {% if var.dynamic %}
-    copy_dev_to_host_array_{{ varname[15:] }}();
+    copy_dev_to_host_array_{{ array_basename(varname) }}();
     {% else %}
     CUDA_SAFE_CALL(
         cudaMemcpy(

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -2,6 +2,9 @@
 {# ALLOWS_SCALAR_WRITE #}
 {% extends 'common_group.cu' %}
 
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}
 
 {% block kernel_maincode %}
     ///// block kernel_maincode /////

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -48,6 +48,7 @@
     );
     {% endif %}
     {% endfor %}
+    sync_all_dev_ptrs();
 {% endblock %}
 
 

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -3,7 +3,8 @@
 {% extends 'common_group.cu' %}
 
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
+#include "objects_api.h"
 {% endblock %}
 
 {% block kernel_maincode %}

--- a/brian2cuda/templates/main.cu
+++ b/brian2cuda/templates/main.cu
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include "objects.h"
 #include "objects_api.h"
+#include "network.h"
 #include <csignal>
 #include <ctime>
 #include <time.h>

--- a/brian2cuda/templates/main.cu
+++ b/brian2cuda/templates/main.cu
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 #include "objects.h"
-#include "objects_thrust.h"
+#include "objects_api.h"
 #include <csignal>
 #include <ctime>
 #include <time.h>

--- a/brian2cuda/templates/main.cu
+++ b/brian2cuda/templates/main.cu
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include "objects.h"
+#include "objects_thrust.h"
 #include <csignal>
 #include <ctime>
 #include <time.h>

--- a/brian2cuda/templates/network.cu
+++ b/brian2cuda/templates/network.cu
@@ -2,6 +2,7 @@
 
 #include "brianlib/cuda_utils.h"
 #include "objects.h"
+#include "objects_thrust.h"
 #include "network.h"
 #include <stdlib.h>
 #include <iostream>

--- a/brian2cuda/templates/network.cu
+++ b/brian2cuda/templates/network.cu
@@ -2,7 +2,6 @@
 
 #include "brianlib/cuda_utils.h"
 #include "objects.h"
-#include "objects_storage.h"
 #include "network.h"
 #include <stdlib.h>
 #include <iostream>
@@ -99,7 +98,7 @@ void Network::run(const double duration, void (*report_func)(const double, const
         {% if varname in spikegenerator_eventspaces %}
         brian::previous_idx{{varname}} = brian::current_idx{{varname}};
         {% endif %}
-        brian::current_idx{{varname}} = (brian::current_idx{{varname}} + 1) % brian::dev{{varname}}.size();
+        brian::current_idx{{varname}} = (brian::current_idx{{varname}} + 1) % brian::_num_dev{{ varname }};
         {% endfor %}
 
         {% if maximum_run_time is not none %}

--- a/brian2cuda/templates/network.cu
+++ b/brian2cuda/templates/network.cu
@@ -2,7 +2,7 @@
 
 #include "brianlib/cuda_utils.h"
 #include "objects.h"
-#include "objects_thrust.h"
+#include "objects_storage.h"
 #include "network.h"
 #include <stdlib.h>
 #include <iostream>

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -14,16 +14,22 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 {% endif %}
 {%- endmacro %}
 
-#include "objects_thrust.h"
-#include "objects.h"
 #define BRIAN2CUDA_CURAND_HOST
+#include "objects_storage.h"
+#include "objects.h"
+#include "objects_api.h"
 #include "brianlib/cuda_utils.h"
 #include "rand.h"
 #include <iostream>
 #include <fstream>
 #include <chrono>
 #include <ctime>
+#include <algorithm>
 #include <curand.h>
+#include <thrust/sort.h>
+#include <thrust/sequence.h>
+#include <thrust/unique.h>
+#include <thrust/copy.h>
 
 size_t brian::used_device_memory = 0;
 std::string brian::results_dir = "results/";  // can be overwritten by --results_dir command line arg
@@ -216,7 +222,7 @@ thrust::device_vector<{{c_data_type(var.dtype)}}*> brian::addresses_monitor_{{va
 thrust::device_vector<{{c_data_type(var.dtype)}}>* brian::{{varname}};
 {% endfor %}
 
-// PIMPL: bare pointers synced from Thrust containers (for lean COs without objects_thrust.h).
+// PIMPL: bare pointers synced from Thrust containers.
 // varname is '_dynamic_array_<name>'; PIMPL symbols use <name> only.
 {% set DYNAMIC_ARRAY_PREFIX_LEN = 15 %}  {# len('_dynamic_array_') #}
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
@@ -228,6 +234,15 @@ int brian::_num_dev_array_{{ N }} = 0;
 {% endfor %}
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 {{c_data_type(var.dtype)}}** brian::dev{{ varname }}_view = nullptr;
+int brian::_num_dev{{ varname }} = 0;
+{% endfor %}
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+{{c_data_type(var.dtype)}}** brian::monitor_addresses_{{ varname }} = nullptr;
+int brian::_num_monitor_addresses_{{ varname }} = 0;
+{% endfor %}
+{% for varname in subgroups_with_spikemonitor %}
+int32_t* brian::dev_array_subgroup_eventspace_{{varname}} = nullptr;
+int brian::_num_subgroup_eventspace_{{varname}} = 0;
 {% endfor %}
 
 namespace brian {
@@ -243,7 +258,22 @@ void sync_array_{{ N }}() {
 {% endfor %}
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 void sync_eventspace_{{ varname }}() {
+    _num_dev{{ varname }} = static_cast<int>(dev{{ varname }}.size());
     dev{{ varname }}_view = dev{{ varname }}.empty() ? nullptr : &dev{{ varname }}[0];
+}
+{% endfor %}
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+void sync_monitor_addresses_{{ varname }}() {
+    _num_monitor_addresses_{{ varname }} = static_cast<int>(addresses_monitor_{{ varname }}.size());
+    monitor_addresses_{{ varname }} = _num_monitor_addresses_{{ varname }}
+        ? thrust::raw_pointer_cast(&addresses_monitor_{{ varname }}[0]) : nullptr;
+}
+{% endfor %}
+{% for varname in subgroups_with_spikemonitor %}
+void sync_subgroup_eventspace_{{varname}}() {
+    _num_subgroup_eventspace_{{varname}} = static_cast<int>(_dev_{{varname}}_eventspace.size());
+    dev_array_subgroup_eventspace_{{varname}} = _num_subgroup_eventspace_{{varname}}
+        ? thrust::raw_pointer_cast(&_dev_{{varname}}_eventspace[0]) : nullptr;
 }
 {% endfor %}
 
@@ -254,8 +284,136 @@ void sync_all_dev_ptrs() {
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
     sync_eventspace_{{ varname }}();
 {% endfor %}
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+    sync_monitor_addresses_{{ varname }}();
+{% endfor %}
+{% for varname in subgroups_with_spikemonitor %}
+    sync_subgroup_eventspace_{{varname}}();
+{% endfor %}
 }
+
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
+void push_back_host_array_{{ N }}({{c_data_type(var.dtype)}} v) {
+    {{ varname }}.push_back(v);
+    sync_array_{{ N }}();
 }
+void resize_host_array_{{ N }}(size_t n) {
+    {{ varname }}.resize(n);
+    sync_array_{{ N }}();
+}
+void resize_dev_array_{{ N }}(size_t n) {
+    THRUST_CHECK_ERROR(dev{{ varname }}.resize(n));
+    {{ varname }}.resize(n);
+    sync_array_{{ N }}();
+}
+void copy_dev_to_host_array_{{ N }}() {
+    {{ varname }} = dev{{ varname }};
+    sync_array_{{ N }}();
+}
+void copy_host_to_dev_array_{{ N }}() {
+    dev{{ varname }} = {{ varname }};
+    sync_array_{{ N }}();
+}
+void clear_dev_array_{{ N }}() {
+    dev{{ varname }}.clear();
+    dev{{ varname }}.shrink_to_fit();
+    sync_array_{{ N }}();
+}
+{% endfor %}
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+void expand_eventspace{{ varname }}(int num_queues) {
+    int num_eventspaces = static_cast<int>(dev{{ varname }}.size());
+    if (num_queues <= num_eventspaces) return;
+    std::rotate(
+        dev{{ varname }}.begin(),
+        dev{{ varname }}.begin() + current_idx{{ varname }},
+        dev{{ varname }}.end());
+    current_idx{{ varname }} = 0;
+    for (int i = num_eventspaces; i < num_queues; i++) {
+        {{c_data_type(var.dtype)}}* new_eventspace;
+        CUDA_SAFE_CALL(cudaMalloc(
+            (void**)&new_eventspace,
+            sizeof({{c_data_type(var.dtype)}}) * _num_{{ varname }}));
+        CUDA_SAFE_CALL(cudaMemcpy(
+            new_eventspace, {{ varname }},
+            sizeof({{c_data_type(var.dtype)}}) * _num_{{ varname }},
+            cudaMemcpyHostToDevice));
+        dev{{ varname }}.push_back(new_eventspace);
+    }
+    sync_eventspace_{{ varname }}();
+}
+{% endfor %}
+{% for varname in subgroups_with_spikemonitor %}
+void resize_subgroup_eventspace_{{varname}}(size_t n) {
+    THRUST_CHECK_ERROR(_dev_{{varname}}_eventspace.resize(n));
+    sync_subgroup_eventspace_{{varname}}();
+}
+{% endfor %}
+struct _subgroup_eventspace_pred {
+    int32_t start;
+    int32_t stop;
+    __device__ bool operator()(int32_t neuron) const {
+        return start <= neuron && neuron < stop;
+    }
+};
+int filter_subgroup_eventspace(
+        int32_t* src, int n, int32_t* dst, int32_t start, int32_t stop) {
+    thrust::device_ptr<int32_t> d_src(src);
+    thrust::device_ptr<int32_t> d_dst(dst);
+    auto out = thrust::copy_if(
+            d_src, d_src + n, d_dst, _subgroup_eventspace_pred{start, stop});
+    return static_cast<int>(out - d_dst);
+}
+void curand_generate_normal_double(
+        curandGenerator_t gen, double* out, size_t n, double mean, double stddev) {
+    CUDA_SAFE_CALL(curandGenerateNormalDouble(gen, out, n, mean, stddev));
+}
+void curand_generate_uniform_double(curandGenerator_t gen, double* out, size_t n) {
+    CUDA_SAFE_CALL(curandGenerateUniformDouble(gen, out, n));
+}
+void curand_generate_normal_float(
+        curandGenerator_t gen, float* out, size_t n, float mean, float stddev) {
+    CUDA_SAFE_CALL(curandGenerateNormal(gen, out, n, mean, stddev));
+}
+void curand_generate_uniform_float(curandGenerator_t gen, float* out, size_t n) {
+    CUDA_SAFE_CALL(curandGenerateUniform(gen, out, n));
+}
+void curand_generate_poisson(
+        curandGenerator_t gen, unsigned int* out, size_t n, double lambda) {
+    CUDA_SAFE_CALL(curandGeneratePoisson(gen, out, n, lambda));
+}
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+void clear_monitor_addresses_{{ varname }}() {
+    addresses_monitor_{{ varname }}.clear();
+    sync_monitor_addresses_{{ varname }}();
+}
+void resize_monitor_row_{{ varname }}(int row, size_t n) {
+    {{ varname }}[row].resize(n);
+    sync_monitor_addresses_{{ varname }}();
+}
+void push_monitor_address_{{ varname }}(int row) {
+    addresses_monitor_{{ varname }}.push_back(
+        thrust::raw_pointer_cast(&{{ varname }}[row][0]));
+    sync_monitor_addresses_{{ varname }}();
+}
+void set_monitor_address_{{ varname }}(int row) {
+    addresses_monitor_{{ varname }}[row] =
+        thrust::raw_pointer_cast(&{{ varname }}[row][0]);
+    sync_monitor_addresses_{{ varname }}();
+}
+{% endfor %}
+void sort_by_key_int_int32(int* keys, int32_t* values, size_t n) {
+    thrust::sort_by_key(thrust::host, keys, keys + n, values);
+}
+void fill_sequence_int(int* out, size_t n) {
+    thrust::sequence(thrust::host, out, out + n);
+}
+size_t unique_by_key_int_int(int* keys, int* values, size_t n) {
+    return static_cast<size_t>(thrust::unique_by_key(
+        thrust::host, keys, keys + n, values).first - keys);
+}
+}  // namespace brian
 
 /////////////// static arrays /////////////
 {% for (name, dtype_spec, N, filename) in static_array_specs | sort %}
@@ -393,7 +551,7 @@ void _init_arrays()
     {% endif %}
 
     // this sets seed for host and device api RNG
-    random_number_buffer.set_seed(seed);
+    random_number_buffer_set_seed(seed);
 
     {% for S in synapses | sort(attribute='name') %}
     {% for path in S._pathways | sort(attribute='name') %}
@@ -486,12 +644,11 @@ void _init_arrays()
     );
     {% endfor %}
 
-    sync_all_dev_ptrs();
-
     CUDA_CHECK_MEMORY();
     const double to_MB = 1.0 / (1024.0 * 1024.0);
     double tot_memory_MB = (used_device_memory - used_device_memory_start) * to_MB;
     double time_passed = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start_timer).count();
+    sync_all_dev_ptrs();
     std::cout << "INFO: _init_arrays() took " <<  time_passed << "s";
     if (tot_memory_MB > 0)
         std::cout << " and used " << tot_memory_MB << "MB of device memory.";
@@ -799,20 +956,9 @@ extern const int _num_{{varname}};
 {% endif %}
 {% endfor %}
 
-//////////////// dynamic array PIMPL pointers ///////////
-{% set DYNAMIC_ARRAY_PREFIX_LEN = 15 %}  {# len('_dynamic_array_') #}
-{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-{% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
-extern {{c_data_type(var.dtype)}}* host_array_{{ N }};
-extern int _num_host_array_{{ N }};
-extern {{c_data_type(var.dtype)}}* dev_array_{{ N }};
-extern int _num_dev_array_{{ N }};
-{% endfor %}
-
 //////////////// eventspaces ///////////////
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 extern {{c_data_type(var.dtype)}} * {{varname}};
-extern {{c_data_type(var.dtype)}}** dev{{varname}}_view;
 extern const int _num_{{varname}};
 extern int current_idx{{varname}};
 {% if varname in spikegenerator_eventspaces %}
@@ -829,6 +975,35 @@ extern {{dtype_spec}} *dev{{name}};
 extern __device__ {{dtype_spec}} *d{{name}};
 extern const int _num_{{name}};
 {% endif %}
+{% endfor %}
+
+//////////////// dynamic arrays 1d (pimpl pointers) ///////////
+{# varname is '_dynamic_array_<name>'; expose <name> only #}
+{% set DYNAMIC_ARRAY_PREFIX_LEN = 15 %}  {# len('_dynamic_array_') #}
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
+extern {{c_data_type(var.dtype)}}* host_array_{{ N }};
+extern int _num_host_array_{{ N }};
+extern {{c_data_type(var.dtype)}}* dev_array_{{ N }};
+extern int _num_dev_array_{{ N }};
+{% endfor %}
+
+//////////////// eventspaces (pimpl pointers) ///////////////
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+extern {{c_data_type(var.dtype)}}** dev{{ varname }}_view;
+extern int _num_dev{{ varname }};
+{% endfor %}
+
+//////////////// dynamic arrays 2d (pimpl pointers) ///////////////
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+extern {{c_data_type(var.dtype)}}** monitor_addresses_{{ varname }};
+extern int _num_monitor_addresses_{{ varname }};
+{% endfor %}
+
+//////////////// subgroup eventspace buffers (pimpl pointers) ///////////////
+{% for varname in subgroups_with_spikemonitor %}
+extern int32_t* dev_array_subgroup_eventspace_{{varname}};
+extern int _num_subgroup_eventspace_{{varname}};
 {% endfor %}
 
 //////////////// synapses /////////////////
@@ -883,8 +1058,6 @@ extern int max_threads_per_sm;
 extern int max_shared_mem_size;
 extern int num_threads_per_warp;
 
-void sync_all_dev_ptrs();
-
 }
 
 void _init_arrays();
@@ -897,13 +1070,13 @@ void _dealloc_arrays();
 
 {% endmacro %}
 
-{% macro h_thrust_file() %}
+{% macro h_storage_file() %}
 #include "objects.h"
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
-#ifndef _BRIAN_OBJECTS_THRUST_H
-#define _BRIAN_OBJECTS_THRUST_H
+#ifndef _BRIAN_OBJECTS_STORAGE_H
+#define _BRIAN_OBJECTS_STORAGE_H
 
 namespace brian {
 
@@ -928,5 +1101,66 @@ extern thrust::device_vector<{{c_data_type(var.dtype)}}>* {{varname}};
 {% endfor %}
 
 }
-#endif // _BRIAN_OBJECTS_THRUST_H
+#endif // _BRIAN_OBJECTS_STORAGE_H
+{% endmacro %}
+
+{% macro h_api_file() %}
+#ifndef _BRIAN_OBJECTS_API_H
+#define _BRIAN_OBJECTS_API_H
+
+#include <cstddef>
+#include <cstdint>
+
+struct curandGenerator_st;
+typedef struct curandGenerator_st* curandGenerator_t;
+
+namespace brian {
+
+{# Public: full refresh after _init_arrays. Per-array sync_* stay internal to objects.cu. #}
+void sync_all_dev_ptrs();
+
+void random_number_buffer_set_seed(unsigned long long seed);
+void random_number_buffer_ensure_enough_curand_states();
+void random_number_buffer_run_finished();
+
+
+void curand_generate_normal_double(
+        curandGenerator_t gen, double* out, size_t n, double mean, double stddev);
+void curand_generate_uniform_double(curandGenerator_t gen, double* out, size_t n);
+void curand_generate_normal_float(
+        curandGenerator_t gen, float* out, size_t n, float mean, float stddev);
+void curand_generate_uniform_float(curandGenerator_t gen, float* out, size_t n);
+void curand_generate_poisson(
+        curandGenerator_t gen, unsigned int* out, size_t n, double lambda);
+
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+void expand_eventspace{{ varname }}(int num_queues);
+{% endfor %}
+void sort_by_key_int_int32(int* keys, int32_t* values, size_t n);
+void fill_sequence_int(int* out, size_t n);
+size_t unique_by_key_int_int(int* keys, int* values, size_t n);
+int filter_subgroup_eventspace(int32_t* src, int n, int32_t* dst, int32_t start, int32_t stop);
+{% for varname in subgroups_with_spikemonitor %}
+void resize_subgroup_eventspace_{{varname}}(size_t n);
+{% endfor %}
+{% set DYNAMIC_ARRAY_PREFIX_LEN = 15 %}  {# len('_dynamic_array_') #}
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
+void resize_host_array_{{ N }}(size_t n);
+void push_back_host_array_{{ N }}({{c_data_type(var.dtype)}} v);
+void resize_dev_array_{{ N }}(size_t n);
+void clear_dev_array_{{ N }}();
+void copy_dev_to_host_array_{{ N }}();
+void copy_host_to_dev_array_{{ N }}();
+{% endfor %}
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+void clear_monitor_addresses_{{ varname }}();
+void resize_monitor_row_{{ varname }}(int row, size_t n);
+void push_monitor_address_{{ varname }}(int row);
+void set_monitor_address_{{ varname }}(int row);
+{% endfor %}
+
+}
+
+#endif
 {% endmacro %}

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -462,29 +462,6 @@ int brian::max_threads_per_sm;
 int brian::max_shared_mem_size;
 int brian::num_threads_per_warp;
 
-{% for S in synapses | sort(attribute='name') %}
-{% for path in S._pathways | sort(attribute='name') %}
-__global__ void {{path.name}}_init(
-                int32_t* sources,
-                int32_t* targets,
-                double dt,
-                int32_t source_start,
-                int32_t source_stop
-        )
-{
-    using namespace brian;
-
-    {{path.name}}.init(
-            sources,
-            targets,
-            dt,
-            // TODO: called source here, spikes in SynapticPathway (use same name)
-            source_start,
-            source_stop);
-}
-{% endfor %}
-{% endfor %}
-
 {% if profiled_codeobjects is defined %}
 // Profiling information for each code object
 {% for codeobj in profiled_codeobjects | sort %}
@@ -805,17 +782,6 @@ void _write_arrays()
         std::cout << "Error writing last run info to file." << std::endl;
     }
 }
-
-{% for S in synapses | sort(attribute='name') %}
-{% for path in S._pathways | sort(attribute='name') %}
-__global__ void {{path.name}}_destroy()
-{
-    using namespace brian;
-
-    {{path.name}}.destroy();
-}
-{% endfor %}
-{% endfor %}
 
 void _dealloc_arrays()
 {

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -18,6 +18,10 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 #include "objects_storage.h"
 #include "objects.h"
 #include "objects_api.h"
+#include "network.h"
+{% if synapses %}
+#include "synapses_classes.h"
+{% endif %}
 #include "brianlib/cuda_utils.h"
 #include "rand.h"
 #include <iostream>
@@ -881,12 +885,15 @@ typedef struct curandStateXORWOW curandState;
 #include <string>
 #include <stdint.h>
 #include "brianlib/clocks.h"
-#include "network.h"
-{% if synapses %}
-#include "synapses_classes.h"
-{% endif %}
 {% if profiled_codeobjects is defined %}
 #include <chrono>
+{% endif %}
+
+// Forward declarations; TUs that access members include
+// "network.h" / "synapses_classes.h" directly.
+class Network;
+{% if synapses %}
+class SynapticPathway;
 {% endif %}
 
 namespace brian {

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -16,13 +16,14 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 
 #include "objects_thrust.h"
 #include "objects.h"
+#define BRIAN2CUDA_CURAND_HOST
 #include "brianlib/cuda_utils.h"
 #include "rand.h"
 #include <iostream>
 #include <fstream>
 #include <chrono>
+#include <ctime>
 #include <curand.h>
-#include <curand_kernel.h>
 
 size_t brian::used_device_memory = 0;
 std::string brian::results_dir = "results/";  // can be overwritten by --results_dir command line arg
@@ -303,32 +304,6 @@ std::chrono::nanoseconds brian::{{codeobj}}_kernel_currents_profiling_info(0);
 {% endfor %}
 {% endif %}
 
-//////////////random numbers//////////////////
-curandGenerator_t brian::curand_generator;
-__device__ unsigned long long* brian::d_curand_seed;
-unsigned long long* brian::dev_curand_seed;
-// dev_{co.name}_{rng_type}_allocator
-//      pointer to start of generated random numbers array
-//      at each generation cycle this array is refilled
-// dev_{co.name}_{rng_type}
-//      pointer moving through generated random number array
-//      until it is regenerated at the next generation cycle
-{% for rng_type in all_codeobj_with_host_rng.keys() %}
-{% for co in all_codeobj_with_host_rng[rng_type] | sort(attribute='name') %}
-{% if rng_type in ['rand', 'randn'] %}
-{% set dtype = 'randomNumber_t' %}
-{% else %}  {# rng_type = 'poisson_<idx>' #}
-{% set dtype = 'unsigned int' %}
-{% endif %}
-{{dtype}}* brian::dev_{{co.name}}_{{rng_type}}_allocator;
-{{dtype}}* brian::dev_{{co.name}}_{{rng_type}};
-__device__ {{dtype}}* brian::_array_{{co.name}}_{{rng_type}};
-{% endfor %}{# rng_type #}
-{% endfor %}{# co #}
-curandState* brian::dev_curand_states;
-__device__ curandState* brian::d_curand_states;
-RandomNumberBuffer brian::random_number_buffer;
-
 void _init_arrays()
 {
     using namespace brian;
@@ -485,8 +460,8 @@ void _load_arrays()
     using namespace brian;
 
     {% for (name, dtype_spec, N, filename) in static_array_specs | sort %}
-    ifstream f{{name}};
-    f{{name}}.open("static_arrays/{{name}}", ios::in | ios::binary);
+    std::ifstream f{{name}};
+    f{{name}}.open("static_arrays/{{name}}", std::ios::in | std::ios::binary);
     if(f{{name}}.is_open())
     {
         {% if name in dynamic_array_specs.values() %}
@@ -496,7 +471,7 @@ void _load_arrays()
         {% endif %}
     } else
     {
-        std::cout << "Error opening static array {{name}}." << endl;
+        std::cout << "Error opening static array {{name}}." << std::endl;
     }
     {% if not (name in dynamic_array_specs.values()) %}
     CUDA_SAFE_CALL(
@@ -526,15 +501,15 @@ void _write_arrays()
             cudaMemcpy({{varname}}, dev{{varname}}, sizeof({{c_data_type(var.dtype)}})*_num_{{varname}}, cudaMemcpyDeviceToHost)
             );
     {% endif %}
-    ofstream outfile_{{varname}};
-    outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", ios::binary | ios::out);
+    std::ofstream outfile_{{varname}};
+    outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", std::ios::binary | std::ios::out);
     if(outfile_{{varname}}.is_open())
     {
         outfile_{{varname}}.write(reinterpret_cast<char*>({{varname}}), {{var.size}}*sizeof({{c_data_type(var.dtype)}}));
         outfile_{{varname}}.close();
     } else
     {
-        std::cout << "Error writing output file for {{varname}}." << endl;
+        std::cout << "Error writing output file for {{varname}}." << std::endl;
     }
     {% endif %}
     {% endfor %}
@@ -543,15 +518,15 @@ void _write_arrays()
     {% if varname not in variables_on_host_only %}
     {{varname}} = dev{{varname}};
     {% endif %}
-    ofstream outfile_{{varname}};
-    outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", ios::binary | ios::out);
+    std::ofstream outfile_{{varname}};
+    outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", std::ios::binary | std::ios::out);
     if(outfile_{{varname}}.is_open())
     {
         outfile_{{varname}}.write(reinterpret_cast<char*>(thrust::raw_pointer_cast(&{{varname}}[0])), {{varname}}.size()*sizeof({{c_data_type(var.dtype)}}));
         outfile_{{varname}}.close();
     } else
     {
-        std::cout << "Error writing output file for {{varname}}." << endl;
+        std::cout << "Error writing output file for {{varname}}." << std::endl;
     }
     {% endfor %}
 
@@ -559,11 +534,11 @@ void _write_arrays()
         {% if var in profile_statemonitor_vars %}
         {# Record copying statemonitor variable from device to host for benchmarking #}
         std::chrono::nanoseconds before_copy_statemon;
-        string profile_statemonitor_copy_to_host_varname = "{{var.owner.name}}_copy_to_host_{{profile_statemonitor_copy_to_host}}";
+        std::string profile_statemonitor_copy_to_host_varname = "{{var.owner.name}}_copy_to_host_{{profile_statemonitor_copy_to_host}}";
         std::chrono::nanoseconds copy_time_statemon;
         {% endif %}
-        ofstream outfile_{{varname}};
-        outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", ios::binary | ios::out);
+        std::ofstream outfile_{{varname}};
+        outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", std::ios::binary | std::ios::out);
         if(outfile_{{varname}}.is_open())
         {
             {% if var in profile_statemonitor_vars %}
@@ -575,7 +550,7 @@ void _write_arrays()
                 temp_array{{varname}}[n] = {{varname}}[n];
             }
             {% if var in profile_statemonitor_vars %}
-            string profile_statemonitor_copy_to_host_varname = "{{varname}}_copy_to_host";
+            std::string profile_statemonitor_copy_to_host_varname = "{{varname}}_copy_to_host";
             copy_time_statemon += std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - before_copy_statemon);
             {% endif %}
             for(int j = 0; j < temp_array{{varname}}[0].size(); j++)
@@ -588,14 +563,14 @@ void _write_arrays()
             outfile_{{varname}}.close();
         } else
         {
-            std::cout << "Error writing output file for {{varname}}." << endl;
+            std::cout << "Error writing output file for {{varname}}." << std::endl;
         }
     {% endfor %}
 
     {% if profiled_codeobjects is defined and profiled_codeobjects %}
     // Write profiling info to disk
-    ofstream outfile_profiling_info;
-    outfile_profiling_info.open(results_dir + "profiling_info.txt", ios::out);
+    std::ofstream outfile_profiling_info;
+    outfile_profiling_info.open(results_dir + "profiling_info.txt", std::ios::out);
     if(outfile_profiling_info.is_open())
     {
     {% for codeobj in profiled_codeobjects | sort %}
@@ -620,8 +595,8 @@ void _write_arrays()
     }
     {% endif %}
     // Write last run info to disk
-    ofstream outfile_last_run_info;
-    outfile_last_run_info.open(results_dir + "last_run_info.txt", ios::out);
+    std::ofstream outfile_last_run_info;
+    outfile_last_run_info.open(results_dir + "last_run_info.txt", std::ios::out);
     if(outfile_last_run_info.is_open())
     {
         outfile_last_run_info << (Network::_last_run_time) << " " << (Network::_last_run_completed_fraction) << std::endl;
@@ -749,8 +724,6 @@ typedef struct curandStateXORWOW curandState;
 #include <chrono>
 {% endif %}
 
-class RandomNumberBuffer;
-
 namespace brian {
 
 extern size_t used_device_memory;
@@ -848,31 +821,6 @@ extern std::chrono::nanoseconds {{codeobj}}_kernel_currents_profiling_info;
 #}
 {% endfor %}
 {% endif %}
-
-//////////////// random numbers /////////////////
-extern curandGenerator_t curand_generator;
-extern unsigned long long* dev_curand_seed;
-extern __device__ unsigned long long* d_curand_seed;
-
-{% for rng_type in all_codeobj_with_host_rng.keys() %}
-{% for co in all_codeobj_with_host_rng[rng_type] | sort(attribute='name') %}
-{% if rng_type in ['rand', 'randn'] %}
-{% set dtype = 'randomNumber_t' %}
-{% else %}  {# rng_type = 'poisson_<idx>' #}
-{% set dtype = 'unsigned int' %}
-{% endif %}
-// pointer to start of generated random numbers array
-// at each generation cycle this array is refilled
-extern {{dtype}}* dev_{{co.name}}_{{rng_type}}_allocator;
-// pointer moving through generated random number array
-// until it is regenerated at the next generation cycle
-extern {{dtype}}* dev_{{co.name}}_{{rng_type}};
-extern __device__ {{dtype}}* _array_{{co.name}}_{{rng_type}};
-{% endfor %}{# rng_type #}
-{% endfor %}{# co #}
-extern curandState* dev_curand_states;
-extern __device__ curandState* d_curand_states;
-extern RandomNumberBuffer random_number_buffer;
 
 //CUDA
 extern int num_parallel_blocks;

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -29,11 +29,13 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 #include <chrono>
 #include <ctime>
 #include <algorithm>
-#include <curand.h>
-#include <thrust/sort.h>
-#include <thrust/sequence.h>
-#include <thrust/unique.h>
+#include <vector>
 #include <thrust/copy.h>
+#include <thrust/count.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+#include <thrust/unique.h>
+#include <curand.h>
 
 size_t brian::used_device_memory = 0;
 std::string brian::results_dir = "results/";  // can be overwritten by --results_dir command line arg
@@ -226,10 +228,8 @@ thrust::device_vector<{{c_data_type(var.dtype)}}*> brian::addresses_monitor_{{va
 thrust::device_vector<{{c_data_type(var.dtype)}}>* brian::{{varname}};
 {% endfor %}
 
-// varname is '_dynamic_array_<name>'; exposed symbols use <name> only.
-{% set DYNAMIC_ARRAY_PREFIX_LEN = 15 %}  {# len('_dynamic_array_') #}
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-{% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
+{% set N = array_basename(varname) %}
 {{c_data_type(var.dtype)}}* brian::host_array_{{ N }} = nullptr;
 int brian::_num_host_array_{{ N }} = 0;
 {{c_data_type(var.dtype)}}* brian::dev_array_{{ N }} = nullptr;
@@ -249,16 +249,105 @@ int brian::_num_subgroup_eventspace_{{varname}} = 0;
 {% endfor %}
 
 namespace brian {
-{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-{% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
-void sync_array_{{ N }}() {
-    _num_host_array_{{ N }} = static_cast<int>({{ varname }}.size());
-    host_array_{{ N }} = _num_host_array_{{ N }} ? &{{ varname }}[0] : nullptr;
-    _num_dev_array_{{ N }} = static_cast<int>(dev{{ varname }}.size());
-    dev_array_{{ N }} = _num_dev_array_{{ N }}
-        ? thrust::raw_pointer_cast(&dev{{ varname }}[0]) : nullptr;
+
+namespace dyn_array {
+
+template <typename T>
+void sync_host_dev(
+        thrust::host_vector<T>& host,
+        thrust::device_vector<T>& device,
+        T*& host_ptr, int& host_n,
+        T*& device_ptr, int& device_n)
+{
+    host_n = static_cast<int>(host.size());
+    host_ptr = host_n ? &host[0] : nullptr;
+    device_n = static_cast<int>(device.size());
+    device_ptr = device_n
+        ? thrust::raw_pointer_cast(&device[0]) : nullptr;
 }
-{% endfor %}
+
+template <typename T>
+void push_back_host(
+        thrust::host_vector<T>& host,
+        thrust::device_vector<T>& device,
+        T v,
+        T*& host_ptr, int& host_n,
+        T*& device_ptr, int& device_n)
+{
+    host.push_back(v);
+    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
+}
+
+template <typename T>
+void resize_host(
+        thrust::host_vector<T>& host,
+        thrust::device_vector<T>& device,
+        size_t n,
+        T*& host_ptr, int& host_n,
+        T*& device_ptr, int& device_n)
+{
+    host.resize(n);
+    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
+}
+
+template <typename T>
+void resize_dev(
+        thrust::host_vector<T>& host,
+        thrust::device_vector<T>& device,
+        size_t n,
+        T*& host_ptr, int& host_n,
+        T*& device_ptr, int& device_n)
+{
+    THRUST_CHECK_ERROR(device.resize(n));
+    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
+}
+
+template <typename T>
+void copy_dev_to_host(
+        thrust::host_vector<T>& host,
+        thrust::device_vector<T>& device,
+        T*& host_ptr, int& host_n,
+        T*& device_ptr, int& device_n)
+{
+    host = device;
+    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
+}
+
+template <typename T>
+void copy_host_to_dev(
+        thrust::host_vector<T>& host,
+        thrust::device_vector<T>& device,
+        T*& host_ptr, int& host_n,
+        T*& device_ptr, int& device_n)
+{
+    device = host;
+    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
+}
+
+template <typename T>
+void clear_dev(
+        thrust::host_vector<T>& host,
+        thrust::device_vector<T>& device,
+        T*& host_ptr, int& host_n,
+        T*& device_ptr, int& device_n)
+{
+    device.clear();
+    device.shrink_to_fit();
+    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
+}
+
+template <typename T>
+void sync_device_ptr(
+        thrust::device_vector<T>& device,
+        T*& device_ptr, int& device_n)
+{
+    device_n = static_cast<int>(device.size());
+    device_ptr = device_n
+        ? thrust::raw_pointer_cast(&device[0]) : nullptr;
+}
+
+}  // namespace dyn_array
+
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 void sync_eventspace_{{ varname }}() {
     _num_dev{{ varname }} = static_cast<int>(dev{{ varname }}.size());
@@ -267,22 +356,28 @@ void sync_eventspace_{{ varname }}() {
 {% endfor %}
 {% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
 void sync_monitor_addresses_{{ varname }}() {
-    _num_monitor_addresses_{{ varname }} = static_cast<int>(addresses_monitor_{{ varname }}.size());
-    monitor_addresses_{{ varname }} = _num_monitor_addresses_{{ varname }}
-        ? thrust::raw_pointer_cast(&addresses_monitor_{{ varname }}[0]) : nullptr;
+    dyn_array::sync_device_ptr(
+        addresses_monitor_{{ varname }},
+        monitor_addresses_{{ varname }},
+        _num_monitor_addresses_{{ varname }});
 }
 {% endfor %}
 {% for varname in subgroups_with_spikemonitor %}
 void sync_subgroup_eventspace_{{varname}}() {
-    _num_subgroup_eventspace_{{varname}} = static_cast<int>(_dev_{{varname}}_eventspace.size());
-    dev_array_subgroup_eventspace_{{varname}} = _num_subgroup_eventspace_{{varname}}
-        ? thrust::raw_pointer_cast(&_dev_{{varname}}_eventspace[0]) : nullptr;
+    dyn_array::sync_device_ptr(
+        _dev_{{varname}}_eventspace,
+        dev_array_subgroup_eventspace_{{varname}},
+        _num_subgroup_eventspace_{{varname}});
 }
 {% endfor %}
 
 void sync_all_dev_ptrs() {
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-    sync_array_{{ varname[DYNAMIC_ARRAY_PREFIX_LEN:] }}();
+{% set N = array_basename(varname) %}
+    dyn_array::sync_host_dev(
+        {{ varname }}, dev{{ varname }},
+        host_array_{{ N }}, _num_host_array_{{ N }},
+        dev_array_{{ N }}, _num_dev_array_{{ N }});
 {% endfor %}
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
     sync_eventspace_{{ varname }}();
@@ -296,32 +391,42 @@ void sync_all_dev_ptrs() {
 }
 
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-{% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
+{% set N = array_basename(varname) %}
 void push_back_host_array_{{ N }}({{c_data_type(var.dtype)}} v) {
-    {{ varname }}.push_back(v);
-    sync_array_{{ N }}();
+    dyn_array::push_back_host(
+        {{ varname }}, dev{{ varname }}, v,
+        host_array_{{ N }}, _num_host_array_{{ N }},
+        dev_array_{{ N }}, _num_dev_array_{{ N }});
 }
 void resize_host_array_{{ N }}(size_t n) {
-    {{ varname }}.resize(n);
-    sync_array_{{ N }}();
+    dyn_array::resize_host(
+        {{ varname }}, dev{{ varname }}, n,
+        host_array_{{ N }}, _num_host_array_{{ N }},
+        dev_array_{{ N }}, _num_dev_array_{{ N }});
 }
 void resize_dev_array_{{ N }}(size_t n) {
-    THRUST_CHECK_ERROR(dev{{ varname }}.resize(n));
-    {{ varname }}.resize(n);
-    sync_array_{{ N }}();
+    dyn_array::resize_dev(
+        {{ varname }}, dev{{ varname }}, n,
+        host_array_{{ N }}, _num_host_array_{{ N }},
+        dev_array_{{ N }}, _num_dev_array_{{ N }});
 }
 void copy_dev_to_host_array_{{ N }}() {
-    {{ varname }} = dev{{ varname }};
-    sync_array_{{ N }}();
+    dyn_array::copy_dev_to_host(
+        {{ varname }}, dev{{ varname }},
+        host_array_{{ N }}, _num_host_array_{{ N }},
+        dev_array_{{ N }}, _num_dev_array_{{ N }});
 }
 void copy_host_to_dev_array_{{ N }}() {
-    dev{{ varname }} = {{ varname }};
-    sync_array_{{ N }}();
+    dyn_array::copy_host_to_dev(
+        {{ varname }}, dev{{ varname }},
+        host_array_{{ N }}, _num_host_array_{{ N }},
+        dev_array_{{ N }}, _num_dev_array_{{ N }});
 }
 void clear_dev_array_{{ N }}() {
-    dev{{ varname }}.clear();
-    dev{{ varname }}.shrink_to_fit();
-    sync_array_{{ N }}();
+    dyn_array::clear_dev(
+        {{ varname }}, dev{{ varname }},
+        host_array_{{ N }}, _num_host_array_{{ N }},
+        dev_array_{{ N }}, _num_dev_array_{{ N }});
 }
 {% endfor %}
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
@@ -353,20 +458,39 @@ void resize_subgroup_eventspace_{{varname}}(size_t n) {
     sync_subgroup_eventspace_{{varname}}();
 }
 {% endfor %}
-struct _subgroup_eventspace_pred {
+// Namespace-scope: nvcc/CUB reject local classes as thrust predicates.
+struct is_in_subgroup
+{
     int32_t start;
     int32_t stop;
-    __device__ bool operator()(int32_t neuron) const {
+
+    __host__ __device__
+    bool operator()(const int32_t& neuron) const
+    {
         return start <= neuron && neuron < stop;
     }
 };
+
 int filter_subgroup_eventspace(
         int32_t* src, int n, int32_t* dst, int32_t start, int32_t stop) {
-    thrust::device_ptr<int32_t> d_src(src);
-    thrust::device_ptr<int32_t> d_dst(dst);
-    auto out = thrust::copy_if(
-            d_src, d_src + n, d_dst, _subgroup_eventspace_pred{start, stop});
-    return static_cast<int>(out - d_dst);
+    if (n <= 0) return 0;
+
+    thrust::device_ptr<int32_t> src_ptr(src);
+    thrust::device_ptr<int32_t> dst_ptr(dst);
+    is_in_subgroup pred{start, stop};
+
+    // Count the elements in eventspace that are in the subgroup
+    int out_n = 0;
+    THRUST_CHECK_ERROR(
+        out_n = static_cast<int>(
+            thrust::count_if(src_ptr, src_ptr + n, pred)
+        )
+    );
+    // Copy all neuron IDs that are in this subgroup to the new device pointer
+    THRUST_CHECK_ERROR(
+        thrust::copy_if(src_ptr, src_ptr + n, dst_ptr, pred)
+    );
+    return out_n;
 }
 void curand_generate_normal_double(
         curandGenerator_t gen, double* out, size_t n, double mean, double stddev) {
@@ -407,14 +531,18 @@ void set_monitor_address_{{ varname }}(int row) {
 }
 {% endfor %}
 void sort_by_key_int_int32(int* keys, int32_t* values, size_t n) {
-    thrust::sort_by_key(thrust::host, keys, keys + n, values);
+    if (n <= 1) {
+        return;
+    }
+    thrust::sort_by_key(keys, keys + n, values);
 }
 void fill_sequence_int(int* out, size_t n) {
-    thrust::sequence(thrust::host, out, out + n);
+    thrust::sequence(out, out + n);
 }
 size_t unique_by_key_int_int(int* keys, int* values, size_t n) {
-    return static_cast<size_t>(thrust::unique_by_key(
-        thrust::host, keys, keys + n, values).first - keys);
+    if (n == 0) return 0;
+    auto out_pair = thrust::unique_by_key(keys, keys + n, values);
+    return static_cast<size_t>(out_pair.first - keys);
 }
 }  // namespace brian
 
@@ -889,8 +1017,6 @@ typedef struct curandStateXORWOW curandState;
 #include <chrono>
 {% endif %}
 
-// Forward declarations; TUs that access members include
-// "network.h" / "synapses_classes.h" directly.
 class Network;
 {% if synapses %}
 class SynapticPathway;
@@ -950,10 +1076,8 @@ extern const int _num_{{name}};
 {% endfor %}
 
 //////////////// dynamic arrays 1d ///////////
-{# varname is '_dynamic_array_<name>'; expose <name> only #}
-{% set DYNAMIC_ARRAY_PREFIX_LEN = 15 %}  {# len('_dynamic_array_') #}
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-{% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
+{% set N = array_basename(varname) %}
 extern {{c_data_type(var.dtype)}}* host_array_{{ N }};
 extern int _num_host_array_{{ N }};
 extern {{c_data_type(var.dtype)}}* dev_array_{{ N }};
@@ -1114,9 +1238,8 @@ int filter_subgroup_eventspace(int32_t* src, int n, int32_t* dst, int32_t start,
 {% for varname in subgroups_with_spikemonitor %}
 void resize_subgroup_eventspace_{{varname}}(size_t n);
 {% endfor %}
-{% set DYNAMIC_ARRAY_PREFIX_LEN = 15 %}  {# len('_dynamic_array_') #}
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-{% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
+{% set N = array_basename(varname) %}
 void resize_host_array_{{ N }}(size_t n);
 void push_back_host_array_{{ N }}({{c_data_type(var.dtype)}} v);
 void resize_dev_array_{{ N }}(size_t n);

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -216,6 +216,47 @@ thrust::device_vector<{{c_data_type(var.dtype)}}*> brian::addresses_monitor_{{va
 thrust::device_vector<{{c_data_type(var.dtype)}}>* brian::{{varname}};
 {% endfor %}
 
+// PIMPL: bare pointers synced from Thrust containers (for lean COs without objects_thrust.h).
+// varname is '_dynamic_array_<name>'; PIMPL symbols use <name> only.
+{% set DYNAMIC_ARRAY_PREFIX_LEN = 15 %}  {# len('_dynamic_array_') #}
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
+{{c_data_type(var.dtype)}}* brian::host_array_{{ N }} = nullptr;
+int brian::_num_host_array_{{ N }} = 0;
+{{c_data_type(var.dtype)}}* brian::dev_array_{{ N }} = nullptr;
+int brian::_num_dev_array_{{ N }} = 0;
+{% endfor %}
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+{{c_data_type(var.dtype)}}** brian::dev{{ varname }}_view = nullptr;
+{% endfor %}
+
+namespace brian {
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
+void sync_array_{{ N }}() {
+    _num_host_array_{{ N }} = static_cast<int>({{ varname }}.size());
+    host_array_{{ N }} = _num_host_array_{{ N }} ? &{{ varname }}[0] : nullptr;
+    _num_dev_array_{{ N }} = static_cast<int>(dev{{ varname }}.size());
+    dev_array_{{ N }} = _num_dev_array_{{ N }}
+        ? thrust::raw_pointer_cast(&dev{{ varname }}[0]) : nullptr;
+}
+{% endfor %}
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+void sync_eventspace_{{ varname }}() {
+    dev{{ varname }}_view = dev{{ varname }}.empty() ? nullptr : &dev{{ varname }}[0];
+}
+{% endfor %}
+
+void sync_all_dev_ptrs() {
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+    sync_array_{{ varname[DYNAMIC_ARRAY_PREFIX_LEN:] }}();
+{% endfor %}
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+    sync_eventspace_{{ varname }}();
+{% endfor %}
+}
+}
+
 /////////////// static arrays /////////////
 {% for (name, dtype_spec, N, filename) in static_array_specs | sort %}
 {# arrays that are initialized from static data are already declared #}
@@ -444,6 +485,8 @@ void _init_arrays()
         )
     );
     {% endfor %}
+
+    sync_all_dev_ptrs();
 
     CUDA_CHECK_MEMORY();
     const double to_MB = 1.0 / (1024.0 * 1024.0);
@@ -756,9 +799,20 @@ extern const int _num_{{varname}};
 {% endif %}
 {% endfor %}
 
+//////////////// dynamic array PIMPL pointers ///////////
+{% set DYNAMIC_ARRAY_PREFIX_LEN = 15 %}  {# len('_dynamic_array_') #}
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
+extern {{c_data_type(var.dtype)}}* host_array_{{ N }};
+extern int _num_host_array_{{ N }};
+extern {{c_data_type(var.dtype)}}* dev_array_{{ N }};
+extern int _num_dev_array_{{ N }};
+{% endfor %}
+
 //////////////// eventspaces ///////////////
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 extern {{c_data_type(var.dtype)}} * {{varname}};
+extern {{c_data_type(var.dtype)}}** dev{{varname}}_view;
 extern const int _num_{{varname}};
 extern int current_idx{{varname}};
 {% if varname in spikegenerator_eventspaces %}
@@ -828,6 +882,8 @@ extern int max_threads_per_block;
 extern int max_threads_per_sm;
 extern int max_shared_mem_size;
 extern int num_threads_per_warp;
+
+void sync_all_dev_ptrs();
 
 }
 

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -14,21 +14,13 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 {% endif %}
 {%- endmacro %}
 
+#include "objects_thrust.h"
 #include "objects.h"
-#include "synapses_classes.h"
-#include "brianlib/clocks.h"
 #include "brianlib/cuda_utils.h"
-#include "network.h"
 #include "rand.h"
-#include <stdint.h>
 #include <iostream>
 #include <fstream>
 #include <chrono>
-#include <ctime>
-#include <utility>
-
-#include <thrust/host_vector.h>
-#include <thrust/device_vector.h>
 #include <curand.h>
 #include <curand_kernel.h>
 
@@ -730,26 +722,34 @@ void _dealloc_arrays()
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 
 {% macro h_file() %}
-#include <ctime>
+
 // typedefs need to be outside the include guards to
 // be visible to all files including objects.h
 typedef {{curand_float_type}} randomNumber_t;  // random number type
 
+struct curandGenerator_st;
+typedef struct curandGenerator_st* curandGenerator_t;
+#ifndef CURAND_KERNEL_H_
+struct curandStateXORWOW;
+typedef struct curandStateXORWOW curandState;
+#endif
+
 #ifndef _BRIAN_OBJECTS_H
 #define _BRIAN_OBJECTS_H
 
-#include<vector>
-#include<stdint.h>
-#include "synapses_classes.h"
+#include <vector>
+#include <string>
+#include <stdint.h>
 #include "brianlib/clocks.h"
 #include "network.h"
-#include "rand.h"
-
-#include <thrust/device_vector.h>
-#include <thrust/host_vector.h>
+{% if synapses %}
+#include "synapses_classes.h"
+{% endif %}
+{% if profiled_codeobjects is defined %}
 #include <chrono>
-#include <curand.h>
-#include <curand_kernel.h>
+{% endif %}
+
+class RandomNumberBuffer;
 
 namespace brian {
 
@@ -772,14 +772,6 @@ extern Network {{net.name}};
 
 extern void set_variable_by_name(std::string, std::string);
 
-//////////////// dynamic arrays 1d ///////////
-{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-extern thrust::host_vector<{{c_data_type(var.dtype)}}> {{varname}};
-extern thrust::device_vector<{{c_data_type(var.dtype)}}> dev{{varname}};
-{% endfor %}
-{% for varname in subgroups_with_spikemonitor %}
-extern thrust::device_vector<int32_t> _dev_{{varname}}_eventspace;
-{% endfor %}
 
 //////////////// arrays ///////////////////
 {% for var, varname in array_specs | dictsort(by='value') %}
@@ -794,18 +786,11 @@ extern const int _num_{{varname}};
 //////////////// eventspaces ///////////////
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 extern {{c_data_type(var.dtype)}} * {{varname}};
-extern thrust::host_vector<{{c_data_type(var.dtype)}}*> dev{{varname}};
 extern const int _num_{{varname}};
 extern int current_idx{{varname}};
 {% if varname in spikegenerator_eventspaces %}
 extern int previous_idx{{varname}};
 {% endif %}
-{% endfor %}
-
-//////////////// dynamic arrays 2d /////////
-{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
-extern thrust::device_vector<{{c_data_type(var.dtype)}}*> addresses_monitor_{{varname}};
-extern thrust::device_vector<{{c_data_type(var.dtype)}}>* {{varname}};
 {% endfor %}
 
 /////////////// static arrays /////////////
@@ -906,4 +891,38 @@ void _dealloc_arrays();
 #endif
 
 
+{% endmacro %}
+
+{% macro h_thrust_file() %}
+#include "objects.h"
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+#ifndef _BRIAN_OBJECTS_THRUST_H
+#define _BRIAN_OBJECTS_THRUST_H
+
+namespace brian {
+
+//////////////// dynamic arrays 1d ///////////
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+extern thrust::host_vector<{{c_data_type(var.dtype)}}> {{varname}};
+extern thrust::device_vector<{{c_data_type(var.dtype)}}> dev{{varname}};
+{% endfor %}
+{% for varname in subgroups_with_spikemonitor %}
+extern thrust::device_vector<int32_t> _dev_{{varname}}_eventspace;
+{% endfor %}
+
+//////////////// eventspaces ///////////////
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+extern thrust::host_vector<{{c_data_type(var.dtype)}}*> dev{{varname}};
+{% endfor %}
+
+//////////////// dynamic arrays 2d /////////
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+extern thrust::device_vector<{{c_data_type(var.dtype)}}*> addresses_monitor_{{varname}};
+extern thrust::device_vector<{{c_data_type(var.dtype)}}>* {{varname}};
+{% endfor %}
+
+}
+#endif // _BRIAN_OBJECTS_THRUST_H
 {% endmacro %}

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -222,8 +222,7 @@ thrust::device_vector<{{c_data_type(var.dtype)}}*> brian::addresses_monitor_{{va
 thrust::device_vector<{{c_data_type(var.dtype)}}>* brian::{{varname}};
 {% endfor %}
 
-// PIMPL: bare pointers synced from Thrust containers.
-// varname is '_dynamic_array_<name>'; PIMPL symbols use <name> only.
+// varname is '_dynamic_array_<name>'; exposed symbols use <name> only.
 {% set DYNAMIC_ARRAY_PREFIX_LEN = 15 %}  {# len('_dynamic_array_') #}
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
 {% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
@@ -977,7 +976,7 @@ extern const int _num_{{name}};
 {% endif %}
 {% endfor %}
 
-//////////////// dynamic arrays 1d (pimpl pointers) ///////////
+//////////////// dynamic arrays 1d ///////////
 {# varname is '_dynamic_array_<name>'; expose <name> only #}
 {% set DYNAMIC_ARRAY_PREFIX_LEN = 15 %}  {# len('_dynamic_array_') #}
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
@@ -988,19 +987,19 @@ extern {{c_data_type(var.dtype)}}* dev_array_{{ N }};
 extern int _num_dev_array_{{ N }};
 {% endfor %}
 
-//////////////// eventspaces (pimpl pointers) ///////////////
+//////////////// eventspaces (synced views) ///////////////
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 extern {{c_data_type(var.dtype)}}** dev{{ varname }}_view;
 extern int _num_dev{{ varname }};
 {% endfor %}
 
-//////////////// dynamic arrays 2d (pimpl pointers) ///////////////
+//////////////// dynamic arrays 2d (synced views) ///////////////
 {% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
 extern {{c_data_type(var.dtype)}}** monitor_addresses_{{ varname }};
 extern int _num_monitor_addresses_{{ varname }};
 {% endfor %}
 
-//////////////// subgroup eventspace buffers (pimpl pointers) ///////////////
+//////////////// subgroup eventspace buffers ///////////////
 {% for varname in subgroups_with_spikemonitor %}
 extern int32_t* dev_array_subgroup_eventspace_{{varname}};
 extern int _num_subgroup_eventspace_{{varname}};
@@ -1116,7 +1115,6 @@ typedef struct curandGenerator_st* curandGenerator_t;
 
 namespace brian {
 
-{# Public: full refresh after _init_arrays. Per-array sync_* stay internal to objects.cu. #}
 void sync_all_dev_ptrs();
 
 void random_number_buffer_set_seed(unsigned long long seed);

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -65,18 +65,18 @@ template<class T> void set_variable_from_value(std::string varname, T* var_point
 }
 
 template<class T> void set_variable_from_file(std::string varname, T* var_pointer, size_t data_size, std::string filename) {
-    ifstream f;
-    streampos size;
+    std::ifstream f;
+    std::streampos size;
     #ifdef DEBUG
     std::cout << "Setting '" << varname << "' from file '" << filename << "'" << std::endl;
     #endif
-    f.open(filename, ios::in | ios::binary | ios::ate);
+    f.open(filename, std::ios::in | std::ios::binary | std::ios::ate);
     size = f.tellg();
     if (size != data_size) {
         std::cerr << "Error reading '" << filename << "': file size " << size << " does not match expected size " << data_size << std::endl;
         return;
     }
-    f.seekg(0, ios::beg);
+    f.seekg(0, std::ios::beg);
     if (f.is_open())
         f.read(reinterpret_cast<char *>(var_pointer), data_size);
     else

--- a/brian2cuda/templates/rand.cu
+++ b/brian2cuda/templates/rand.cu
@@ -8,6 +8,7 @@
 #define BRIAN2CUDA_CURAND_HOST
 #include "brianlib/cuda_utils.h"
 #include "network.h"
+#include <cassert>
 #include <curand.h>
 #include <ctime>
 #include <curand_kernel.h>

--- a/brian2cuda/templates/rand.cu
+++ b/brian2cuda/templates/rand.cu
@@ -4,6 +4,7 @@
 #include "rand.h"
 #include "synapses_classes.h"
 #include "brianlib/clocks.h"
+#define BRIAN2CUDA_CURAND_HOST
 #include "brianlib/cuda_utils.h"
 #include "network.h"
 #include <curand.h>
@@ -14,6 +15,32 @@
 //      https://github.com/brian-team/brian2cuda/wiki/Random-number-generation
 
 using namespace brian;
+
+//////////////random numbers//////////////////
+curandGenerator_t brian::curand_generator;
+__device__ unsigned long long* brian::d_curand_seed;
+unsigned long long* brian::dev_curand_seed;
+// dev_{co.name}_{rng_type}_allocator
+//      pointer to start of generated random numbers array
+//      at each generation cycle this array is refilled
+// dev_{co.name}_{rng_type}
+//      pointer moving through generated random number array
+//      until it is regenerated at the next generation cycle
+{% for rng_type in all_codeobj_with_host_rng.keys() %}
+{% for co in all_codeobj_with_host_rng[rng_type] | sort(attribute='name') %}
+{% if rng_type in ['rand', 'randn'] %}
+{% set dtype = 'randomNumber_t' %}
+{% else %}  {# rng_type = 'poisson_<idx>' #}
+{% set dtype = 'unsigned int' %}
+{% endif %}
+{{dtype}}* brian::dev_{{co.name}}_{{rng_type}}_allocator;
+{{dtype}}* brian::dev_{{co.name}}_{{rng_type}};
+__device__ {{dtype}}* brian::_array_{{co.name}}_{{rng_type}};
+{% endfor %}{# rng_type #}
+{% endfor %}{# co #}
+curandState* brian::dev_curand_states;
+__device__ curandState* brian::d_curand_states;
+RandomNumberBuffer brian::random_number_buffer;
 
 // TODO make this a class member function
 // TODO don't call one kernel per codeobject but instead on kernel which takes
@@ -47,7 +74,7 @@ namespace {
 // method, which is of different type
 void _run_random_number_buffer()
 {
-    // random_number_buffer is a RandomNumberBuffer instance, declared in objects.cu
+    // random_number_buffer is a RandomNumberBuffer instance, declared in rand.cu
     random_number_buffer.next_time_step();
 }
 
@@ -470,7 +497,7 @@ void RandomNumberBuffer::next_time_step()
 #ifndef _BRIAN_RAND_H
 #define _BRIAN_RAND_H
 
-#include <curand.h>
+#include "objects.h"
 
 void _run_random_number_buffer();
 
@@ -559,6 +586,35 @@ public:
     void run_finished();
     void ensure_enough_curand_states();
 };
+
+namespace brian {
+
+//////////////// random numbers /////////////////
+extern curandGenerator_t curand_generator;
+extern unsigned long long* dev_curand_seed;
+extern __device__ unsigned long long* d_curand_seed;
+
+{% for rng_type in all_codeobj_with_host_rng.keys() %}
+{% for co in all_codeobj_with_host_rng[rng_type] | sort(attribute='name') %}
+{% if rng_type in ['rand', 'randn'] %}
+{% set dtype = 'randomNumber_t' %}
+{% else %}  {# rng_type = 'poisson_<idx>' #}
+{% set dtype = 'unsigned int' %}
+{% endif %}
+// pointer to start of generated random numbers array
+// at each generation cycle this array is refilled
+extern {{dtype}}* dev_{{co.name}}_{{rng_type}}_allocator;
+// pointer moving through generated random number array
+// until it is regenerated at the next generation cycle
+extern {{dtype}}* dev_{{co.name}}_{{rng_type}};
+extern __device__ {{dtype}}* _array_{{co.name}}_{{rng_type}};
+{% endfor %}{# rng_type #}
+{% endfor %}{# co #}
+extern curandState* dev_curand_states;
+extern __device__ curandState* d_curand_states;
+extern RandomNumberBuffer random_number_buffer;
+
+}
 
 #endif
 

--- a/brian2cuda/templates/rand.cu
+++ b/brian2cuda/templates/rand.cu
@@ -1,6 +1,7 @@
 {% macro cu_file() %}
 
 #include "objects.h"
+#include "objects_api.h"
 #include "rand.h"
 #include "synapses_classes.h"
 #include "brianlib/clocks.h"
@@ -488,6 +489,26 @@ void RandomNumberBuffer::next_time_step()
     }// run_counter == {{run_i}}
     {% endfor %}{# run_i #}
 }
+
+namespace brian {
+
+void random_number_buffer_set_seed(unsigned long long seed)
+{
+    random_number_buffer.set_seed(seed);
+}
+
+void random_number_buffer_ensure_enough_curand_states()
+{
+    random_number_buffer.ensure_enough_curand_states();
+}
+
+void random_number_buffer_run_finished()
+{
+    random_number_buffer.run_finished();
+}
+
+}  // namespace brian
+
 {% endmacro %}
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/brian2cuda/templates/rand.cu
+++ b/brian2cuda/templates/rand.cu
@@ -76,7 +76,6 @@ namespace {
 // method, which is of different type
 void _run_random_number_buffer()
 {
-    // random_number_buffer is a RandomNumberBuffer instance, declared in rand.cu
     random_number_buffer.next_time_step();
 }
 

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -17,10 +17,10 @@ static int start_offset = current_iteration;
 
 {% block prepare_kernel_inner %}
 int num_iterations = {{owner.clock.name}}.i_end;
-int size_till_now = _num_dev_array_{{ _dynamic_t[15:] }};
+int size_till_now = _num_dev_array_{{ array_basename(_dynamic_t) }};
 int new_size = num_iterations + size_till_now - start_offset;
-resize_dev_array_{{ _dynamic_t[15:] }}(new_size);
-resize_dev_array_{{ _dynamic_rate[15:] }}(new_size);
+resize_dev_array_{{ array_basename(_dynamic_t) }}(new_size);
+resize_dev_array_{{ array_basename(_dynamic_rate) }}(new_size);
 // Update size variables for Python side indexing to work
 // (Note: Need to update device variable which will be copied to host in write_arrays())
 _array_{{owner.name}}_N[0] = new_size;
@@ -36,8 +36,8 @@ num_blocks = 1;
 {% block kernel_call %}
 _run_kernel_{{codeobj_name}}<<<num_blocks, num_threads>>>(
     current_iteration - start_offset,
-    dev_array_{{ _dynamic_rate[15:] }},
-    dev_array_{{ _dynamic_t[15:] }},
+    dev_array_{{ array_basename(_dynamic_rate) }},
+    dev_array_{{ array_basename(_dynamic_t) }},
     ///// HOST_PARAMETERS /////
     %HOST_PARAMETERS%);
 

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -2,6 +2,9 @@
                     _num_source_neurons, _source_start, _source_stop } #}
 {# WRITES_TO_READ_ONLY_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
+{% block extra_headers}
+#include "objects_thrust.h"
+{% endblock %}
 
 {% block define_N %}
 {% endblock %}

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -3,7 +3,7 @@
 {# WRITES_TO_READ_ONLY_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 {% endblock %}
 
 {% block define_N %}

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -2,7 +2,7 @@
                     _num_source_neurons, _source_start, _source_stop } #}
 {# WRITES_TO_READ_ONLY_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
-{% block extra_headers}
+{% block extra_headers %}
 #include "objects_thrust.h"
 {% endblock %}
 

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -2,8 +2,9 @@
                     _num_source_neurons, _source_start, _source_stop } #}
 {# WRITES_TO_READ_ONLY_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
+
 {% block extra_headers %}
-#include "objects_storage.h"
+#include "objects_api.h"
 {% endblock %}
 
 {% block define_N %}
@@ -16,14 +17,10 @@ static int start_offset = current_iteration;
 
 {% block prepare_kernel_inner %}
 int num_iterations = {{owner.clock.name}}.i_end;
-int size_till_now = dev{{_dynamic_t}}.size();
+int size_till_now = _num_dev_array_{{ _dynamic_t[15:] }};
 int new_size = num_iterations + size_till_now - start_offset;
-THRUST_CHECK_ERROR(
-        dev{{_dynamic_t}}.resize(new_size)
-        );
-THRUST_CHECK_ERROR(
-        dev{{_dynamic_rate}}.resize(new_size)
-        );
+resize_dev_array_{{ _dynamic_t[15:] }}(new_size);
+resize_dev_array_{{ _dynamic_rate[15:] }}(new_size);
 // Update size variables for Python side indexing to work
 // (Note: Need to update device variable which will be copied to host in write_arrays())
 _array_{{owner.name}}_N[0] = new_size;
@@ -39,8 +36,8 @@ num_blocks = 1;
 {% block kernel_call %}
 _run_kernel_{{codeobj_name}}<<<num_blocks, num_threads>>>(
     current_iteration - start_offset,
-    thrust::raw_pointer_cast(&(dev{{_dynamic_rate}}[0])),
-    thrust::raw_pointer_cast(&(dev{{_dynamic_t}}[0])),
+    dev_array_{{ _dynamic_rate[15:] }},
+    dev_array_{{ _dynamic_t[15:] }},
     ///// HOST_PARAMETERS /////
     %HOST_PARAMETERS%);
 

--- a/brian2cuda/templates/reset.cu
+++ b/brian2cuda/templates/reset.cu
@@ -1,5 +1,9 @@
 {# USES_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}
+
 {% block kernel_maincode %}
 
     {#  Get the name of the array that stores these events (e.g. the spikespace array) #}

--- a/brian2cuda/templates/reset.cu
+++ b/brian2cuda/templates/reset.cu
@@ -1,8 +1,5 @@
 {# USES_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
-{% block extra_headers %}
-#include "objects_thrust.h"
-{% endblock %}
 
 {% block kernel_maincode %}
 

--- a/brian2cuda/templates/run.cu
+++ b/brian2cuda/templates/run.cu
@@ -2,6 +2,7 @@
 #include<stdlib.h>
 #include "brianlib/cuda_utils.h"
 #include "objects.h"
+#include "rand.h"
 #include<ctime>
 
 {% for codeobj in code_objects | sort(attribute='name') %}

--- a/brian2cuda/templates/run.cu
+++ b/brian2cuda/templates/run.cu
@@ -2,6 +2,7 @@
 #include<stdlib.h>
 #include "brianlib/cuda_utils.h"
 #include "objects.h"
+#include "network.h"
 #include "rand.h"
 #include<ctime>
 

--- a/brian2cuda/templates/spatialstateupdate.cu
+++ b/brian2cuda/templates/spatialstateupdate.cu
@@ -12,9 +12,6 @@
 
 
 {% extends 'common_group.cu' %}
-{% block extra_headers %}
-#include "objects_thrust.h"
-{% endblock %}
 
 
 {### BEFORE RUN ###}

--- a/brian2cuda/templates/spatialstateupdate.cu
+++ b/brian2cuda/templates/spatialstateupdate.cu
@@ -12,6 +12,9 @@
 
 
 {% extends 'common_group.cu' %}
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}
 
 
 {### BEFORE RUN ###}

--- a/brian2cuda/templates/spikegenerator.cu
+++ b/brian2cuda/templates/spikegenerator.cu
@@ -38,6 +38,9 @@
                    t_in_timesteps, N}
 #}
 {% extends 'common_group.cu' %}
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}
 {% block kernel_maincode %}
     // The period in multiples of dt
     const int32_t _the_period = {{_period_bins}};

--- a/brian2cuda/templates/spikegenerator.cu
+++ b/brian2cuda/templates/spikegenerator.cu
@@ -39,7 +39,7 @@
 #}
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 {% endblock %}
 {% block kernel_maincode %}
     // The period in multiples of dt

--- a/brian2cuda/templates/spikegenerator.cu
+++ b/brian2cuda/templates/spikegenerator.cu
@@ -38,9 +38,6 @@
                    t_in_timesteps, N}
 #}
 {% extends 'common_group.cu' %}
-{% block extra_headers %}
-#include "objects_storage.h"
-{% endblock %}
 {% block kernel_maincode %}
     // The period in multiples of dt
     const int32_t _the_period = {{_period_bins}};
@@ -142,7 +139,7 @@
     // Note: If we have no delays, there is only one spikespace and
     //       current_idx equals previous_idx.
     _reset_{{codeobj_name}}<<<num_blocks, num_threads>>>(
-            dev{{_spikespace_name}}[previous_idx{{_spikespace_name}}],
+            dev{{ _spikespace_name }}_view[previous_idx{{ _spikespace_name }}],
             ///// HOST_PARAMETERS /////
             %HOST_PARAMETERS%
         );

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -55,7 +55,8 @@ CUDA_SAFE_CALL(
 
 {# TODO: Use isintance instead (needs to be made available in Jinja templates) #}
 {% if owner.source.__class__.__name__ == 'Subgroup' %}
-// Filter eventspace to subgroup neurons (implementation in objects.cu)
+// Count the elements in eventspace that are in the subgroup
+// Copy all neuron IDs that are in this subgroup to the new device pointer
 _N = filter_subgroup_eventspace(
         _eventspace,
         _num_events,
@@ -63,6 +64,7 @@ _N = filter_subgroup_eventspace(
         {{_source_start}},
         {{_source_stop}}
         );
+// Use same kernel as without subgroups on copied subgroup eventspace
 _eventspace = dev_array_subgroup_eventspace_{{owner.source.name}};
 {% else %}{# not is_subgroup #}
 // Get the number of events
@@ -77,12 +79,12 @@ _N = _num_events;
 {% set var = record_variables.values() | first %}
 {% set dyn_name = get_array_name(var, access_data=False) %}
 // Get current size of device vectors
-int _monitor_size = _num_dev_array_{{ dyn_name[15:] }};
+int _monitor_size = _num_dev_array_{{ array_basename(dyn_name) }};
 
 // Increase device vectors based on number of events
 {% for varname, var in record_variables.items() %}
 {% set dyn_name = get_array_name(var, access_data=False) %}
-resize_dev_array_{{ dyn_name[15:] }}(_monitor_size + _N);
+resize_dev_array_{{ array_basename(dyn_name) }}(_monitor_size + _N);
 {% endfor %}
 {% endif %}{# not record_variables #}
 
@@ -101,7 +103,7 @@ if (_N > 0)
             _eventspace,
             {% for varname, var in record_variables.items() %}
             {% set dyn_name = get_array_name(var, access_data=False) %}
-            dev_array_{{ dyn_name[15:] }},
+            dev_array_{{ array_basename(dyn_name) }},
             {% endfor %}
             ///// HOST_PARAMETERS /////
             %HOST_PARAMETERS%

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -4,25 +4,9 @@
 
 
 {% block extra_headers %}
-#include "objects_storage.h"
-#include <thrust/copy.h>
-#include <thrust/count.h>
-#include <thrust/execution_policy.h>
+#include "objects_api.h"
+#include <cassert>
 {% endblock %}
-
-
-{% block extra_device_helper %}
-{% if owner.source.__class__.__name__ == 'Subgroup' %}
-struct is_in_subgroup
-{
-  __device__
-  bool operator()(const int32_t &neuron)
-  {
-    return ({{_source_start}} <= neuron && neuron < {{_source_stop}});
-  }
-};
-{% endif %}{# Subgroup #}
-{% endblock extra_device_helper %}
 
 
 {# We change _N depending on number of events and subgroups #}
@@ -41,10 +25,7 @@ int num_events, num_blocks;
 
 {% block modify_kernel_dimensions %}
 {% if owner.source.__class__.__name__ == 'Subgroup' %}
-// Initialize device vector for subgroup eventspace
-THRUST_CHECK_ERROR(
-    _dev_{{owner.source.name}}_eventspace.resize(_num_source_idx)
-);
+resize_subgroup_eventspace_{{owner.source.name}}(_num_source_idx);
 {% endif %}{# Subgroup #}
 {% endblock %}
 
@@ -61,8 +42,8 @@ THRUST_CHECK_ERROR(
    neurons are part of the subgroup). #}
 
 // Number of events in eventspace
-int _num_events, _num_events_subgroup;
-int32_t* _eventspace = dev{{_eventspace}}[current_idx{{_eventspace}}];
+int _num_events;
+int32_t* _eventspace = dev{{ _eventspace }}_view[current_idx{{ _eventspace }}];
 CUDA_SAFE_CALL(
         cudaMemcpy(
             &_num_events,
@@ -74,26 +55,15 @@ CUDA_SAFE_CALL(
 
 {# TODO: Use isintance instead (needs to be made available in Jinja templates) #}
 {% if owner.source.__class__.__name__ == 'Subgroup' %}
-// Count the elements in eventspace that are in the subgroup
-thrust::device_ptr<int32_t> _dev_eventspace(_eventspace);
-THRUST_CHECK_ERROR(
-    _N = thrust::count_if(
-        _dev_eventspace,
-        _dev_eventspace + _num_events,
-        is_in_subgroup()
-    )
-);
-// Copy all neuron IDs that are in this subgroup to the new device pointer
-THRUST_CHECK_ERROR(
-    thrust::copy_if(
-        _dev_eventspace,
-        _dev_eventspace + _num_events,
-        _dev_{{owner.source.name}}_eventspace.begin(),
-        is_in_subgroup()
-    )
-);
-// Use same kernel as without subgroups on copied subgroup eventspace
-_eventspace = thrust::raw_pointer_cast(&_dev_{{owner.source.name}}_eventspace[0]);
+// Filter eventspace to subgroup neurons (implementation in objects.cu)
+_N = filter_subgroup_eventspace(
+        _eventspace,
+        _num_events,
+        dev_array_subgroup_eventspace_{{owner.source.name}},
+        {{_source_start}},
+        {{_source_stop}}
+        );
+_eventspace = dev_array_subgroup_eventspace_{{owner.source.name}};
 {% else %}{# not is_subgroup #}
 // Get the number of events
 _N = _num_events;
@@ -105,16 +75,14 @@ _N = _num_events;
    because the pointers underlying the device vectors change when resizing
    leads to memory reallocation) #}
 {% set var = record_variables.values() | first %}
-{% set dev_array_name = get_array_name(var, access_data=False, prefix='dev') %}
+{% set dyn_name = get_array_name(var, access_data=False) %}
 // Get current size of device vectors
-int _monitor_size = {{dev_array_name}}.size();
+int _monitor_size = _num_dev_array_{{ dyn_name[15:] }};
 
 // Increase device vectors based on number of events
 {% for varname, var in record_variables.items() %}
-{% set dev_array_name = get_array_name(var, access_data=False, prefix='dev') %}
-THRUST_CHECK_ERROR(
-        {{dev_array_name}}.resize(_monitor_size + _N)
-        );
+{% set dyn_name = get_array_name(var, access_data=False) %}
+resize_dev_array_{{ dyn_name[15:] }}(_monitor_size + _N);
 {% endfor %}
 {% endif %}{# not record_variables #}
 
@@ -131,12 +99,9 @@ if (_N > 0)
             _monitor_size,
             {% endif %}
             _eventspace,
-            {# We need to get a new raw_pointer_cast because the thrust vectors
-               were resized, which changes the underlying data pointer if memory
-               has to be reallocated #}
             {% for varname, var in record_variables.items() %}
-            {% set dev_array_name = get_array_name(var, access_data=False, prefix='dev') %}
-            thrust::raw_pointer_cast(&{{dev_array_name}}[0]),
+            {% set dyn_name = get_array_name(var, access_data=False) %}
+            dev_array_{{ dyn_name[15:] }},
             {% endfor %}
             ///// HOST_PARAMETERS /////
             %HOST_PARAMETERS%
@@ -165,8 +130,7 @@ _array_{{owner.name}}_N[0] += _N;
 
 {% block kernel_maincode %}
 {# We pass as _eventspace the filtered eventspace, such that all neuron IDs are
-   within the subgroup (if this is one). We take care of that with the
-   thrust::copy_if above. #}
+   within the subgroup (if this is one). Filtering is done via objects_api. #}
 
 // Eventspace is filled from left with all neuron IDs that triggered an event, rest -1
 int32_t spiking_neuron = _eventspace[_idx];

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -4,6 +4,7 @@
 
 
 {% block extra_headers %}
+#include "objects_thrust.h"
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -4,7 +4,7 @@
 
 
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>

--- a/brian2cuda/templates/statemonitor.cu
+++ b/brian2cuda/templates/statemonitor.cu
@@ -1,8 +1,9 @@
 {# USES_VARIABLES { t, _indices, N } #}
 {# WRITES_TO_READ_ONLY_VARIABLES { t, N } #}
 {% extends 'common_group.cu' %}
+
 {% block extra_headers %}
-#include "objects_storage.h"
+#include "objects_api.h"
 {% endblock %}
 
 {% block define_N %}
@@ -12,14 +13,14 @@
 {% block modify_kernel_dimensions %}
 {% for varname, var in _recorded_variables | dictsort %}
 {% set _recorded = get_array_name(var, access_data=False) %}
-addresses_monitor_{{_recorded}}.clear();
+clear_monitor_addresses_{{ _recorded }}();
 {% endfor %}
 for(int i = 0; i < _num__array_{{owner.name}}__indices; i++)
 {
     {% for varname, var in _recorded_variables | dictsort %}
     {% set _recorded = get_array_name(var, access_data=False) %}
-    {{_recorded}}[i].resize(_numt_host + num_iterations - current_iteration);
-    addresses_monitor_{{_recorded}}.push_back(thrust::raw_pointer_cast(&{{_recorded}}[i][0]));
+    resize_monitor_row_{{ _recorded }}(i, _numt_host + num_iterations - current_iteration);
+    push_monitor_address_{{ _recorded }}(i);
     {% endfor %}
 }
 {% endblock modify_kernel_dimensions %}
@@ -33,10 +34,10 @@ const int _N = _num_indices;
 
 // We are using an extra variable because HOST_CONSTANTS uses the device vector, which
 // is not used (TODO: Fix this in HOST_CONSTANTS instead of this hack here...)
-const int _numt_host = _dynamic_array_{{owner.name}}_t.size();
+const int _numt_host = _num_host_array_{{ owner.name }}_t;
 
 // We push t only on host and don't make a device->host copy in write_arrays()
-_dynamic_array_{{owner.name}}_t.push_back({{owner.clock.name}}.t[0]);
+push_back_host_array_{{ owner.name }}_t({{ owner.clock.name }}.t[0]);
 
 // Update size variables for Python side indexing to work
 _array_{{owner.name}}_N[0] += 1;
@@ -56,8 +57,8 @@ if(current_iteration >= num_iterations)
     {
         {% for varname, var in _recorded_variables | dictsort %}
         {% set _recorded =  get_array_name(var, access_data=False) %}
-        {{_recorded}}[i].resize(_numt_host + 1);
-        addresses_monitor_{{_recorded}}[i] = thrust::raw_pointer_cast(&{{_recorded}}[i][0]);
+        resize_monitor_row_{{ _recorded }}(i, _numt_host + 1);
+        set_monitor_address_{{ _recorded }}(i);
         {% endfor %}
     }
 }
@@ -99,6 +100,6 @@ if (_num__array_{{owner.name}}__indices > 0)
     current_iteration - start_offset,
     {% for varname, var in _recorded_variables | dictsort %}
     {% set _recorded =  get_array_name(var, access_data=False) %}
-    thrust::raw_pointer_cast(&addresses_monitor_{{_recorded}}[0]),
+    monitor_addresses_{{ _recorded }},
     {% endfor %}
 {% endblock %}

--- a/brian2cuda/templates/statemonitor.cu
+++ b/brian2cuda/templates/statemonitor.cu
@@ -2,7 +2,7 @@
 {# WRITES_TO_READ_ONLY_VARIABLES { t, N } #}
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 {% endblock %}
 
 {% block define_N %}

--- a/brian2cuda/templates/statemonitor.cu
+++ b/brian2cuda/templates/statemonitor.cu
@@ -1,6 +1,9 @@
 {# USES_VARIABLES { t, _indices, N } #}
 {# WRITES_TO_READ_ONLY_VARIABLES { t, N } #}
 {% extends 'common_group.cu' %}
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}
 
 {% block define_N %}
 {% endblock %}

--- a/brian2cuda/templates/stateupdate.cu
+++ b/brian2cuda/templates/stateupdate.cu
@@ -1,6 +1,3 @@
 {# USES_VARIABLES { N } #}
 {# ALLOWS_SCALAR_WRITE #}
 {% extends 'common_group.cu' %}
-{% block extra_headers %}
-#include "objects_thrust.h"
-{% endblock %}

--- a/brian2cuda/templates/stateupdate.cu
+++ b/brian2cuda/templates/stateupdate.cu
@@ -1,3 +1,6 @@
 {# USES_VARIABLES { N } #}
 {# ALLOWS_SCALAR_WRITE #}
 {% extends 'common_group.cu' %}
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}

--- a/brian2cuda/templates/summed_variable.cu
+++ b/brian2cuda/templates/summed_variable.cu
@@ -1,8 +1,5 @@
 {# USES_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
-{% block extra_headers %}
-#include "objects_thrust.h"
-{% endblock %}
 
 {% block extra_kernel_call %}
 {# Get the device pointer from the thrust device vector for usage in host code #}

--- a/brian2cuda/templates/summed_variable.cu
+++ b/brian2cuda/templates/summed_variable.cu
@@ -1,6 +1,8 @@
 {# USES_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
-
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}
 
 {% block extra_kernel_call %}
 {# Get the device pointer from the thrust device vector for usage in host code #}

--- a/brian2cuda/templates/synapses.cu
+++ b/brian2cuda/templates/synapses.cu
@@ -284,7 +284,7 @@ if ({{pathway.name}}_max_size > 0)
         if (defaultclock.timestep[0] >= {{pathway.name}}_delay)
         {
             cudaMemcpy(&num_spiking_neurons,
-                    &dev{{_eventspace}}[{{pathway.name}}_eventspace_idx][_num_{{_eventspace}} - 1],
+                    &dev{{_eventspace}}_view[{{pathway.name}}_eventspace_idx][_num_{{_eventspace}} - 1],
                     sizeof(int32_t), cudaMemcpyDeviceToHost);
             num_blocks = num_parallel_blocks * num_spiking_neurons;
             //TODO collect info abt mean, std of num spiking neurons per time
@@ -303,7 +303,7 @@ if ({{pathway.name}}_max_size > 0)
                 {% if bundle_mode %}
                 num_threads_per_bundle,
                 {% endif %}
-                dev{{_eventspace}}[{{pathway.name}}_eventspace_idx],
+                dev{{_eventspace}}_view[{{pathway.name}}_eventspace_idx],
                 {% if uses_atomics or synaptic_effects == "synapse" %}
                 num_spiking_neurons,
                 {% else %}
@@ -325,7 +325,7 @@ if ({{pathway.name}}_max_size > 0)
 void _debugmsg_{{codeobj_name}}()
 {
     using namespace brian;
-    std::cout << "Number of synapses: " << {{constant_or_scalar('N', variables['N'])}} << endl;
+    printf("Number of synapses: %d\n", {{constant_or_scalar('N', variables['N'])}});
 }
 {% endblock %}
 

--- a/brian2cuda/templates/synapses_classes.cu
+++ b/brian2cuda/templates/synapses_classes.cu
@@ -1,4 +1,51 @@
 {% macro cu_file() %}
+#include "objects.h"
+#include "synapses_classes.h"
+#include "brianlib/spikequeue.h"
+#include "brianlib/cuda_utils.h"
+
+__device__ void SynapticPathway::init(
+        int32_t* _sources,
+        int32_t* _targets,
+        double _dt,
+        int32_t _spikes_start,
+        int32_t _spikes_stop)
+{
+    dev_sources = _sources;
+    dev_targets = _targets;
+    dt = _dt;
+    spikes_start = _spikes_start;
+    spikes_stop = _spikes_stop;
+    queue = new CudaSpikeQueue;
+}
+
+__device__ void SynapticPathway::destroy()
+{
+    queue->destroy();
+    delete queue;
+}
+
+{% for S in synapses | sort(attribute='name') %}
+{% for path in S._pathways | sort(attribute='name') %}
+__global__ void {{path.name}}_init(
+                int32_t* sources,
+                int32_t* targets,
+                double dt,
+                int32_t source_start,
+                int32_t source_stop)
+{
+    using namespace brian;
+    {{path.name}}.init(sources, targets, dt, source_start, source_stop);
+}
+
+__global__ void {{path.name}}_destroy()
+{
+    using namespace brian;
+    {{path.name}}.destroy();
+}
+{% endfor %}
+{% endfor %}
+
 {% endmacro %}
 
 {% macro h_file() %}
@@ -6,10 +53,9 @@
 #ifndef _BRIAN_SYNAPSES_H
 #define _BRIAN_SYNAPSES_H
 
-#include<vector>
-#include<algorithm>
+#include <stdint.h>
 
-#include "brianlib/spikequeue.h"
+class CudaSpikeQueue;
 
 class SynapticPathway
 {
@@ -26,29 +72,28 @@ public:
     CudaSpikeQueue* queue;
     bool no_or_const_delay_mode;
 
-    //our real constructor
     __device__ void init(
             int32_t* _sources,
             int32_t* _targets,
             double _dt,
             int32_t _spikes_start,
-            int32_t _spikes_stop)
-    {
-        dev_sources = _sources;
-        dev_targets = _targets;
-        dt = _dt;
-        spikes_start = _spikes_start;
-        spikes_stop = _spikes_stop;
-        queue = new CudaSpikeQueue;
-    };
+            int32_t _spikes_stop);
 
-    //our real destructor
-    __device__ void destroy()
-    {
-        queue->destroy();
-        delete queue;
-    }
+    __device__ void destroy();
 };
+
+{% for S in synapses | sort(attribute='name') %}
+{% for path in S._pathways | sort(attribute='name') %}
+__global__ void {{path.name}}_init(
+                int32_t* sources,
+                int32_t* targets,
+                double dt,
+                int32_t source_start,
+                int32_t source_stop);
+__global__ void {{path.name}}_destroy();
+{% endfor %}
+{% endfor %}
+
 #endif
 
 {% endmacro %}

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -58,8 +58,8 @@ std::cout << std::endl;
 constants or scalar arrays#}
 const int _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
 const int _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
-resize_host_array_{{ _dynamic_N_incoming[15:] }}(_N_post + _target_offset);
-resize_host_array_{{ _dynamic_N_outgoing[15:] }}(_N_pre + _source_offset);
+resize_host_array_{{ array_basename(_dynamic_N_incoming) }}(_N_post + _target_offset);
+resize_host_array_{{ array_basename(_dynamic_N_outgoing) }}(_N_pre + _source_offset);
 
 ///// pointers_lines /////
 {{pointers_lines|autoindent}}
@@ -70,23 +70,25 @@ for (int _idx=0; _idx<_numsources; _idx++) {
        only necessary for supporting subgroups #}
     {{vector_code|autoindent}}
 
-    push_back_host_array_{{ _dynamic__synaptic_pre[15:] }}(_real_sources);
-    push_back_host_array_{{ _dynamic__synaptic_post[15:] }}(_real_targets);
-    host_array_{{ _dynamic_N_outgoing[15:] }}[_real_sources]++;
-    host_array_{{ _dynamic_N_incoming[15:] }}[_real_targets]++;
+    push_back_host_array_{{ array_basename(_dynamic__synaptic_pre) }}(_real_sources);
+    push_back_host_array_{{ array_basename(_dynamic__synaptic_post) }}(_real_targets);
+    host_array_{{ array_basename(_dynamic_N_outgoing) }}[_real_sources]++;
+    host_array_{{ array_basename(_dynamic_N_incoming) }}[_real_targets]++;
 }
 
 // now we need to resize all registered variables
-const int32_t newsize = _num_host_array_{{ _dynamic__synaptic_pre[15:] }};
+const int32_t newsize = _num_host_array_{{ array_basename(_dynamic__synaptic_pre) }};
 {% for variable in owner._registered_variables | sort(attribute='name') %}
     {% set varname = get_array_name(variable, access_data=False) %}
     {% if variable.name == 'delay' and no_or_const_delay_mode %}
-        resize_dev_array_{{ varname[15:] }}(1);
+        resize_dev_array_{{ array_basename(varname) }}(1);
+        resize_host_array_{{ array_basename(varname) }}(1);
     {% else %}
         {% if not multisynaptic_index or not variable == multisynaptic_idx_var %}
-        resize_dev_array_{{ varname[15:] }}(newsize);
+        resize_dev_array_{{ array_basename(varname) }}(newsize);
+        resize_host_array_{{ array_basename(varname) }}(newsize);
         {% else %}
-        resize_host_array_{{ varname[15:] }}(newsize);
+        resize_host_array_{{ array_basename(varname) }}(newsize);
         {% endif %}
     {% endif %}
 {% endfor %}
@@ -102,12 +104,12 @@ for (int _i=0; _i<newsize; _i++)
     // Note that source_target_count will create a new entry initialized
     // with 0 when the key does not exist yet
     const std::pair<int32_t, int32_t> source_target = std::pair<int32_t, int32_t>(
-            host_array_{{ _dynamic__synaptic_pre[15:] }}[_i],
-            host_array_{{ _dynamic__synaptic_post[15:] }}[_i]);
+            host_array_{{ array_basename(_dynamic__synaptic_pre) }}[_i],
+            host_array_{{ array_basename(_dynamic__synaptic_post) }}[_i]);
     {% if multisynaptic_index %}
     // Save the "synapse number"
     {% set dynamic_multisynaptic_idx = get_array_name(multisynaptic_idx_var, access_data=False) %}
-    host_array_{{ dynamic_multisynaptic_idx[15:] }}[_i] = source_target_count[source_target];
+    host_array_{{ array_basename(dynamic_multisynaptic_idx) }}[_i] = source_target_count[source_target];
     {% endif %}
     source_target_count[source_target]++;
     //printf("source target count = %i\n", source_target_count[source_target]);
@@ -121,12 +123,12 @@ for (int _i=0; _i<newsize; _i++)
 }
 // Check
 // copy changed host data to device
-copy_host_to_dev_array_{{ _dynamic_N_incoming[15:] }}();
-copy_host_to_dev_array_{{ _dynamic_N_outgoing[15:] }}();
-copy_host_to_dev_array_{{ _dynamic__synaptic_pre[15:] }}();
-copy_host_to_dev_array_{{ _dynamic__synaptic_post[15:] }}();
+copy_host_to_dev_array_{{ array_basename(_dynamic_N_incoming) }}();
+copy_host_to_dev_array_{{ array_basename(_dynamic_N_outgoing) }}();
+copy_host_to_dev_array_{{ array_basename(_dynamic__synaptic_pre) }}();
+copy_host_to_dev_array_{{ array_basename(_dynamic__synaptic_post) }}();
 {% if multisynaptic_index %}
-copy_host_to_dev_array_{{ dynamic_multisynaptic_idx[15:] }}();
+copy_host_to_dev_array_{{ array_basename(dynamic_multisynaptic_idx) }}();
 {% endif %}
 CUDA_SAFE_CALL(
         cudaMemcpy(dev{{get_array_name(variables['N'], access_data=False)}},

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -2,7 +2,8 @@
 
 {% block extra_headers %}
 {{ super() }}
-#include "objects_thrust.h"
+#include "objects_storage.h"
+#include "objects_api.h"
 #include<map>
 {% endblock %}
 

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -138,4 +138,6 @@ CUDA_SAFE_CALL(
             cudaMemcpyHostToDevice)
         );
 
+sync_all_dev_ptrs();
+
 {% endblock host_maincode %}

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -2,6 +2,7 @@
 
 {% block extra_headers %}
 {{ super() }}
+#include "objects_thrust.h"
 #include<map>
 {% endblock %}
 

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -3,6 +3,7 @@
 {% block extra_headers %}
 {{ super() }}
 #include "objects_api.h"
+#include <iostream>
 #include<map>
 {% endblock %}
 

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -2,7 +2,6 @@
 
 {% block extra_headers %}
 {{ super() }}
-#include "objects_storage.h"
 #include "objects_api.h"
 #include<map>
 {% endblock %}
@@ -58,8 +57,8 @@ std::cout << std::endl;
 constants or scalar arrays#}
 const int _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
 const int _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
-{{_dynamic_N_incoming}}.resize(_N_post + _target_offset);
-{{_dynamic_N_outgoing}}.resize(_N_pre + _source_offset);
+resize_host_array_{{ _dynamic_N_incoming[15:] }}(_N_post + _target_offset);
+resize_host_array_{{ _dynamic_N_outgoing[15:] }}(_N_pre + _source_offset);
 
 ///// pointers_lines /////
 {{pointers_lines|autoindent}}
@@ -70,30 +69,24 @@ for (int _idx=0; _idx<_numsources; _idx++) {
        only necessary for supporting subgroups #}
     {{vector_code|autoindent}}
 
-    {{_dynamic__synaptic_pre}}.push_back(_real_sources);
-    {{_dynamic__synaptic_post}}.push_back(_real_targets);
-    {{_dynamic_N_outgoing}}[_real_sources]++;
-    {{_dynamic_N_incoming}}[_real_targets]++;
+    push_back_host_array_{{ _dynamic__synaptic_pre[15:] }}(_real_sources);
+    push_back_host_array_{{ _dynamic__synaptic_post[15:] }}(_real_targets);
+    host_array_{{ _dynamic_N_outgoing[15:] }}[_real_sources]++;
+    host_array_{{ _dynamic_N_incoming[15:] }}[_real_targets]++;
 }
 
 // now we need to resize all registered variables
-const int32_t newsize = {{_dynamic__synaptic_pre}}.size();
+const int32_t newsize = _num_host_array_{{ _dynamic__synaptic_pre[15:] }};
 {% for variable in owner._registered_variables | sort(attribute='name') %}
     {% set varname = get_array_name(variable, access_data=False) %}
     {% if variable.name == 'delay' and no_or_const_delay_mode %}
-        THRUST_CHECK_ERROR(
-                dev{{varname}}.resize(1)
-                );
-        {# //TODO: do we actually need to resize varname? #}
-        {{varname}}.resize(1);
+        resize_dev_array_{{ varname[15:] }}(1);
     {% else %}
         {% if not multisynaptic_index or not variable == multisynaptic_idx_var %}
-        THRUST_CHECK_ERROR(
-                dev{{varname}}.resize(newsize)
-                );
+        resize_dev_array_{{ varname[15:] }}(newsize);
+        {% else %}
+        resize_host_array_{{ varname[15:] }}(newsize);
         {% endif %}
-        {# //TODO: do we actually need to resize varname? #}
-        {{varname}}.resize(newsize);
     {% endif %}
 {% endfor %}
 CUDA_CHECK_MEMORY();
@@ -107,11 +100,13 @@ for (int _i=0; _i<newsize; _i++)
 {
     // Note that source_target_count will create a new entry initialized
     // with 0 when the key does not exist yet
-    const std::pair<int32_t, int32_t> source_target = std::pair<int32_t, int32_t>({{_dynamic__synaptic_pre}}[_i], {{_dynamic__synaptic_post}}[_i]);
+    const std::pair<int32_t, int32_t> source_target = std::pair<int32_t, int32_t>(
+            host_array_{{ _dynamic__synaptic_pre[15:] }}[_i],
+            host_array_{{ _dynamic__synaptic_post[15:] }}[_i]);
     {% if multisynaptic_index %}
     // Save the "synapse number"
     {% set dynamic_multisynaptic_idx = get_array_name(multisynaptic_idx_var, access_data=False) %}
-    {{dynamic_multisynaptic_idx}}[_i] = source_target_count[source_target];
+    host_array_{{ dynamic_multisynaptic_idx[15:] }}[_i] = source_target_count[source_target];
     {% endif %}
     source_target_count[source_target]++;
     //printf("source target count = %i\n", source_target_count[source_target]);
@@ -125,12 +120,12 @@ for (int _i=0; _i<newsize; _i++)
 }
 // Check
 // copy changed host data to device
-dev{{_dynamic_N_incoming}} = {{_dynamic_N_incoming}};
-dev{{_dynamic_N_outgoing}} = {{_dynamic_N_outgoing}};
-dev{{_dynamic__synaptic_pre}} = {{_dynamic__synaptic_pre}};
-dev{{_dynamic__synaptic_post}} = {{_dynamic__synaptic_post}};
+copy_host_to_dev_array_{{ _dynamic_N_incoming[15:] }}();
+copy_host_to_dev_array_{{ _dynamic_N_outgoing[15:] }}();
+copy_host_to_dev_array_{{ _dynamic__synaptic_pre[15:] }}();
+copy_host_to_dev_array_{{ _dynamic__synaptic_post[15:] }}();
 {% if multisynaptic_index %}
-dev{{dynamic_multisynaptic_idx}} = {{dynamic_multisynaptic_idx}};
+copy_host_to_dev_array_{{ dynamic_multisynaptic_idx[15:] }}();
 {% endif %}
 CUDA_SAFE_CALL(
         cudaMemcpy(dev{{get_array_name(variables['N'], access_data=False)}},
@@ -138,7 +133,5 @@ CUDA_SAFE_CALL(
             sizeof({{c_data_type(variables['N'].dtype)}}),
             cudaMemcpyHostToDevice)
         );
-
-sync_all_dev_ptrs();
 
 {% endblock host_maincode %}

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -14,6 +14,7 @@
 #include<brianlib/curand_buffer.h>
 #include "brianlib/cuda_utils.h"
 #include<map>
+#include<set>
 {% endblock extra_headers %}
 
 {% block random_functions %}

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -9,7 +9,8 @@
 
 {% block extra_headers %}
 {{ super() }}
-#include "objects_thrust.h"
+#include "objects_storage.h"
+#include "objects_api.h"
 #include "rand.h"
 #include<iostream>
 #include<curand.h>

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -9,11 +9,8 @@
 
 {% block extra_headers %}
 {{ super() }}
-#include "objects_storage.h"
 #include "objects_api.h"
-#include "rand.h"
 #include<iostream>
-#include<curand.h>
 #include<brianlib/curand_buffer.h>
 #include "brianlib/cuda_utils.h"
 #include<map>
@@ -173,8 +170,8 @@ std::cout << std::endl;
     constants or scalar arrays#}
     const size_t _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
     const size_t _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
-    {{_dynamic_N_incoming}}.resize(_N_post + _target_offset);
-    {{_dynamic_N_outgoing}}.resize(_N_pre + _source_offset);
+    resize_host_array_{{ _dynamic_N_incoming[15:] }}(_N_post + _target_offset);
+    resize_host_array_{{ _dynamic_N_outgoing[15:] }}(_N_pre + _source_offset);
 
     size_t _raw_pre_idx, _raw_post_idx;
     {# For a connect call j='k+i for k in range(0, N_post, 2) if k+i < N_post'
@@ -263,8 +260,8 @@ std::cout << std::endl;
             {% if skip_if_invalid %}
             _uiter_size = _n_total;
             {% else %}
-            cout << "Error: Requested sample size " << _uiter_size << " is bigger than the " <<
-                    "population size " << _n_total << "." << endl;
+            std::cout << "Error: Requested sample size " << _uiter_size << " is bigger than the " <<
+                    "population size " << _n_total << "." << std::endl;
             exit(1);
             {% endif %}
         } else if (_uiter_size < 0)
@@ -272,7 +269,7 @@ std::cout << std::endl;
             {% if skip_if_invalid %}
             continue;
             {% else %}
-            cout << "Error: Requested sample size " << _uiter_size << " is negative." << endl;
+            std::cout << "Error: Requested sample size " << _uiter_size << " is negative." << std::endl;
             exit(1);
             {% endif %}
         } else if (_uiter_size == 0)
@@ -355,8 +352,8 @@ std::cout << std::endl;
                     {% if skip_if_invalid %}
                     continue;
                     {% else %}
-                    cout << "Error: tried to create synapse to neuron {{result_index}}=" << _{{result_index}} << " outside range 0 to " <<
-                                            _{{result_index_size}}-1 << endl;
+                    std::cout << "Error: tried to create synapse to neuron {{result_index}}=" << _{{result_index}} << " outside range 0 to " <<
+                                            _{{result_index_size}}-1 << std::endl;
                     exit(1);
                     {% endif %}
                 }
@@ -379,8 +376,8 @@ std::cout << std::endl;
                 {% if skip_if_invalid %}
                 continue;
                 {% else %}
-                cout << "Error: tried to create synapse to neuron {{result_index}}=" << _{{result_index}} <<
-                        " outside range 0 to " << _{{result_index_size}}-1 << endl;
+                std::cout << "Error: tried to create synapse to neuron {{result_index}}=" << _{{result_index}} <<
+                        " outside range 0 to " << _{{result_index_size}}-1 << std::endl;
                 exit(1);
                 {% endif %}
             }
@@ -390,25 +387,21 @@ std::cout << std::endl;
             {{vector_code['update']|autoindent}}
 
             for (size_t _repetition=0; _repetition<_n; _repetition++) {
-                {{_dynamic_N_outgoing}}[_pre_idx] += 1;
-                {{_dynamic_N_incoming}}[_post_idx] += 1;
-                {{_dynamic__synaptic_pre}}.push_back(_pre_idx);
-                {{_dynamic__synaptic_post}}.push_back(_post_idx);
+                host_array_{{ _dynamic_N_outgoing[15:] }}[_pre_idx] += 1;
+                host_array_{{ _dynamic_N_incoming[15:] }}[_post_idx] += 1;
+                push_back_host_array_{{ _dynamic__synaptic_pre[15:] }}(_pre_idx);
+                push_back_host_array_{{ _dynamic__synaptic_post[15:] }}(_post_idx);
             }
         }
     }
 
     // now we need to resize all registered variables
-    const int32_t newsize = {{_dynamic__synaptic_pre}}.size();
+    const int32_t newsize = _num_host_array_{{ _dynamic__synaptic_pre[15:] }};
     {% for variable in owner._registered_variables | sort(attribute='name') %}
         {% set varname = get_array_name(variable, access_data=False) %}
         {% if variable.name == 'delay' and no_or_const_delay_mode %}
-            assert(dev{{varname}}.size() <= 1);
-            THRUST_CHECK_ERROR(
-                    dev{{varname}}.resize(1)
-                    );
-            {# //TODO: do we actually need to resize varname? #}
-            {{varname}}.resize(1);
+            assert(_num_dev_array_{{ varname[15:] }} <= 1);
+            resize_dev_array_{{ varname[15:] }}(1);
         {% elif variable.name == '_synaptic_pre' and no_pre_references %}
         // prefs['devices.cuda_standalone.no_pre_references'] was set,
         // skipping synaptic_pre resize
@@ -417,12 +410,10 @@ std::cout << std::endl;
         // skipping synaptic_post resize
         {% else %}
             {% if not multisynaptic_index or not variable == multisynaptic_idx_var %}
-            THRUST_CHECK_ERROR(
-                    dev{{varname}}.resize(newsize)
-                    );
+            resize_dev_array_{{ varname[15:] }}(newsize);
+            {% else %}
+            resize_host_array_{{ varname[15:] }}(newsize);
             {% endif %}
-            {# //TODO: do we actually need to resize varname? #}
-            {{varname}}.resize(newsize);
         {% endif %}
     {% endfor %}
     // Also update the total number of synapses
@@ -434,11 +425,13 @@ std::cout << std::endl;
     {
         // Note that source_target_count will create a new entry initialized
         // with 0 when the key does not exist yet
-        const std::pair<int32_t, int32_t> source_target = std::pair<int32_t, int32_t>({{_dynamic__synaptic_pre}}[_i], {{_dynamic__synaptic_post}}[_i]);
+        const std::pair<int32_t, int32_t> source_target = std::pair<int32_t, int32_t>(
+                host_array_{{ _dynamic__synaptic_pre[15:] }}[_i],
+                host_array_{{ _dynamic__synaptic_post[15:] }}[_i]);
         {% if multisynaptic_index %}
         // Save the "synapse number"
         {% set dynamic_multisynaptic_idx = get_array_name(multisynaptic_idx_var, access_data=False) %}
-        {{dynamic_multisynaptic_idx}}[_i] = source_target_count[source_target];
+        host_array_{{ dynamic_multisynaptic_idx[15:] }}[_i] = source_target_count[source_target];
         {% endif %}
         source_target_count[source_target]++;
         //printf("source target count = %i\n", source_target_count[source_target]);
@@ -452,12 +445,12 @@ std::cout << std::endl;
     }
 
     // copy changed host data to device
-    dev{{_dynamic_N_incoming}} = {{_dynamic_N_incoming}};
-    dev{{_dynamic_N_outgoing}} = {{_dynamic_N_outgoing}};
-    dev{{_dynamic__synaptic_pre}} = {{_dynamic__synaptic_pre}};
-    dev{{_dynamic__synaptic_post}} = {{_dynamic__synaptic_post}};
+    copy_host_to_dev_array_{{ _dynamic_N_incoming[15:] }}();
+    copy_host_to_dev_array_{{ _dynamic_N_outgoing[15:] }}();
+    copy_host_to_dev_array_{{ _dynamic__synaptic_pre[15:] }}();
+    copy_host_to_dev_array_{{ _dynamic__synaptic_post[15:] }}();
     {% if multisynaptic_index %}
-    dev{{dynamic_multisynaptic_idx}} = {{dynamic_multisynaptic_idx}};
+    copy_host_to_dev_array_{{ dynamic_multisynaptic_idx[15:] }}();
     {% endif %}
     CUDA_SAFE_CALL(
             cudaMemcpy(dev{{get_array_name(variables['N'], access_data=False)}},
@@ -465,8 +458,6 @@ std::cout << std::endl;
                 sizeof({{c_data_type(variables['N'].dtype)}}),
                 cudaMemcpyHostToDevice)
             );
-
-    sync_all_dev_ptrs();
 {% endblock host_maincode %}
 
 {% block extra_kernel_call_post %}

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -9,6 +9,7 @@
 
 {% block extra_headers %}
 {{ super() }}
+#include "objects_thrust.h"
 #include<iostream>
 #include<curand.h>
 #include<brianlib/curand_buffer.h>

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -464,6 +464,8 @@ std::cout << std::endl;
                 sizeof({{c_data_type(variables['N'].dtype)}}),
                 cudaMemcpyHostToDevice)
             );
+
+    sync_all_dev_ptrs();
 {% endblock host_maincode %}
 
 {% block extra_kernel_call_post %}

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -10,6 +10,7 @@
 {% block extra_headers %}
 {{ super() }}
 #include "objects_thrust.h"
+#include "rand.h"
 #include<iostream>
 #include<curand.h>
 #include<brianlib/curand_buffer.h>

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -171,8 +171,8 @@ std::cout << std::endl;
     constants or scalar arrays#}
     const size_t _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
     const size_t _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
-    resize_host_array_{{ _dynamic_N_incoming[15:] }}(_N_post + _target_offset);
-    resize_host_array_{{ _dynamic_N_outgoing[15:] }}(_N_pre + _source_offset);
+    resize_host_array_{{ array_basename(_dynamic_N_incoming) }}(_N_post + _target_offset);
+    resize_host_array_{{ array_basename(_dynamic_N_outgoing) }}(_N_pre + _source_offset);
 
     size_t _raw_pre_idx, _raw_post_idx;
     {# For a connect call j='k+i for k in range(0, N_post, 2) if k+i < N_post'
@@ -388,21 +388,22 @@ std::cout << std::endl;
             {{vector_code['update']|autoindent}}
 
             for (size_t _repetition=0; _repetition<_n; _repetition++) {
-                host_array_{{ _dynamic_N_outgoing[15:] }}[_pre_idx] += 1;
-                host_array_{{ _dynamic_N_incoming[15:] }}[_post_idx] += 1;
-                push_back_host_array_{{ _dynamic__synaptic_pre[15:] }}(_pre_idx);
-                push_back_host_array_{{ _dynamic__synaptic_post[15:] }}(_post_idx);
+                host_array_{{ array_basename(_dynamic_N_outgoing) }}[_pre_idx] += 1;
+                host_array_{{ array_basename(_dynamic_N_incoming) }}[_post_idx] += 1;
+                push_back_host_array_{{ array_basename(_dynamic__synaptic_pre) }}(_pre_idx);
+                push_back_host_array_{{ array_basename(_dynamic__synaptic_post) }}(_post_idx);
             }
         }
     }
 
     // now we need to resize all registered variables
-    const int32_t newsize = _num_host_array_{{ _dynamic__synaptic_pre[15:] }};
+    const int32_t newsize = _num_host_array_{{ array_basename(_dynamic__synaptic_pre) }};
     {% for variable in owner._registered_variables | sort(attribute='name') %}
         {% set varname = get_array_name(variable, access_data=False) %}
         {% if variable.name == 'delay' and no_or_const_delay_mode %}
-            assert(_num_dev_array_{{ varname[15:] }} <= 1);
-            resize_dev_array_{{ varname[15:] }}(1);
+            assert(_num_dev_array_{{ array_basename(varname) }} <= 1);
+            resize_dev_array_{{ array_basename(varname) }}(1);
+            resize_host_array_{{ array_basename(varname) }}(1);
         {% elif variable.name == '_synaptic_pre' and no_pre_references %}
         // prefs['devices.cuda_standalone.no_pre_references'] was set,
         // skipping synaptic_pre resize
@@ -411,9 +412,10 @@ std::cout << std::endl;
         // skipping synaptic_post resize
         {% else %}
             {% if not multisynaptic_index or not variable == multisynaptic_idx_var %}
-            resize_dev_array_{{ varname[15:] }}(newsize);
+            resize_dev_array_{{ array_basename(varname) }}(newsize);
+            resize_host_array_{{ array_basename(varname) }}(newsize);
             {% else %}
-            resize_host_array_{{ varname[15:] }}(newsize);
+            resize_host_array_{{ array_basename(varname) }}(newsize);
             {% endif %}
         {% endif %}
     {% endfor %}
@@ -427,12 +429,12 @@ std::cout << std::endl;
         // Note that source_target_count will create a new entry initialized
         // with 0 when the key does not exist yet
         const std::pair<int32_t, int32_t> source_target = std::pair<int32_t, int32_t>(
-                host_array_{{ _dynamic__synaptic_pre[15:] }}[_i],
-                host_array_{{ _dynamic__synaptic_post[15:] }}[_i]);
+                host_array_{{ array_basename(_dynamic__synaptic_pre) }}[_i],
+                host_array_{{ array_basename(_dynamic__synaptic_post) }}[_i]);
         {% if multisynaptic_index %}
         // Save the "synapse number"
         {% set dynamic_multisynaptic_idx = get_array_name(multisynaptic_idx_var, access_data=False) %}
-        host_array_{{ dynamic_multisynaptic_idx[15:] }}[_i] = source_target_count[source_target];
+        host_array_{{ array_basename(dynamic_multisynaptic_idx) }}[_i] = source_target_count[source_target];
         {% endif %}
         source_target_count[source_target]++;
         //printf("source target count = %i\n", source_target_count[source_target]);
@@ -446,12 +448,12 @@ std::cout << std::endl;
     }
 
     // copy changed host data to device
-    copy_host_to_dev_array_{{ _dynamic_N_incoming[15:] }}();
-    copy_host_to_dev_array_{{ _dynamic_N_outgoing[15:] }}();
-    copy_host_to_dev_array_{{ _dynamic__synaptic_pre[15:] }}();
-    copy_host_to_dev_array_{{ _dynamic__synaptic_post[15:] }}();
+    copy_host_to_dev_array_{{ array_basename(_dynamic_N_incoming) }}();
+    copy_host_to_dev_array_{{ array_basename(_dynamic_N_outgoing) }}();
+    copy_host_to_dev_array_{{ array_basename(_dynamic__synaptic_pre) }}();
+    copy_host_to_dev_array_{{ array_basename(_dynamic__synaptic_post) }}();
     {% if multisynaptic_index %}
-    copy_host_to_dev_array_{{ dynamic_multisynaptic_idx[15:] }}();
+    copy_host_to_dev_array_{{ array_basename(dynamic_multisynaptic_idx) }}();
     {% endif %}
     CUDA_SAFE_CALL(
             cudaMemcpy(dev{{get_array_name(variables['N'], access_data=False)}},

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -5,7 +5,8 @@
 {% set _eventspace = get_array_name(eventspace_variable, access_data=False) %}
 
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
+#include "objects_api.h"
 {% endblock %}
 
 {### BEFORE RUN ###}
@@ -40,7 +41,8 @@
  #}
 {% block before_run_headers %}
 {{super()}}
-#include "objects_thrust.h"
+#include "objects_storage.h"
+#include "objects_api.h"
 #include <thrust/sort.h>
 #include <thrust/reduce.h>
 #include <thrust/unique.h>

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -35,6 +35,8 @@
  # sorted by their delay (if they have any).
  #}
 {% block before_run_headers %}
+{{super()}}
+#include "objects_thrust.h"
 #include <thrust/sort.h>
 #include <thrust/reduce.h>
 #include <thrust/unique.h>

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -4,6 +4,10 @@
 {# Get the name of the array that stores these events (e.g. the spikespace array) #}
 {% set _eventspace = get_array_name(eventspace_variable, access_data=False) %}
 
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}
+
 {### BEFORE RUN ###}
 {# TEMPLATE INFO
  # This template creates the connectivity matrix for this SynapticPathway

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -4,11 +4,6 @@
 {# Get the name of the array that stores these events (e.g. the spikespace array) #}
 {% set _eventspace = get_array_name(eventspace_variable, access_data=False) %}
 
-{% block extra_headers %}
-#include "objects_storage.h"
-#include "objects_api.h"
-{% endblock %}
-
 {### BEFORE RUN ###}
 {# TEMPLATE INFO
  # This template creates the connectivity matrix for this SynapticPathway
@@ -40,23 +35,23 @@
  # sorted by their delay (if they have any).
  #}
 {% block before_run_headers %}
-{{super()}}
-#include "objects_storage.h"
+{{ super() }}
 #include "objects_api.h"
-#include <thrust/sort.h>
-#include <thrust/reduce.h>
-#include <thrust/unique.h>
-#include <iostream>
-#include <ctime>
-#include <limits.h>
-#include <tuple>
+#include "synapses_classes.h"
+#include "brianlib/spikequeue.h"
+#include <algorithm>
+#include <chrono>
+#include <climits>
+#include <cmath>
 #include <string>
-#include <iomanip>
+#include <tuple>
 #include <vector>
-#include "objects.h"
-#include "code_objects/{{codeobj_name}}.h"
-#include "brianlib/cuda_utils.h"
 {% endblock before_run_headers %}
+
+{% block extra_headers %}
+#include "synapses_classes.h"
+#include "brianlib/spikequeue.h"
+{% endblock %}
 
 
 {% block before_run_defines %}
@@ -65,8 +60,7 @@
     _copyHostArrayToDeviceSymbol(a, b, c, d, e, __FILE__, __LINE__)
 
 namespace {
-    // vector_t<T> is an alias for thrust:host_vector<T>
-    template <typename T> using vector_t = thrust::host_vector<T>;
+    template <typename T> using vector_t = std::vector<T>;
     // tuple type typedef
     typedef std::tuple<std::string, size_t, int> tuple_t;
 
@@ -202,6 +196,12 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
     // total number of synapses
     int syn_N = (int)syn_N_check;
 
+    // Skip re-init when delay was cleared after the first run and not repopulated.
+    if (!first_run && (host_array_{{ _dynamic_delay[15:] }} == nullptr
+            || _num_host_array_{{ _dynamic_delay[15:] }} == 0)) {
+        return;
+    }
+
     // simulation time step
     double dt = {{_source_dt}};
     // number of neurons in source group
@@ -323,7 +323,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
 
 
     //fill vectors of connectivity matrix with synapse IDs and delays (in units of simulation time step)
-    int max_delay = (int)({{_dynamic_delay}}[0] / dt + 0.5);
+    int max_delay = (int)(host_array_{{ _dynamic_delay[15:] }}[0] / dt + 0.5);
     {% if not no_or_const_delay_mode %}
     int min_delay = max_delay;
     {% endif %}
@@ -376,11 +376,11 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
         // be NOT equal to the idx in their NeuronGroup
         {% set source_ids = get_array_name(owner.synapse_sources, access_data=False) %}
         {% set target_ids = get_array_name(owner.synapse_targets, access_data=False) %}
-        int32_t pre_neuron_id = {{source_ids}}[syn_id] - {{source_offset}};
-        int32_t post_neuron_id = {{target_ids}}[syn_id] - {{target_offset}};
+        int32_t pre_neuron_id = host_array_{{ source_ids[15:] }}[syn_id] - {{source_offset}};
+        int32_t post_neuron_id = host_array_{{ target_ids[15:] }}[syn_id] - {{target_offset}};
 
         {% if not no_or_const_delay_mode %}
-        int delay = (int)({{_dynamic_delay}}[syn_id] / dt + 0.5);
+        int delay = (int)(host_array_{{ _dynamic_delay[15:] }}[syn_id] / dt + 0.5);
         if (delay > max_delay)
             max_delay = delay;
         if (delay < min_delay)
@@ -462,44 +462,26 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
             // reduce the delay arrays to unique delays and store the
             // start indices in the synapses array for each unique delay
 
-            typedef vector_t<int>::iterator itr;
-
             // sort synapses (values) and delays (keys) by delay
-            thrust::sort_by_key(
-                    h_vec_delays_by_pre[i].begin(),     // keys start
-                    h_vec_delays_by_pre[i].end(),       // keys end
-                    h_vec_synapse_ids_by_pre[i].begin() // values start
-                    );
+            sort_by_key_int_int32(
+                    h_vec_delays_by_pre[i].data(),
+                    h_vec_synapse_ids_by_pre[i].data(),
+                    num_elements);
 
-            // worst case: number of unique delays is num_elements
             h_vec_unique_delay_start_idcs_by_pre[i].resize(num_elements);
+            fill_sequence_int(
+                    h_vec_unique_delay_start_idcs_by_pre[i].data(),
+                    num_elements);
 
-            // Initialise the unique delay start idcs array as a sequence
-            thrust::sequence(h_vec_unique_delay_start_idcs_by_pre[i].begin(),
-                    h_vec_unique_delay_start_idcs_by_pre[i].end());
+            size_t num_unique_elements = unique_by_key_int_int(
+                    h_vec_delays_by_pre[i].data(),
+                    h_vec_unique_delay_start_idcs_by_pre[i].data(),
+                    num_elements);
 
-            // get delays (keys) and values (indices) for first occurence of each delay value
-            thrust::pair<itr, itr> end_pair = thrust::unique_by_key(
-                    h_vec_delays_by_pre[i].begin(),                 // keys start
-                    h_vec_delays_by_pre[i].end(),                   // keys end
-                    h_vec_unique_delay_start_idcs_by_pre[i].begin() // values start (position in original delay array)
-                    );
-
-            itr unique_delay_end = end_pair.first;
-            itr idx_end = end_pair.second;
-
-            // erase unneded vector entries
-            h_vec_unique_delay_start_idcs_by_pre[i].erase(
-                    idx_end, h_vec_unique_delay_start_idcs_by_pre[i].end());
-            // free not used but allocated host memory
+            h_vec_unique_delay_start_idcs_by_pre[i].resize(num_unique_elements);
             h_vec_unique_delay_start_idcs_by_pre[i].shrink_to_fit();
-            h_vec_delays_by_pre[i].erase(unique_delay_end,
-                    h_vec_delays_by_pre[i].end());
-            // delay_by_pre holds the set of unique delays now
-            // we don't need shrink_to_fit, swap takes care of that
+            h_vec_delays_by_pre[i].resize(num_unique_elements);
             h_vec_unique_delays_by_pre[i].swap(h_vec_delays_by_pre[i]);
-
-            int num_unique_elements = h_vec_unique_delays_by_pre[i].size();
             sum_num_unique_elements += num_unique_elements;
 
             if (num_unique_elements > {{owner.name}}_max_num_unique_delays)
@@ -540,7 +522,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
 
                 // copy this bundle to device and store the device pointer
                 int32_t* d_this_bundle = d_ptr_synapse_ids + sum_bundle_sizes;
-                int32_t* h_this_bundle = thrust::raw_pointer_cast(&h_vec_synapse_ids_by_pre[i][synapses_start_idx]);
+                int32_t* h_this_bundle = &h_vec_synapse_ids_by_pre[i][synapses_start_idx];
                 size_t memory_size = sizeof(int32_t) * num_synapses;
                 CUDA_SAFE_CALL(
                         cudaMemcpy(d_this_bundle, h_this_bundle, memory_size, cudaMemcpyHostToDevice)
@@ -572,7 +554,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
             h_ptr_d_ptr_synapse_ids_by_pre[i] = d_ptr_synapse_ids + sum_num_elements;
             CUDA_SAFE_CALL(
                     cudaMemcpy(h_ptr_d_ptr_synapse_ids_by_pre[i],
-                        thrust::raw_pointer_cast(&(h_vec_synapse_ids_by_pre[i][0])),
+                        h_vec_synapse_ids_by_pre[i].data(),
                         sizeof(int32_t) * num_elements,
                         cudaMemcpyHostToDevice)
                     );
@@ -673,8 +655,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
                 CUDA_SAFE_CALL(
                         cudaMemcpy(d_ptr_unique_delays
                                        + sum_num_unique_elements,
-                                   thrust::raw_pointer_cast(
-                                       &(h_vec_unique_delays_by_pre[i][0])),
+                                   h_vec_unique_delays_by_pre[i].data(),
                                    sizeof(int)*num_unique_elements,
                                    cudaMemcpyHostToDevice)
                         );
@@ -685,7 +666,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
                 // copy the unique delays start indices to the device
                 CUDA_SAFE_CALL(
                         cudaMemcpy(d_ptr_unique_delay_start_idcs + sum_num_unique_elements,
-                                   thrust::raw_pointer_cast(&(h_vec_unique_delay_start_idcs_by_pre[i][0])),
+                                   h_vec_unique_delay_start_idcs_by_pre[i].data(),
                                    sizeof(int)*num_unique_elements,
                                    cudaMemcpyHostToDevice)
                         );
@@ -727,13 +708,13 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
         }
         // size by bundle
         COPY_HOST_ARRAY_TO_DEVICE_SYMBOL(d_ptr_num_synapses_by_bundle,
-                thrust::raw_pointer_cast(&h_num_synapses_by_bundle[0]),
+                h_num_synapses_by_bundle.data(),
                 {{owner.name}}_num_synapses_by_bundle, num_bundle_ids,
                 "number of synapses per bundle");
 
         // synapses offset by bundle
         COPY_HOST_ARRAY_TO_DEVICE_SYMBOL(d_ptr_synapses_offset_by_bundle,
-                thrust::raw_pointer_cast(&h_synapses_offset_by_bundle[0]),
+                h_synapses_offset_by_bundle.data(),
                 {{owner.name}}_synapses_offset_by_bundle, num_bundle_ids,
                 "synapses bundle offset");
 
@@ -782,20 +763,15 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
 
     // sum all allocated memory
     size_t total_memory = 0;
-    int max_string_length = 0;
     for(auto const& tuple: memory_recorder){
         total_memory += std::get<1>(tuple);
-        int str_len = std::get<0>(tuple).length();
-        if (str_len > max_string_length)
-            max_string_length = str_len;
     }
     double total_memory_MB = total_memory * to_MB;
-    max_string_length += 5;
 
     // sort tuples by used memory
-    std::sort(begin(memory_recorder), end(memory_recorder),
+    std::sort(memory_recorder.begin(), memory_recorder.end(),
             [](tuple_t const &t1, tuple_t const &t2) {
-            return std::get<1>(t1) > std::get<1>(t2); // or use a custom compare function
+            return std::get<1>(t1) > std::get<1>(t2);
             }
             );
 
@@ -808,30 +784,37 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
     {% endif %}{# not no_or_const_delay_mode #}
 
     // print memory information
-    std::cout.precision(1);
-    std::cout.setf(std::ios::fixed, std::ios::floatfield);
-    std::cout << "INFO: synapse statistics and memory usage for {{owner.name}}:\n"
-        << "\tnumber of synapses: " << syn_N << "\n"
+    printf("INFO: synapse statistics and memory usage for {{owner.name}}:\n"
+        "\tnumber of synapses: %d\n"
     {% if not no_or_const_delay_mode and bundle_mode %}
-        << "\tnumber of bundles: " << num_bundle_ids << "\n"
+        "\tnumber of bundles: %d\n"
     {% endif %}
-        << "\tnumber of pre/post blocks: " << num_pre_post_blocks << "\n"
-        << "\tnumber of synapses over all pre/post blocks:\n"
-        << "\t\tmean: " << mean_num_elements << "\tstd: "
-            << std_num_elements << "\n"
+        "\tnumber of pre/post blocks: %d\n"
+        "\tnumber of synapses over all pre/post blocks:\n"
+        "\t\tmean: %.1f\tstd: %.1f\n"
     {% if not no_or_const_delay_mode %}
-        << "\tnumber of unique delays over all pre/post blocks:\n"
-        << "\t\tmean: " << mean_num_unique_elements << "\tstd: "
-            << std_num_unique_elements << "\n"
+        "\tnumber of unique delays over all pre/post blocks:\n"
+        "\t\tmean: %.1f\tstd: %.1f\n"
     {% if bundle_mode %}
-    << "\tbundle size over all bundles:\n"
-        << "\t\tmean: " << mean_bundle_sizes << "\tstd: "
-        << std_bundle_sizes << "\n"
+        "\tbundle size over all bundles:\n"
+        "\t\tmean: %.1f\tstd: %.1f\n"
     {% endif %}{# bundle_mode #}
     {% endif %}{# not no_or_const_delay_mode #}
-    << "\n\tmemory usage: TOTAL: " << total_memory_MB << " MB (~"
-        << total_memory_MB / syn_N * 1024.0 * 1024.0  << " byte per synapse)"
-        << std::endl;
+        "\n\tmemory usage: TOTAL: %.1f MB (~%.1f byte per synapse)\n",
+        syn_N,
+    {% if not no_or_const_delay_mode and bundle_mode %}
+        num_bundle_ids,
+    {% endif %}
+        num_pre_post_blocks,
+        mean_num_elements, std_num_elements,
+    {% if not no_or_const_delay_mode %}
+        mean_num_unique_elements, std_num_unique_elements,
+    {% if bundle_mode %}
+        mean_bundle_sizes, std_bundle_sizes,
+    {% endif %}{# bundle_mode #}
+    {% endif %}{# not no_or_const_delay_mode #}
+        total_memory_MB,
+        total_memory_MB / syn_N * 1024.0 * 1024.0);
 
     for(auto const& tuple: memory_recorder){
         std::string name;
@@ -840,9 +823,8 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
         std::tie(name, bytes, num_elements) = tuple;
         double memory = bytes * to_MB;
         double fraction = memory / total_memory_MB * 100;
-        std::cout << "\t\t" << std::setprecision(1) << std::fixed << fraction
-            << "%\t" << std::setprecision(3) << std::fixed << memory << " MB\t"
-            << name << " [" << num_elements << "]" << std::endl;
+        printf("\t\t%.1f%%\t%.3f MB\t%s [%d]\n",
+               fraction, memory, name.c_str(), num_elements);
     }
 
 
@@ -851,43 +833,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
     if (scalar_delay)
     {% endif %}
     {
-        int num_eventspaces = dev{{_eventspace}}.size();
-        bool require_new_eventspaces = (num_queues > num_eventspaces);
-
-        if (require_new_eventspaces)
-        {
-            // rotate circular eventspace such that the current idx is at the start
-            // (logic copied from CSpikeQueue.expand() in Brian's cspikequeue.cpp)
-            std::rotate(
-                dev{{_eventspace}}.begin(),
-                dev{{_eventspace}}.begin() + current_idx{{_eventspace}},
-                dev{{_eventspace}}.end()
-            );
-            current_idx{{_eventspace}} = 0;
-            // add new eventspaces
-            for (int i = num_eventspaces; i < num_queues; i++)
-            {
-                {{c_data_type(eventspace_variable.dtype)}}* new_eventspace;
-                CUDA_SAFE_CALL(
-                    cudaMalloc(
-                        (void**)&new_eventspace,
-                        sizeof({{c_data_type(eventspace_variable.dtype)}}) * _num_{{_eventspace}}
-                    )
-                );
-                // initialize device eventspace with -1 and counter with 0
-                CUDA_SAFE_CALL(
-                    cudaMemcpy(
-                        new_eventspace,
-                        {{_eventspace}},  // defined in objects.cu
-                        sizeof({{c_data_type(eventspace_variable.dtype)}}) * _num_{{_eventspace}},
-                        cudaMemcpyHostToDevice
-                    )
-                );
-                dev{{_eventspace}}.push_back(new_eventspace);
-            }
-            // host_vector may have reallocated; refresh PIMPL views for lean COs
-            sync_all_dev_ptrs();
-        }
+        expand_eventspace{{ _eventspace }}(num_queues);
     }
 
     int num_threads = num_queues;
@@ -987,17 +933,18 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
     }
 
     CUDA_CHECK_MEMORY();
-    double time_passed = std::chrono::duration<double>(std::chrono::high_resolution_clock::now() - start_timer).count();
-    std::cout << "INFO: {{owner.name}} initialisation took " <<  time_passed << "s";
+    double time_passed = std::chrono::duration<double>(
+            std::chrono::high_resolution_clock::now() - start_timer).count();
+    printf("INFO: {{owner.name}} initialisation took %.6fs", time_passed);
     if (used_device_memory_after_dealloc < used_device_memory_start){
         size_t freed_bytes = used_device_memory_start - used_device_memory_after_dealloc;
-        std::cout << ", freed " << freed_bytes * to_MB << "MB";
+        printf(", freed %.1fMB", freed_bytes * to_MB);
     }
     if (used_device_memory > used_device_memory_start){
         size_t used_bytes = used_device_memory - used_device_memory_start;
-        std::cout << " and used " << used_bytes * to_MB << "MB of device memory.";
+        printf(" and used %.1fMB of device memory.", used_bytes * to_MB);
     }
-    std::cout << std::endl;
+    printf("\n");
 
     first_run = false;
 {% endblock before_run_host_maincode %}
@@ -1066,7 +1013,7 @@ _run_kernel_{{codeobj_name}}(
 {% block host_maincode %}
     if ({{owner.name}}_scalar_delay)
     {
-        int num_eventspaces = dev{{_eventspace}}.size();
+        int num_eventspaces = _num_dev{{ _eventspace }};
         {{owner.name}}_eventspace_idx = (current_idx{{_eventspace}} - {{owner.name}}_delay + num_eventspaces) % num_eventspaces;
 
         //////////////////////////////////////////////
@@ -1080,7 +1027,7 @@ _run_kernel_{{codeobj_name}}(
         int32_t num_spiking_neurons;
         CUDA_SAFE_CALL(
                 cudaMemcpy(&num_spiking_neurons,
-                    dev{{_eventspace}}[current_idx{{_eventspace}}] + _num_{{owner.event}}space - 1,
+                    dev{{ _eventspace }}_view[current_idx{{ _eventspace }}] + _num_{{ owner.event }}space - 1,
                     sizeof(int32_t), cudaMemcpyDeviceToHost)
                 );
 
@@ -1133,7 +1080,7 @@ _run_kernel_{{codeobj_name}}(
                     num_parallel_blocks,
                     num_blocks,
                     num_threads,
-                    dev{{_eventspace}}[current_idx{{_eventspace}}]);
+                    dev{{ _eventspace }}_view[current_idx{{ _eventspace }}]);
 
             CUDA_CHECK_ERROR("_run_kernel_{{codeobj_name}}");
         }

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -196,12 +196,6 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
     // total number of synapses
     int syn_N = (int)syn_N_check;
 
-    // Skip re-init when delay was cleared after the first run and not repopulated.
-    if (!first_run && (host_array_{{ _dynamic_delay[15:] }} == nullptr
-            || _num_host_array_{{ _dynamic_delay[15:] }} == 0)) {
-        return;
-    }
-
     // simulation time step
     double dt = {{_source_dt}};
     // number of neurons in source group
@@ -323,7 +317,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
 
 
     //fill vectors of connectivity matrix with synapse IDs and delays (in units of simulation time step)
-    int max_delay = (int)(host_array_{{ _dynamic_delay[15:] }}[0] / dt + 0.5);
+    int max_delay = (int)(host_array_{{ array_basename(_dynamic_delay) }}[0] / dt + 0.5);
     {% if not no_or_const_delay_mode %}
     int min_delay = max_delay;
     {% endif %}
@@ -376,11 +370,11 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
         // be NOT equal to the idx in their NeuronGroup
         {% set source_ids = get_array_name(owner.synapse_sources, access_data=False) %}
         {% set target_ids = get_array_name(owner.synapse_targets, access_data=False) %}
-        int32_t pre_neuron_id = host_array_{{ source_ids[15:] }}[syn_id] - {{source_offset}};
-        int32_t post_neuron_id = host_array_{{ target_ids[15:] }}[syn_id] - {{target_offset}};
+        int32_t pre_neuron_id = host_array_{{ array_basename(source_ids) }}[syn_id] - {{source_offset}};
+        int32_t post_neuron_id = host_array_{{ array_basename(target_ids) }}[syn_id] - {{target_offset}};
 
         {% if not no_or_const_delay_mode %}
-        int delay = (int)(host_array_{{ _dynamic_delay[15:] }}[syn_id] / dt + 0.5);
+        int delay = (int)(host_array_{{ array_basename(_dynamic_delay) }}[syn_id] / dt + 0.5);
         if (delay > max_delay)
             max_delay = delay;
         if (delay < min_delay)
@@ -464,23 +458,31 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
 
             // sort synapses (values) and delays (keys) by delay
             sort_by_key_int_int32(
-                    h_vec_delays_by_pre[i].data(),
-                    h_vec_synapse_ids_by_pre[i].data(),
+                    h_vec_delays_by_pre[i].data(),     // keys start
+                    h_vec_synapse_ids_by_pre[i].data(), // values start
                     num_elements);
 
+            // worst case: number of unique delays is num_elements
             h_vec_unique_delay_start_idcs_by_pre[i].resize(num_elements);
+
+            // Initialise the unique delay start idcs array as a sequence
             fill_sequence_int(
                     h_vec_unique_delay_start_idcs_by_pre[i].data(),
                     num_elements);
 
+            // get delays (keys) and values (indices) for first occurence of each delay value
             size_t num_unique_elements = unique_by_key_int_int(
-                    h_vec_delays_by_pre[i].data(),
-                    h_vec_unique_delay_start_idcs_by_pre[i].data(),
+                    h_vec_delays_by_pre[i].data(),                 // keys start
+                    h_vec_unique_delay_start_idcs_by_pre[i].data(), // values start (position in original delay array)
                     num_elements);
 
+            // erase unneded vector entries
             h_vec_unique_delay_start_idcs_by_pre[i].resize(num_unique_elements);
+            // free not used but allocated host memory
             h_vec_unique_delay_start_idcs_by_pre[i].shrink_to_fit();
             h_vec_delays_by_pre[i].resize(num_unique_elements);
+            // delay_by_pre holds the set of unique delays now
+            // we don't need shrink_to_fit, swap takes care of that
             h_vec_unique_delays_by_pre[i].swap(h_vec_delays_by_pre[i]);
             sum_num_unique_elements += num_unique_elements;
 

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -883,6 +883,8 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
                 );
                 dev{{_eventspace}}.push_back(new_eventspace);
             }
+            // host_vector may have reallocated; refresh PIMPL views for lean COs
+            sync_all_dev_ptrs();
         }
     }
 

--- a/brian2cuda/templates/threshold.cu
+++ b/brian2cuda/templates/threshold.cu
@@ -1,12 +1,12 @@
 {# USES_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 {% endblock %}
 
 {% block after_run_headers %}
 {{ super() }}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 {% endblock %}
 
 {# not_refractory and lastspike are added as needed_variables in the

--- a/brian2cuda/templates/threshold.cu
+++ b/brian2cuda/templates/threshold.cu
@@ -1,5 +1,8 @@
 {# USES_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}
 
 {# not_refractory and lastspike are added as needed_variables in the
    Thresholder class, we cannot use the USES_VARIABLE mechanism

--- a/brian2cuda/templates/threshold.cu
+++ b/brian2cuda/templates/threshold.cu
@@ -1,13 +1,5 @@
 {# USES_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
-{% block extra_headers %}
-#include "objects_storage.h"
-{% endblock %}
-
-{% block after_run_headers %}
-{{ super() }}
-#include "objects_storage.h"
-{% endblock %}
 
 {# not_refractory and lastspike are added as needed_variables in the
    Thresholder class, we cannot use the USES_VARIABLE mechanism
@@ -86,7 +78,7 @@ _reset_{{codeobj_name}}(
 {% block extra_kernel_call %}
     {% if extra_threshold_kernel %}
         _reset_{{codeobj_name}}<<<num_blocks, num_threads>>>(
-                dev{{_eventspace_name}}[current_idx{{_eventspace_name}}]
+                dev{{ _eventspace_name }}_view[current_idx{{ _eventspace_name }}]
             );
 
         CUDA_CHECK_ERROR("_reset_{{codeobj_name}}");
@@ -98,7 +90,7 @@ _reset_{{codeobj_name}}(
 {% if not extra_threshold_kernel %}
     // reset eventspace counter to 0
     CUDA_SAFE_CALL(
-            cudaMemset(&(dev{{_eventspace_name}}[current_idx{{_eventspace_name}}][_N]), 0, sizeof(int32_t))
+            cudaMemset(&(dev{{ _eventspace_name }}_view[current_idx{{ _eventspace_name }}][_N]), 0, sizeof(int32_t))
             );
 {% endif %}
 {% endblock host_maincode %}
@@ -144,7 +136,7 @@ num_threads = min(max_threads_per_block, (int)ceil(_N/(double)num_blocks));
 {% endif %}
 
 _reset_{{codeobj_name}}<<<num_blocks, num_threads>>>(
-        dev{{_eventspace_name}}[current_idx{{_eventspace_name}}]
+        dev{{ _eventspace_name }}_view[current_idx{{ _eventspace_name }}]
     );
 
 CUDA_CHECK_ERROR("_reset_{{codeobj_name}}");

--- a/brian2cuda/templates/threshold.cu
+++ b/brian2cuda/templates/threshold.cu
@@ -4,6 +4,11 @@
 #include "objects_thrust.h"
 {% endblock %}
 
+{% block after_run_headers %}
+{{ super() }}
+#include "objects_thrust.h"
+{% endblock %}
+
 {# not_refractory and lastspike are added as needed_variables in the
    Thresholder class, we cannot use the USES_VARIABLE mechanism
    conditionally

--- a/examples/mushroombody.py
+++ b/examples/mushroombody.py
@@ -103,6 +103,8 @@ set_device(params['devicename'], directory=codefolder, compile=True, run=True,
 
 if params['seed'] is not None:
     seed(params['seed'])
+    np.random.seed(params['seed'])
+    py_random.seed(params['seed'])
 
 # Number of neurons
 N_MB = params['N']
@@ -274,7 +276,7 @@ if params['profiling']:
 
 if params['monitors']:
     style_file = os.path.join(os.path.dirname(__file__), 'figures.mplstyle')
-    plt.style.use(['seaborn-paper', style_file])
+    #plt.style.use(['seaborn-paper', style_file])
     fig = plt.figure(constrained_layout=True, figsize=(7.08, 7.08))
     axs = fig.subplot_mosaic(
     """

--- a/examples/stdp.py
+++ b/examples/stdp.py
@@ -89,6 +89,7 @@ update_from_command_line(params, choices=choices)
 
 # do the imports after parsing command line arguments (quicker --help)
 import os
+import random as py_random
 import matplotlib
 matplotlib.use('Agg')
 
@@ -116,6 +117,8 @@ set_device(params['devicename'], directory=codefolder, compile=True, run=True,
 
 if params['seed'] is not None:
     seed(params['seed'])
+    np.random.seed(params['seed'])
+    py_random.seed(params['seed'])
 
 # On average `K_poisson` Poisson neurons are connected to each LIF neuron
 N_poisson = params['N']
@@ -195,7 +198,7 @@ if params['profiling']:
         print('profiling information saved in {}'.format(profilingpath))
 
 style_file = os.path.join(os.path.dirname(__file__), 'figures.mplstyle')
-plt.style.use(['seaborn-paper', style_file])
+#plt.style.use(['seaborn-paper', style_file])
 
 if params['monitors']:
     # We show only the first second of activity, but show the weight development


### PR DESCRIPTION
## Header separation
This PR involves the header file separation of objects.h and rand.h. It's a preparation work for later PIMPL approach.
For objects.h, we now have objects_thrust.h, which is in charge of Thrust containers declaration. They are explicitly imported in templates right now. These will later be replaced by objects_api.h (which provides an API for Thrust functionalities). The main idea is to let code objects only include the Thrust library when they indeed need it, instead of importing it everywhere.

Another change concerns the RNG in objects.h, which has now been moved into rand.h, making it responsible for RNG  declarations / buffer / device states. Since parsing <curand.h> also takes a lot of time for a bunch of code objects, we only import it when necessary, just like what we did for Thrust. The main approach is similar to what we have achieved in cuda_generator.py. 
A better long-term approach would be making Brian2's BinomialFunction to forward compiler_kwds.

The modification was tested with examples/mushroombody.py with monitors on and N=1000 by manually testing the build time of the artifacts. 

Other minor modifications include adding the explicit namespace for std:: functions and adding random seed configurations for stdp.py and mushroombody.py.
## Outcomes:
The -j1 compilation time reduced from 273.2s to 223.0s. For -j12 compilation time, it dropped from 31.65s to 28.08s.

## Limits
Since we have thrust functionalities in a lot code objects. Splitting the header file will only provides a small acceleration.
A follow up PR would be PIMPL to hide the thrust and curand library for code objects, so that they won't parsing them and wasting time.