### PR TITLE
Issue 179 compilation speedup PIMPL

### DIFF
--- a/brian2cuda/binomial.py
+++ b/brian2cuda/binomial.py
@@ -4,11 +4,17 @@ CUDA implementation of `BinomialFunction`
 import numpy as np
 
 from brian2.core.functions import DEFAULT_FUNCTIONS
-from brian2.units.fundamentalunits import check_units
 from brian2.utils.stringtools import replace
 from brian2.input.binomial import (BinomialFunction, _pre_calc_constants,
                                    _pre_calc_constants_approximated)
 from brian2 import prefs
+#ths can be removed when brian2 is updated to forward compiler_kwds from target generators
+_CUDA_BINOMIAL_COMPILER_KWDS = {
+    "headers": [
+        '"rand.h"',
+        "<curand_kernel.h>",
+    ],
+}
 
 
 def _generate_cuda_code(n, p, use_normal, name):
@@ -103,3 +109,15 @@ def _generate_cuda_code(n, p, use_normal, name):
 
 
 BinomialFunction.implementations['cuda'] = _generate_cuda_code
+
+_original_binomial_init = BinomialFunction.__init__
+
+
+def _binomial_init_with_cuda_headers(self, n, p, approximate=True, name="_binomial*"):
+    _original_binomial_init(self, n, p, approximate=approximate, name=name)
+    cuda_impl = self.implementations._implementations.get("cuda")
+    if cuda_impl is not None:
+        cuda_impl.compiler_kwds = dict(_CUDA_BINOMIAL_COMPILER_KWDS)
+
+
+BinomialFunction.__init__ = _binomial_init_with_cuda_headers

--- a/brian2cuda/brianlib/clocks.h
+++ b/brian2cuda/brianlib/clocks.h
@@ -1,7 +1,6 @@
 #ifndef _BRIAN_CLOCKS_H
 #define _BRIAN_CLOCKS_H
 #include<stdlib.h>
-#include<iostream>
 #include<algorithm>
 #include<brianlib/stdint_compat.h>
 #include<math.h>

--- a/brian2cuda/brianlib/cuda_utils.h
+++ b/brian2cuda/brianlib/cuda_utils.h
@@ -1,9 +1,11 @@
 #ifndef BRIAN2CUDA_ERROR_CHECK_H
 #define BRIAN2CUDA_ERROR_CHECK_H
 #include <stdio.h>
-#include <thrust/system_error.h>
-#include "objects.h"
-#include "curand.h"
+#include <cuda_runtime.h>
+
+namespace brian{
+  extern size_t used_device_memory;
+}
 
 // Define this to turn on error checking
 #define BRIAN2CUDA_ERROR_CHECK
@@ -23,9 +25,9 @@
 #define THRUST_CHECK_ERROR(code)  { try {code;} \
     catch(...) {_thrustCheckError(__FILE__, __LINE__, #code);} }
 
-
+#ifdef BRIAN2CUDA_CURAND_HOST
+#include <curand.h>
 // adapted from NVIDIA cuda samples, shipped with cuda 10.1 (common/inc/helper_cuda.h)
-#ifdef CURAND_H_
 // cuRAND API errors
 static const char *_curandGetErrorEnum(curandStatus_t error) {
   switch (error) {
@@ -71,7 +73,21 @@ static const char *_curandGetErrorEnum(curandStatus_t error) {
 
   return "<unknown>";
 }
+
+inline void _cudaSafeCall(curandStatus_t err, const char *file, const int line, const char *call = "")
+{
+#ifdef BRIAN2CUDA_ERROR_CHECK
+    if (CURAND_STATUS_SUCCESS != err)
+    {
+        fprintf(stderr, "ERROR: %s failed at %s:%i : %s\n",
+                call, file, line, _curandGetErrorEnum(err));
+        exit(-1);
+    }
 #endif
+
+    return;
+}
+#endif // BRIAN2CUDA_CURAND_HOST
 
 
 inline void _cudaSafeCall(cudaError err, const char *file, const int line, const char *call = "")
@@ -87,22 +103,6 @@ inline void _cudaSafeCall(cudaError err, const char *file, const int line, const
 
     return;
 }
-
-
-inline void _cudaSafeCall(curandStatus_t err, const char *file, const int line, const char *call = "")
-{
-#ifdef BRIAN2CUDA_ERROR_CHECK
-    if (CURAND_STATUS_SUCCESS != err)
-    {
-        fprintf(stderr, "ERROR: %s failed at %s:%i : %s\n",
-                call, file, line, _curandGetErrorEnum(err));
-        exit(-1);
-    }
-#endif
-
-    return;
-}
-
 
 inline void _cudaCheckError(const char *file, const int line, const char *msg)
 {
@@ -176,5 +176,4 @@ inline void _thrustCheckError(const char *file, const int line,
             code, file, line);
     throw;
 }
-
 #endif  // BRIAN2CUDA_ERROR_CHECK_H

--- a/brian2cuda/brianlib/spikequeue.h
+++ b/brian2cuda/brianlib/spikequeue.h
@@ -1,4 +1,3 @@
-#include<iostream>
 #include<vector>
 #include<algorithm>
 #include<inttypes.h>

--- a/brian2cuda/codeobject.py
+++ b/brian2cuda/codeobject.py
@@ -95,10 +95,13 @@ codegen_targets.add(CUDAStandaloneAtomicsCodeObject)
 rand_code = '''
     #define _rand(vectorisation_idx) (_ptr_array_%CODEOBJ_NAME%_rand[vectorisation_idx])
     '''
+    
+_RAND_HEADERS = {"headers": ['"rand.h"']}
 rand_impls = DEFAULT_FUNCTIONS['rand'].implementations
 rand_impls.add_implementation(CUDAStandaloneCodeObject,
                               code=rand_code,
-                              name='_rand')
+                              name='_rand',
+                              compiler_kwds=_RAND_HEADERS)
 
 randn_code = '''
     #define _randn(vectorisation_idx) (_ptr_array_%CODEOBJ_NAME%_randn[vectorisation_idx])
@@ -106,4 +109,5 @@ randn_code = '''
 randn_impls = DEFAULT_FUNCTIONS['randn'].implementations
 randn_impls.add_implementation(CUDAStandaloneCodeObject,
                                code=randn_code,
-                               name='_randn')
+                               name='_randn',
+                               compiler_kwds=_RAND_HEADERS)

--- a/brian2cuda/cuda_generator.py
+++ b/brian2cuda/cuda_generator.py
@@ -989,7 +989,13 @@ DEFAULT_FUNCTIONS['poisson'].implementations.add_implementation(
     CUDACodeGenerator,
     code=poisson_code,
     name='_poisson',
-    compiler_kwds={"headers": ["<curand.h>"]}
+    compiler_kwds={
+        "headers": [
+            "<curand.h>",
+            "<curand_kernel.h>",
+            '"rand.h"',
+        ],
+    }
 )
 
 

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -64,8 +64,8 @@ class CUDAWriter(CPPWriter):
         elif filename.endswith('.*'):
             self.write(filename[:-1]+'cu', contents.cu_file)
             self.write(filename[:-1]+'h', contents.h_file)
-            if hasattr(contents, 'h_thrust_file'):
-                self.write(filename[:-2]+'_thrust.h', contents.h_thrust_file)
+            if hasattr(contents, 'h_storage_file'):
+                self.write(filename[:-2]+'_storage.h', contents.h_storage_file)
             return
         fullfilename = os.path.join(self.project_dir, filename)
         if os.path.exists(fullfilename):

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -1007,6 +1007,11 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 code = code.replace('%HOST_CONSTANTS%', '\n\t\t'.join(code_object_defs[codeobj.name]))
                 # ADDITIONAL_HOST_CODE is extra code, which needs `_N`
                 code = code.replace('%ADDITIONAL_HOST_CODE%', '\n\t\t'.join(additional_host_code[codeobj.name]))
+                curand_host_define = (
+                    '#define BRIAN2CUDA_CURAND_HOST\n'
+                    if additional_host_code[codeobj.name] else ''
+                )
+                code = code.replace('%CURAND_HOST_DEFINE%', curand_host_define)
                 # KERNEL_CONSTANTS are the same for inside device kernels
                 code = code.replace('%KERNEL_CONSTANTS%', '\n\t'.join(kernel_constants[codeobj.name]))
                 # HOST_PARAMETERS are parameters that device kernels are called with from host code
@@ -1076,13 +1081,16 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     N_value = co.owner._N
                 needed_number_curand_states[co_name] = (N_ptr, N_value)
 
-        rand_tmp = self.code_object_class().templater.rand(None, None,
-                                                           codeobjects_with_rng_per_run=self.codeobjects_with_rng["host_api"]["per_run"],
-                                                           all_poisson_lamdas=self.all_poisson_lamdas,
-                                                           needed_number_curand_states=needed_number_curand_states,
-                                                           number_run_calls=len(self.codeobjects_with_rng["host_api"]["per_run"]),
-                                                           profiled=self.enable_profiling,
-                                                           curand_float_type=c_data_type(prefs['core.default_float_dtype']))
+        rand_tmp = self.code_object_class().templater.rand(
+            None, None,
+            codeobjects_with_rng_per_run=self.codeobjects_with_rng["host_api"]["per_run"],
+            all_codeobj_with_host_rng=self.codeobjects_with_rng["host_api"]["all_runs"],
+            all_poisson_lamdas=self.all_poisson_lamdas,
+            needed_number_curand_states=needed_number_curand_states,
+            number_run_calls=len(self.codeobjects_with_rng["host_api"]["per_run"]),
+            profiled=self.enable_profiling,
+            curand_float_type=c_data_type(prefs['core.default_float_dtype']),
+        )
         writer.write('rand.*', rand_tmp)
 
     def copy_source_files(self, writer, directory):

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -46,6 +46,19 @@ logger = get_logger(__name__)
 CUDA_CPP_STD = '-std=c++17'
 CUDA_CPP_STD_MSVC = '/std:c++17'
 
+# Matches objects.cu DYNAMIC_ARRAY_PREFIX_LEN / '_dynamic_array_<name>'
+_DYNAMIC_ARRAY_PREFIX = '_dynamic_array_'
+_DEV_DYNAMIC_ARRAY_PREFIX = 'dev_dynamic_array_'
+
+
+def _dynamic_short(arrayname):
+    """Map '_dynamic_array_foo' or 'dev_dynamic_array_foo' -> 'foo', else None."""
+    if arrayname.startswith(_DYNAMIC_ARRAY_PREFIX):
+        return arrayname[len(_DYNAMIC_ARRAY_PREFIX):]
+    if arrayname.startswith(_DEV_DYNAMIC_ARRAY_PREFIX):
+        return arrayname[len(_DEV_DYNAMIC_ARRAY_PREFIX):]
+    return None
+
 
 class CUDAWriter(CPPWriter):
     def __init__(self, project_dir):
@@ -525,7 +538,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                         # At curand state initalization, synapses are not generated yet.
                         # For codeobjects run every tick, this happens in the init() of
                         # the random number buffer called at first clock cycle of the network
-                        main_lines.append('random_number_buffer.ensure_enough_curand_states();')
+                        main_lines.append('random_number_buffer_ensure_enough_curand_states();')
                 main_lines.append(f'_run_{codeobj.name}();')
             elif func == 'after_run_code_object':
                 codeobj, = args
@@ -540,43 +553,37 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     # TODO: Move this into before_run_synapses_push_spikes
                     for synaptic_pre, delete in self.delete_synaptic_pre.items():
                         if delete:
-                            code = f'''
-                                dev{synaptic_pre}.clear();
-                                dev{synaptic_pre}.shrink_to_fit();
-                            '''
-                            main_lines.extend(stripped_deindented_lines(code))
+                            short = _dynamic_short(synaptic_pre)
+                            main_lines.append(f'clear_dev_array_{short}();')
                     for synaptic_post, delete in self.delete_synaptic_post.items():
                         if delete:
-                            code = f'''
-                                dev{synaptic_post}.clear();
-                                dev{synaptic_post}.shrink_to_fit();
-                            '''
-                            main_lines.extend(stripped_deindented_lines(code))
+                            short = _dynamic_short(synaptic_post)
+                            main_lines.append(f'clear_dev_array_{short}();')
                     for synaptic_delay, delete in self.delete_synaptic_delay.items():
                         if delete:
-                            code = f'''
-                                dev{synaptic_delay}.clear();
-                                dev{synaptic_delay}.shrink_to_fit();
-                            '''
-                            main_lines.extend(stripped_deindented_lines(code))
+                            short = _dynamic_short(synaptic_delay)
+                            main_lines.append(f'clear_dev_array_{short}();')
                 # The actual network code
                 main_lines.extend(netcode)
                 # Increment run counter
                 run_counter += 1
             elif func=='set_by_constant':
                 arrayname, value, is_dynamic = args
-                size_str = f"{arrayname}.size()" if is_dynamic else f"_num_{arrayname}"
+                short = _dynamic_short(arrayname)
+                host_arrayname = f'host_array_{short}' if short is not None else arrayname
+                size_str = (f'_num_host_array_{short}' if (is_dynamic and short is not None)
+                            else f'_num_{arrayname}')
                 rendered_value = CPPNodeRenderer().render_expr(repr(value))
                 pointer_arrayname = f"dev{arrayname}"
                 if arrayname.endswith('space'):  # eventspace
-                    pointer_arrayname += f'[current_idx{arrayname}]'
-                if is_dynamic:
-                    pointer_arrayname = f"thrust::raw_pointer_cast(&dev{arrayname}[0])"
+                    pointer_arrayname += f'_view[current_idx{arrayname}]'
+                if is_dynamic and short is not None:
+                    pointer_arrayname = f'dev_array_{short}'
                 # Set on host
                 code = f'''
                     for(int i=0; i<{size_str}; i++)
                     {{
-                        {arrayname}[i] = {rendered_value};
+                        {host_arrayname}[i] = {rendered_value};
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
@@ -585,8 +592,8 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
                             {pointer_arrayname},
-                            &{arrayname}[0],
-                            sizeof({arrayname}[0])*{size_str},
+                            {host_arrayname},
+                            sizeof({host_arrayname}[0])*{size_str},
                             cudaMemcpyHostToDevice
                         )
                     );
@@ -594,21 +601,23 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_by_single_value':
                 arrayname, item, value = args
+                short = _dynamic_short(arrayname)
+                host_arrayname = f'host_array_{short}' if short is not None else arrayname
                 pointer_arrayname = f"dev{arrayname}"
                 if arrayname.endswith('space'):  # eventspace
-                    pointer_arrayname += f'[current_idx{arrayname}]'
-                if arrayname in self.dynamic_arrays.values():
-                    pointer_arrayname = f"thrust::raw_pointer_cast(&dev{arrayname}[0])"
+                    pointer_arrayname += f'_view[current_idx{arrayname}]'
+                if short is not None:
+                    pointer_arrayname = f'dev_array_{short}'
                 # Set on host
-                code = f"{arrayname}[{item}] = {value};"
+                code = f"{host_arrayname}[{item}] = {value};"
                 if arrayname not in self.variables_on_host_only:
                     # Copy to device
                     code += f'''
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
                             {pointer_arrayname} + {item},
-                            &{arrayname}[{item}],
-                            sizeof({arrayname}[{item}]),
+                            {host_arrayname} + {item},
+                            sizeof({host_arrayname}[{item}]),
                             cudaMemcpyHostToDevice
                         )
                     );
@@ -616,17 +625,18 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_by_array':
                 arrayname, staticarrayname, is_dynamic = args
-                size_str = "_num_" + arrayname
-                if is_dynamic:
-                    size_str = arrayname + ".size()"
+                short = _dynamic_short(arrayname)
+                host_arrayname = f'host_array_{short}' if short is not None else arrayname
+                size_str = (f'_num_host_array_{short}' if (is_dynamic and short is not None)
+                            else f'_num_{arrayname}')
                 pointer_arrayname = f"dev{arrayname}"
-                if arrayname in self.dynamic_arrays.values():
-                    pointer_arrayname = f"thrust::raw_pointer_cast(&dev{arrayname}[0])"
+                if short is not None:
+                    pointer_arrayname = f'dev_array_{short}'
                 # Set on host
                 code = f'''
                     for(int i=0; i<_num_{staticarrayname}; i++)
                     {{
-                        {arrayname}[i] = {staticarrayname}[i];
+                        {host_arrayname}[i] = {staticarrayname}[i];
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
@@ -635,8 +645,8 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
                             {pointer_arrayname},
-                            &{arrayname}[0],
-                            sizeof({arrayname}[0])*{size_str},
+                            {host_arrayname},
+                            sizeof({host_arrayname}[0])*{size_str},
                             cudaMemcpyHostToDevice
                         )
                     );
@@ -644,11 +654,19 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_array_by_array':
                 arrayname, staticarrayname_index, staticarrayname_value = args
+                short = _dynamic_short(arrayname)
+                host_arrayname = f'host_array_{short}' if short is not None else arrayname
+                if short is not None:
+                    dev_ptr = f'dev_array_{short}'
+                    memcpy_size = f'_num_host_array_{short}'
+                else:
+                    dev_ptr = f'dev{arrayname}'
+                    memcpy_size = f'_num_{arrayname}'
                 # Set on host
                 code = f'''
                     for(int i=0; i<_num_{staticarrayname_index}; i++)
                     {{
-                        {arrayname}[{staticarrayname_index}[i]] = {staticarrayname_value}[i];
+                        {host_arrayname}[{staticarrayname_index}[i]] = {staticarrayname_value}[i];
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
@@ -656,9 +674,9 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     code += f'''
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
-                            dev{arrayname},
-                            &{arrayname}[0],
-                            sizeof({arrayname}[0])*_num_{arrayname},
+                            {dev_ptr},
+                            {host_arrayname},
+                            sizeof({host_arrayname}[0])*{memcpy_size},
                             cudaMemcpyHostToDevice
                         )
                     );
@@ -666,7 +684,11 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='resize_array':
                 array_name, new_size = args
-                code = f'''
+                short = _dynamic_short(array_name)
+                if short is not None:
+                    code = f'resize_dev_array_{short}({new_size});'
+                else:
+                    code = f'''
                     {array_name}.resize({new_size});
                     THRUST_CHECK_ERROR(dev{array_name}.resize({new_size}));
                 '''
@@ -689,7 +711,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 if seed is None:
                     # draw random seed in range of possible uint64 numbers
                     seed = np.random.randint(np.iinfo(np.uint64).max, dtype=np.uint64)
-                main_lines.append(f'random_number_buffer.set_seed({seed!r}ULL);')
+                main_lines.append(f'random_number_buffer_set_seed({seed!r}ULL);')
             else:
                 raise NotImplementedError("Unknown main queue function type "+func)
 
@@ -897,10 +919,27 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                             dtype = c_data_type(v.dtype)
                             if isinstance(v, DynamicArrayVariable):
                                 if v.ndim == 1:
-
-                                    code_object_defs_lines.append(
-                                        f'{dtype}* const {array_name} = thrust::raw_pointer_cast(&{dyn_array_name}[0]);'
-                                    )
+                                    short = _dynamic_short(dyn_array_name)
+                                    if short is not None:
+                                        if prefix == 'dev':
+                                            pimpl_ptr = f'dev_array_{short}'
+                                        else:
+                                            pimpl_ptr = f'host_array_{short}'
+                                        # If the alias would have the same name as the
+                                        # global pimpl pointer (e.g. dev_array_synapses_weight),
+                                        # emitting `T* const x = x;` would shadow the global
+                                        # with a self-initialized (garbage) local. Just use
+                                        # the global directly in that case.
+                                        if array_name != pimpl_ptr:
+                                            code_object_defs_lines.append(
+                                                f'{dtype}* const {array_name} = {pimpl_ptr};'
+                                            )
+                                    else:
+                                        code_object_defs_lines.append(
+                                            f'{dtype}* const {array_name} = '
+                                            f'thrust::raw_pointer_cast('
+                                            f'&{dyn_array_name}[0]);'
+                                        )
 
                                     # Add host and kernel parameters only for device pointers
                                     if prefix == 'dev':
@@ -916,11 +955,16 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                         kernel_parameters_lines.append(f"{dtype}* {ptr_array_name}")
 
                                     # Add size variables `_num{array}` only once and if
-                                    # there are two prefixes, base it on host array
-                                    # `{array}.size()`
+                                    # there are two prefixes, base it on host array size
                                     if len(prefixes) == 1 or prefix == '':
+                                        if short is None:
+                                            num_expr = f'{dyn_array_name}.size()'
+                                        elif prefix == '' or len(prefixes) > 1:
+                                            num_expr = f'_num_host_array_{short}'
+                                        else:
+                                            num_expr = f'_num_dev_array_{short}'
                                         code_object_defs_lines.append(
-                                            f'const int _num{k} = {dyn_array_name}.size();'
+                                            f'const int _num{k} = {num_expr};'
                                         )
                                         host_parameters_lines.append(f"_num{k}")
                                         kernel_parameters_lines.append(f"const int _num{k}")
@@ -931,7 +975,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                     idx = ''
                                     if k.endswith('space'):
                                         bare_array_name = self.get_array_name(v)
-                                        idx = f'[current_idx{bare_array_name}]'
+                                        idx = f'_view[current_idx{bare_array_name}]'
                                     host_parameters_lines.append(f"{array_name}{idx}")
                                     kernel_parameters_lines.append(f'{dtype}* {ptr_array_name}')
 
@@ -1774,7 +1818,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
         )
         run_lines.extend(self.code_lines["after_network_run"])
         # for multiple runs, the random number buffer needs to be reset
-        run_lines.append('random_number_buffer.run_finished();')
+        run_lines.append('random_number_buffer_run_finished();')
         # nvprof stuff
         run_lines.append('CUDA_SAFE_CALL(cudaDeviceSynchronize());')
         run_lines.append('CUDA_SAFE_CALL(cudaProfilerStop());')

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -64,6 +64,8 @@ class CUDAWriter(CPPWriter):
         elif filename.endswith('.*'):
             self.write(filename[:-1]+'cu', contents.cu_file)
             self.write(filename[:-1]+'h', contents.h_file)
+            if hasattr(contents, 'h_thrust_file'):
+                self.write(filename[:-2]+'_thrust.h', contents.h_thrust_file)
             return
         fullfilename = os.path.join(self.project_dir, filename)
         if os.path.exists(fullfilename):

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -66,6 +66,8 @@ class CUDAWriter(CPPWriter):
             self.write(filename[:-1]+'h', contents.h_file)
             if hasattr(contents, 'h_storage_file'):
                 self.write(filename[:-2]+'_storage.h', contents.h_storage_file)
+            if hasattr(contents, 'h_api_file'):
+                self.write(filename[:-2]+'_api.h', contents.h_api_file)
             return
         fullfilename = os.path.join(self.project_dir, filename)
         if os.path.exists(fullfilename):

--- a/brian2cuda/templates/common_group.cu
+++ b/brian2cuda/templates/common_group.cu
@@ -1,18 +1,22 @@
 {# USES_VARIABLES { N } #}
-
-{### BEFORE RUN ###}
-{% macro before_run_cu_file() %}
-{% block before_run_headers %}
+{% macro co_std_includes() %}
 #include "code_objects/{{codeobj_name}}.h"
 #include "objects.h"
 #include "brianlib/common_math.h"
 #include "brianlib/cuda_utils.h"
 #include "brianlib/stdint_compat.h"
-#include <chrono>
 #include <cmath>
-#include <stdint.h>
+#include <cstdint>
+#include <cstdio>
+#include <cassert>
 #include <ctime>
-#include <stdio.h>
+{% endmacro %}
+
+{### BEFORE RUN ###}
+{% macro before_run_cu_file() %}
+{% block before_run_headers %}
+{{co_std_includes()}}
+#include <chrono>
 {% endblock before_run_headers %}
 
 {% block before_run_defines %}
@@ -44,16 +48,7 @@ void _before_run_{{codeobj_name}}();
 
 {### RUN ###}
 {% macro cu_file() %}
-#include "code_objects/{{codeobj_name}}.h"
-#include "objects.h"
-#include "brianlib/common_math.h"
-#include "brianlib/cuda_utils.h"
-#include "brianlib/stdint_compat.h"
-#include <cmath>
-#include <stdint.h>
-#include <ctime>
-#include <stdio.h>
-
+{{co_std_includes()}}
 {% block extra_headers %}
 {% endblock %}
 
@@ -359,15 +354,7 @@ void _run_{{codeobj_name}}();
 {### AFTER RUN ###}
 {% macro after_run_cu_file() %}
 {% block after_run_headers %}
-#include "code_objects/{{codeobj_name}}.h"
-#include "objects.h"
-#include "brianlib/common_math.h"
-#include "brianlib/cuda_utils.h"
-#include "brianlib/stdint_compat.h"
-#include <cmath>
-#include <stdint.h>
-#include <ctime>
-#include <stdio.h>
+{{ co_std_includes() }}
 {% endblock after_run_headers %}
 
 {% block after_run_defines %}
@@ -386,7 +373,7 @@ void _after_run_{{codeobj_name}}()
 
 {% macro after_run_h_file() %}
 #ifndef _INCLUDED_{{codeobj_name}}_after
-#define _INCLUDED_{{codeobj_name}}_affer
+#define _INCLUDED_{{codeobj_name}}_after
 
 void _after_run_{{codeobj_name}}();
 

--- a/brian2cuda/templates/common_group.cu
+++ b/brian2cuda/templates/common_group.cu
@@ -3,6 +3,7 @@
 #include "code_objects/{{codeobj_name}}.h"
 #include "objects.h"
 #include "brianlib/common_math.h"
+%CURAND_HOST_DEFINE%
 #include "brianlib/cuda_utils.h"
 #include "brianlib/stdint_compat.h"
 #include <cmath>

--- a/brian2cuda/templates/common_synapses.cu
+++ b/brian2cuda/templates/common_synapses.cu
@@ -1,6 +1,7 @@
 {# USES_VARIABLES { N, no_delay_mode } #}
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
+#include "objects_thrust.h"
 #include <stdint.h>
 #include "synapses_classes.h"
 {% endblock %}

--- a/brian2cuda/templates/common_synapses.cu
+++ b/brian2cuda/templates/common_synapses.cu
@@ -1,7 +1,7 @@
 {# USES_VARIABLES { N, no_delay_mode } #}
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 #include <stdint.h>
 #include "synapses_classes.h"
 {% endblock %}

--- a/brian2cuda/templates/group_variable_set.cu
+++ b/brian2cuda/templates/group_variable_set.cu
@@ -2,7 +2,8 @@
 {% extends 'common_group.cu' %}
 
 {% block extra_headers %}
-#include "rand.h"
+#include "objects_thrust.h"
+{# rand.h / curand host API pulled in on demand when this CO uses RNG #}
 {% endblock %}
 
 {% block kernel_maincode %}

--- a/brian2cuda/templates/group_variable_set.cu
+++ b/brian2cuda/templates/group_variable_set.cu
@@ -2,7 +2,7 @@
 {% extends 'common_group.cu' %}
 
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 {% endblock %}
 
 {% block kernel_maincode %}

--- a/brian2cuda/templates/group_variable_set.cu
+++ b/brian2cuda/templates/group_variable_set.cu
@@ -3,7 +3,6 @@
 
 {% block extra_headers %}
 #include "objects_thrust.h"
-{# rand.h / curand host API pulled in on demand when this CO uses RNG #}
 {% endblock %}
 
 {% block kernel_maincode %}

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -3,7 +3,7 @@
 {% extends 'common_group.cu' %}
 
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 {% endblock %}
 
 {% block kernel_maincode %}

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -2,6 +2,9 @@
 {# ALLOWS_SCALAR_WRITE #}
 {% extends 'common_group.cu' %}
 
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}
 
 {% block kernel_maincode %}
     ///// block kernel_maincode /////

--- a/brian2cuda/templates/main.cu
+++ b/brian2cuda/templates/main.cu
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 #include "objects.h"
-#include "objects_thrust.h"
+#include "objects_storage.h"
 #include <csignal>
 #include <ctime>
 #include <time.h>

--- a/brian2cuda/templates/main.cu
+++ b/brian2cuda/templates/main.cu
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include "objects.h"
+#include "objects_thrust.h"
 #include <csignal>
 #include <ctime>
 #include <time.h>

--- a/brian2cuda/templates/main.cu
+++ b/brian2cuda/templates/main.cu
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include "objects.h"
 #include "objects_storage.h"
+#include "objects_api.h"
 #include <csignal>
 #include <ctime>
 #include <time.h>

--- a/brian2cuda/templates/network.cu
+++ b/brian2cuda/templates/network.cu
@@ -2,6 +2,7 @@
 
 #include "brianlib/cuda_utils.h"
 #include "objects.h"
+#include "objects_thrust.h"
 #include "network.h"
 #include <stdlib.h>
 #include <iostream>

--- a/brian2cuda/templates/network.cu
+++ b/brian2cuda/templates/network.cu
@@ -2,7 +2,7 @@
 
 #include "brianlib/cuda_utils.h"
 #include "objects.h"
-#include "objects_thrust.h"
+#include "objects_storage.h"
 #include "network.h"
 #include <stdlib.h>
 #include <iostream>

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -16,13 +16,14 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 
 #include "objects_thrust.h"
 #include "objects.h"
+#define BRIAN2CUDA_CURAND_HOST
 #include "brianlib/cuda_utils.h"
 #include "rand.h"
 #include <iostream>
 #include <fstream>
 #include <chrono>
+#include <ctime>
 #include <curand.h>
-#include <curand_kernel.h>
 
 size_t brian::used_device_memory = 0;
 std::string brian::results_dir = "results/";  // can be overwritten by --results_dir command line arg
@@ -303,32 +304,6 @@ std::chrono::nanoseconds brian::{{codeobj}}_kernel_currents_profiling_info(0);
 {% endfor %}
 {% endif %}
 
-//////////////random numbers//////////////////
-curandGenerator_t brian::curand_generator;
-__device__ unsigned long long* brian::d_curand_seed;
-unsigned long long* brian::dev_curand_seed;
-// dev_{co.name}_{rng_type}_allocator
-//      pointer to start of generated random numbers array
-//      at each generation cycle this array is refilled
-// dev_{co.name}_{rng_type}
-//      pointer moving through generated random number array
-//      until it is regenerated at the next generation cycle
-{% for rng_type in all_codeobj_with_host_rng.keys() %}
-{% for co in all_codeobj_with_host_rng[rng_type] | sort(attribute='name') %}
-{% if rng_type in ['rand', 'randn'] %}
-{% set dtype = 'randomNumber_t' %}
-{% else %}  {# rng_type = 'poisson_<idx>' #}
-{% set dtype = 'unsigned int' %}
-{% endif %}
-{{dtype}}* brian::dev_{{co.name}}_{{rng_type}}_allocator;
-{{dtype}}* brian::dev_{{co.name}}_{{rng_type}};
-__device__ {{dtype}}* brian::_array_{{co.name}}_{{rng_type}};
-{% endfor %}{# rng_type #}
-{% endfor %}{# co #}
-curandState* brian::dev_curand_states;
-__device__ curandState* brian::d_curand_states;
-RandomNumberBuffer brian::random_number_buffer;
-
 void _init_arrays()
 {
     using namespace brian;
@@ -485,8 +460,8 @@ void _load_arrays()
     using namespace brian;
 
     {% for (name, dtype_spec, N, filename) in static_array_specs | sort %}
-    ifstream f{{name}};
-    f{{name}}.open("static_arrays/{{name}}", ios::in | ios::binary);
+    std::ifstream f{{name}};
+    f{{name}}.open("static_arrays/{{name}}", std::ios::in | std::ios::binary);
     if(f{{name}}.is_open())
     {
         {% if name in dynamic_array_specs.values() %}
@@ -496,7 +471,7 @@ void _load_arrays()
         {% endif %}
     } else
     {
-        std::cout << "Error opening static array {{name}}." << endl;
+        std::cout << "Error opening static array {{name}}." << std::endl;
     }
     {% if not (name in dynamic_array_specs.values()) %}
     CUDA_SAFE_CALL(
@@ -526,15 +501,15 @@ void _write_arrays()
             cudaMemcpy({{varname}}, dev{{varname}}, sizeof({{c_data_type(var.dtype)}})*_num_{{varname}}, cudaMemcpyDeviceToHost)
             );
     {% endif %}
-    ofstream outfile_{{varname}};
-    outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", ios::binary | ios::out);
+    std::ofstream outfile_{{varname}};
+    outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", std::ios::binary | std::ios::out);
     if(outfile_{{varname}}.is_open())
     {
         outfile_{{varname}}.write(reinterpret_cast<char*>({{varname}}), {{var.size}}*sizeof({{c_data_type(var.dtype)}}));
         outfile_{{varname}}.close();
     } else
     {
-        std::cout << "Error writing output file for {{varname}}." << endl;
+        std::cout << "Error writing output file for {{varname}}." << std::endl;
     }
     {% endif %}
     {% endfor %}
@@ -543,15 +518,15 @@ void _write_arrays()
     {% if varname not in variables_on_host_only %}
     {{varname}} = dev{{varname}};
     {% endif %}
-    ofstream outfile_{{varname}};
-    outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", ios::binary | ios::out);
+    std::ofstream outfile_{{varname}};
+    outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", std::ios::binary | std::ios::out);
     if(outfile_{{varname}}.is_open())
     {
         outfile_{{varname}}.write(reinterpret_cast<char*>(thrust::raw_pointer_cast(&{{varname}}[0])), {{varname}}.size()*sizeof({{c_data_type(var.dtype)}}));
         outfile_{{varname}}.close();
     } else
     {
-        std::cout << "Error writing output file for {{varname}}." << endl;
+        std::cout << "Error writing output file for {{varname}}." << std::endl;
     }
     {% endfor %}
 
@@ -559,11 +534,11 @@ void _write_arrays()
         {% if var in profile_statemonitor_vars %}
         {# Record copying statemonitor variable from device to host for benchmarking #}
         std::chrono::nanoseconds before_copy_statemon;
-        string profile_statemonitor_copy_to_host_varname = "{{var.owner.name}}_copy_to_host_{{profile_statemonitor_copy_to_host}}";
+        std::string profile_statemonitor_copy_to_host_varname = "{{var.owner.name}}_copy_to_host_{{profile_statemonitor_copy_to_host}}";
         std::chrono::nanoseconds copy_time_statemon;
         {% endif %}
-        ofstream outfile_{{varname}};
-        outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", ios::binary | ios::out);
+        std::ofstream outfile_{{varname}};
+        outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", std::ios::binary | std::ios::out);
         if(outfile_{{varname}}.is_open())
         {
             {% if var in profile_statemonitor_vars %}
@@ -575,7 +550,7 @@ void _write_arrays()
                 temp_array{{varname}}[n] = {{varname}}[n];
             }
             {% if var in profile_statemonitor_vars %}
-            string profile_statemonitor_copy_to_host_varname = "{{varname}}_copy_to_host";
+            std::string profile_statemonitor_copy_to_host_varname = "{{varname}}_copy_to_host";
             copy_time_statemon += std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - before_copy_statemon);
             {% endif %}
             for(int j = 0; j < temp_array{{varname}}[0].size(); j++)
@@ -588,14 +563,14 @@ void _write_arrays()
             outfile_{{varname}}.close();
         } else
         {
-            std::cout << "Error writing output file for {{varname}}." << endl;
+            std::cout << "Error writing output file for {{varname}}." << std::endl;
         }
     {% endfor %}
 
     {% if profiled_codeobjects is defined and profiled_codeobjects %}
     // Write profiling info to disk
-    ofstream outfile_profiling_info;
-    outfile_profiling_info.open(results_dir + "profiling_info.txt", ios::out);
+    std::ofstream outfile_profiling_info;
+    outfile_profiling_info.open(results_dir + "profiling_info.txt", std::ios::out);
     if(outfile_profiling_info.is_open())
     {
     {% for codeobj in profiled_codeobjects | sort %}
@@ -620,8 +595,8 @@ void _write_arrays()
     }
     {% endif %}
     // Write last run info to disk
-    ofstream outfile_last_run_info;
-    outfile_last_run_info.open(results_dir + "last_run_info.txt", ios::out);
+    std::ofstream outfile_last_run_info;
+    outfile_last_run_info.open(results_dir + "last_run_info.txt", std::ios::out);
     if(outfile_last_run_info.is_open())
     {
         outfile_last_run_info << (Network::_last_run_time) << " " << (Network::_last_run_completed_fraction) << std::endl;
@@ -749,8 +724,6 @@ typedef struct curandStateXORWOW curandState;
 #include <chrono>
 {% endif %}
 
-class RandomNumberBuffer;
-
 namespace brian {
 
 extern size_t used_device_memory;
@@ -848,31 +821,6 @@ extern std::chrono::nanoseconds {{codeobj}}_kernel_currents_profiling_info;
 #}
 {% endfor %}
 {% endif %}
-
-//////////////// random numbers /////////////////
-extern curandGenerator_t curand_generator;
-extern unsigned long long* dev_curand_seed;
-extern __device__ unsigned long long* d_curand_seed;
-
-{% for rng_type in all_codeobj_with_host_rng.keys() %}
-{% for co in all_codeobj_with_host_rng[rng_type] | sort(attribute='name') %}
-{% if rng_type in ['rand', 'randn'] %}
-{% set dtype = 'randomNumber_t' %}
-{% else %}  {# rng_type = 'poisson_<idx>' #}
-{% set dtype = 'unsigned int' %}
-{% endif %}
-// pointer to start of generated random numbers array
-// at each generation cycle this array is refilled
-extern {{dtype}}* dev_{{co.name}}_{{rng_type}}_allocator;
-// pointer moving through generated random number array
-// until it is regenerated at the next generation cycle
-extern {{dtype}}* dev_{{co.name}}_{{rng_type}};
-extern __device__ {{dtype}}* _array_{{co.name}}_{{rng_type}};
-{% endfor %}{# rng_type #}
-{% endfor %}{# co #}
-extern curandState* dev_curand_states;
-extern __device__ curandState* d_curand_states;
-extern RandomNumberBuffer random_number_buffer;
 
 //CUDA
 extern int num_parallel_blocks;

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -14,21 +14,13 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 {% endif %}
 {%- endmacro %}
 
+#include "objects_thrust.h"
 #include "objects.h"
-#include "synapses_classes.h"
-#include "brianlib/clocks.h"
 #include "brianlib/cuda_utils.h"
-#include "network.h"
 #include "rand.h"
-#include <stdint.h>
 #include <iostream>
 #include <fstream>
 #include <chrono>
-#include <ctime>
-#include <utility>
-
-#include <thrust/host_vector.h>
-#include <thrust/device_vector.h>
 #include <curand.h>
 #include <curand_kernel.h>
 
@@ -730,26 +722,34 @@ void _dealloc_arrays()
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 
 {% macro h_file() %}
-#include <ctime>
+
 // typedefs need to be outside the include guards to
 // be visible to all files including objects.h
 typedef {{curand_float_type}} randomNumber_t;  // random number type
 
+struct curandGenerator_st;
+typedef struct curandGenerator_st* curandGenerator_t;
+#ifndef CURAND_KERNEL_H_
+struct curandStateXORWOW;
+typedef struct curandStateXORWOW curandState;
+#endif
+
 #ifndef _BRIAN_OBJECTS_H
 #define _BRIAN_OBJECTS_H
 
-#include<vector>
-#include<stdint.h>
-#include "synapses_classes.h"
+#include <vector>
+#include <string>
+#include <stdint.h>
 #include "brianlib/clocks.h"
 #include "network.h"
-#include "rand.h"
-
-#include <thrust/device_vector.h>
-#include <thrust/host_vector.h>
+{% if synapses %}
+#include "synapses_classes.h"
+{% endif %}
+{% if profiled_codeobjects is defined %}
 #include <chrono>
-#include <curand.h>
-#include <curand_kernel.h>
+{% endif %}
+
+class RandomNumberBuffer;
 
 namespace brian {
 
@@ -772,14 +772,6 @@ extern Network {{net.name}};
 
 extern void set_variable_by_name(std::string, std::string);
 
-//////////////// dynamic arrays 1d ///////////
-{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-extern thrust::host_vector<{{c_data_type(var.dtype)}}> {{varname}};
-extern thrust::device_vector<{{c_data_type(var.dtype)}}> dev{{varname}};
-{% endfor %}
-{% for varname in subgroups_with_spikemonitor %}
-extern thrust::device_vector<int32_t> _dev_{{varname}}_eventspace;
-{% endfor %}
 
 //////////////// arrays ///////////////////
 {% for var, varname in array_specs | dictsort(by='value') %}
@@ -794,18 +786,11 @@ extern const int _num_{{varname}};
 //////////////// eventspaces ///////////////
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 extern {{c_data_type(var.dtype)}} * {{varname}};
-extern thrust::host_vector<{{c_data_type(var.dtype)}}*> dev{{varname}};
 extern const int _num_{{varname}};
 extern int current_idx{{varname}};
 {% if varname in spikegenerator_eventspaces %}
 extern int previous_idx{{varname}};
 {% endif %}
-{% endfor %}
-
-//////////////// dynamic arrays 2d /////////
-{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
-extern thrust::device_vector<{{c_data_type(var.dtype)}}*> addresses_monitor_{{varname}};
-extern thrust::device_vector<{{c_data_type(var.dtype)}}>* {{varname}};
 {% endfor %}
 
 /////////////// static arrays /////////////
@@ -906,4 +891,38 @@ void _dealloc_arrays();
 #endif
 
 
+{% endmacro %}
+
+{% macro h_thrust_file() %}
+#include "objects.h"
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+#ifndef _BRIAN_OBJECTS_THRUST_H
+#define _BRIAN_OBJECTS_THRUST_H
+
+namespace brian {
+
+//////////////// dynamic arrays 1d ///////////
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+extern thrust::host_vector<{{c_data_type(var.dtype)}}> {{varname}};
+extern thrust::device_vector<{{c_data_type(var.dtype)}}> dev{{varname}};
+{% endfor %}
+{% for varname in subgroups_with_spikemonitor %}
+extern thrust::device_vector<int32_t> _dev_{{varname}}_eventspace;
+{% endfor %}
+
+//////////////// eventspaces ///////////////
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+extern thrust::host_vector<{{c_data_type(var.dtype)}}*> dev{{varname}};
+{% endfor %}
+
+//////////////// dynamic arrays 2d /////////
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+extern thrust::device_vector<{{c_data_type(var.dtype)}}*> addresses_monitor_{{varname}};
+extern thrust::device_vector<{{c_data_type(var.dtype)}}>* {{varname}};
+{% endfor %}
+
+}
+#endif // _BRIAN_OBJECTS_THRUST_H
 {% endmacro %}

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -1123,7 +1123,6 @@ void random_number_buffer_set_seed(unsigned long long seed);
 void random_number_buffer_ensure_enough_curand_states();
 void random_number_buffer_run_finished();
 
-void _run_random_number_buffer();
 
 void curand_generate_normal_double(
         curandGenerator_t gen, double* out, size_t n, double mean, double stddev);

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -14,7 +14,7 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 {% endif %}
 {%- endmacro %}
 
-#include "objects_thrust.h"
+#include "objects_storage.h"
 #include "objects.h"
 #define BRIAN2CUDA_CURAND_HOST
 #include "brianlib/cuda_utils.h"
@@ -841,13 +841,13 @@ void _dealloc_arrays();
 
 {% endmacro %}
 
-{% macro h_thrust_file() %}
+{% macro h_storage_file() %}
 #include "objects.h"
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
-#ifndef _BRIAN_OBJECTS_THRUST_H
-#define _BRIAN_OBJECTS_THRUST_H
+#ifndef _BRIAN_OBJECTS_STORAGE_H
+#define _BRIAN_OBJECTS_STORAGE_H
 
 namespace brian {
 
@@ -872,5 +872,5 @@ extern thrust::device_vector<{{c_data_type(var.dtype)}}>* {{varname}};
 {% endfor %}
 
 }
-#endif // _BRIAN_OBJECTS_THRUST_H
+#endif // _BRIAN_OBJECTS_STORAGE_H
 {% endmacro %}

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -14,16 +14,22 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 {% endif %}
 {%- endmacro %}
 
+#define BRIAN2CUDA_CURAND_HOST
 #include "objects_storage.h"
 #include "objects.h"
-#define BRIAN2CUDA_CURAND_HOST
+#include "objects_api.h"
 #include "brianlib/cuda_utils.h"
 #include "rand.h"
 #include <iostream>
 #include <fstream>
 #include <chrono>
 #include <ctime>
+#include <algorithm>
 #include <curand.h>
+#include <thrust/sort.h>
+#include <thrust/sequence.h>
+#include <thrust/unique.h>
+#include <thrust/copy.h>
 
 size_t brian::used_device_memory = 0;
 std::string brian::results_dir = "results/";  // can be overwritten by --results_dir command line arg
@@ -216,6 +222,199 @@ thrust::device_vector<{{c_data_type(var.dtype)}}*> brian::addresses_monitor_{{va
 thrust::device_vector<{{c_data_type(var.dtype)}}>* brian::{{varname}};
 {% endfor %}
 
+// PIMPL: bare pointers synced from Thrust containers.
+// varname is '_dynamic_array_<name>'; PIMPL symbols use <name> only.
+{% set DYNAMIC_ARRAY_PREFIX_LEN = 15 %}  {# len('_dynamic_array_') #}
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
+{{c_data_type(var.dtype)}}* brian::host_array_{{ N }} = nullptr;
+int brian::_num_host_array_{{ N }} = 0;
+{{c_data_type(var.dtype)}}* brian::dev_array_{{ N }} = nullptr;
+int brian::_num_dev_array_{{ N }} = 0;
+{% endfor %}
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+{{c_data_type(var.dtype)}}** brian::dev{{ varname }}_view = nullptr;
+int brian::_num_dev{{ varname }} = 0;
+{% endfor %}
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+{{c_data_type(var.dtype)}}** brian::monitor_addresses_{{ varname }} = nullptr;
+int brian::_num_monitor_addresses_{{ varname }} = 0;
+{% endfor %}
+{% for varname in subgroups_with_spikemonitor %}
+int32_t* brian::dev_array_subgroup_eventspace_{{varname}} = nullptr;
+int brian::_num_subgroup_eventspace_{{varname}} = 0;
+{% endfor %}
+
+namespace brian {
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
+void sync_array_{{ N }}() {
+    _num_host_array_{{ N }} = static_cast<int>({{ varname }}.size());
+    host_array_{{ N }} = _num_host_array_{{ N }} ? &{{ varname }}[0] : nullptr;
+    _num_dev_array_{{ N }} = static_cast<int>(dev{{ varname }}.size());
+    dev_array_{{ N }} = _num_dev_array_{{ N }}
+        ? thrust::raw_pointer_cast(&dev{{ varname }}[0]) : nullptr;
+}
+{% endfor %}
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+void sync_eventspace_{{ varname }}() {
+    _num_dev{{ varname }} = static_cast<int>(dev{{ varname }}.size());
+    dev{{ varname }}_view = dev{{ varname }}.empty() ? nullptr : &dev{{ varname }}[0];
+}
+{% endfor %}
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+void sync_monitor_addresses_{{ varname }}() {
+    _num_monitor_addresses_{{ varname }} = static_cast<int>(addresses_monitor_{{ varname }}.size());
+    monitor_addresses_{{ varname }} = _num_monitor_addresses_{{ varname }}
+        ? thrust::raw_pointer_cast(&addresses_monitor_{{ varname }}[0]) : nullptr;
+}
+{% endfor %}
+{% for varname in subgroups_with_spikemonitor %}
+void sync_subgroup_eventspace_{{varname}}() {
+    _num_subgroup_eventspace_{{varname}} = static_cast<int>(_dev_{{varname}}_eventspace.size());
+    dev_array_subgroup_eventspace_{{varname}} = _num_subgroup_eventspace_{{varname}}
+        ? thrust::raw_pointer_cast(&_dev_{{varname}}_eventspace[0]) : nullptr;
+}
+{% endfor %}
+
+void sync_all_dev_ptrs() {
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+    sync_array_{{ varname[DYNAMIC_ARRAY_PREFIX_LEN:] }}();
+{% endfor %}
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+    sync_eventspace_{{ varname }}();
+{% endfor %}
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+    sync_monitor_addresses_{{ varname }}();
+{% endfor %}
+{% for varname in subgroups_with_spikemonitor %}
+    sync_subgroup_eventspace_{{varname}}();
+{% endfor %}
+}
+
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
+void push_back_host_array_{{ N }}({{c_data_type(var.dtype)}} v) {
+    {{ varname }}.push_back(v);
+    sync_array_{{ N }}();
+}
+void resize_host_array_{{ N }}(size_t n) {
+    {{ varname }}.resize(n);
+    sync_array_{{ N }}();
+}
+void resize_dev_array_{{ N }}(size_t n) {
+    THRUST_CHECK_ERROR(dev{{ varname }}.resize(n));
+    {{ varname }}.resize(n);
+    sync_array_{{ N }}();
+}
+void copy_dev_to_host_array_{{ N }}() {
+    {{ varname }} = dev{{ varname }};
+    sync_array_{{ N }}();
+}
+void copy_host_to_dev_array_{{ N }}() {
+    dev{{ varname }} = {{ varname }};
+    sync_array_{{ N }}();
+}
+void clear_dev_array_{{ N }}() {
+    dev{{ varname }}.clear();
+    dev{{ varname }}.shrink_to_fit();
+    sync_array_{{ N }}();
+}
+{% endfor %}
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+void expand_eventspace{{ varname }}(int num_queues) {
+    int num_eventspaces = static_cast<int>(dev{{ varname }}.size());
+    if (num_queues <= num_eventspaces) return;
+    std::rotate(
+        dev{{ varname }}.begin(),
+        dev{{ varname }}.begin() + current_idx{{ varname }},
+        dev{{ varname }}.end());
+    current_idx{{ varname }} = 0;
+    for (int i = num_eventspaces; i < num_queues; i++) {
+        {{c_data_type(var.dtype)}}* new_eventspace;
+        CUDA_SAFE_CALL(cudaMalloc(
+            (void**)&new_eventspace,
+            sizeof({{c_data_type(var.dtype)}}) * _num_{{ varname }}));
+        CUDA_SAFE_CALL(cudaMemcpy(
+            new_eventspace, {{ varname }},
+            sizeof({{c_data_type(var.dtype)}}) * _num_{{ varname }},
+            cudaMemcpyHostToDevice));
+        dev{{ varname }}.push_back(new_eventspace);
+    }
+    sync_eventspace_{{ varname }}();
+}
+{% endfor %}
+{% for varname in subgroups_with_spikemonitor %}
+void resize_subgroup_eventspace_{{varname}}(size_t n) {
+    THRUST_CHECK_ERROR(_dev_{{varname}}_eventspace.resize(n));
+    sync_subgroup_eventspace_{{varname}}();
+}
+{% endfor %}
+struct _subgroup_eventspace_pred {
+    int32_t start;
+    int32_t stop;
+    __device__ bool operator()(int32_t neuron) const {
+        return start <= neuron && neuron < stop;
+    }
+};
+int filter_subgroup_eventspace(
+        int32_t* src, int n, int32_t* dst, int32_t start, int32_t stop) {
+    thrust::device_ptr<int32_t> d_src(src);
+    thrust::device_ptr<int32_t> d_dst(dst);
+    auto out = thrust::copy_if(
+            d_src, d_src + n, d_dst, _subgroup_eventspace_pred{start, stop});
+    return static_cast<int>(out - d_dst);
+}
+void curand_generate_normal_double(
+        curandGenerator_t gen, double* out, size_t n, double mean, double stddev) {
+    CUDA_SAFE_CALL(curandGenerateNormalDouble(gen, out, n, mean, stddev));
+}
+void curand_generate_uniform_double(curandGenerator_t gen, double* out, size_t n) {
+    CUDA_SAFE_CALL(curandGenerateUniformDouble(gen, out, n));
+}
+void curand_generate_normal_float(
+        curandGenerator_t gen, float* out, size_t n, float mean, float stddev) {
+    CUDA_SAFE_CALL(curandGenerateNormal(gen, out, n, mean, stddev));
+}
+void curand_generate_uniform_float(curandGenerator_t gen, float* out, size_t n) {
+    CUDA_SAFE_CALL(curandGenerateUniform(gen, out, n));
+}
+void curand_generate_poisson(
+        curandGenerator_t gen, unsigned int* out, size_t n, double lambda) {
+    CUDA_SAFE_CALL(curandGeneratePoisson(gen, out, n, lambda));
+}
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+void clear_monitor_addresses_{{ varname }}() {
+    addresses_monitor_{{ varname }}.clear();
+    sync_monitor_addresses_{{ varname }}();
+}
+void resize_monitor_row_{{ varname }}(int row, size_t n) {
+    {{ varname }}[row].resize(n);
+    sync_monitor_addresses_{{ varname }}();
+}
+void push_monitor_address_{{ varname }}(int row) {
+    addresses_monitor_{{ varname }}.push_back(
+        thrust::raw_pointer_cast(&{{ varname }}[row][0]));
+    sync_monitor_addresses_{{ varname }}();
+}
+void set_monitor_address_{{ varname }}(int row) {
+    addresses_monitor_{{ varname }}[row] =
+        thrust::raw_pointer_cast(&{{ varname }}[row][0]);
+    sync_monitor_addresses_{{ varname }}();
+}
+{% endfor %}
+void sort_by_key_int_int32(int* keys, int32_t* values, size_t n) {
+    thrust::sort_by_key(thrust::host, keys, keys + n, values);
+}
+void fill_sequence_int(int* out, size_t n) {
+    thrust::sequence(thrust::host, out, out + n);
+}
+size_t unique_by_key_int_int(int* keys, int* values, size_t n) {
+    return static_cast<size_t>(thrust::unique_by_key(
+        thrust::host, keys, keys + n, values).first - keys);
+}
+}  // namespace brian
+
 /////////////// static arrays /////////////
 {% for (name, dtype_spec, N, filename) in static_array_specs | sort %}
 {# arrays that are initialized from static data are already declared #}
@@ -352,7 +551,7 @@ void _init_arrays()
     {% endif %}
 
     // this sets seed for host and device api RNG
-    random_number_buffer.set_seed(seed);
+    random_number_buffer_set_seed(seed);
 
     {% for S in synapses | sort(attribute='name') %}
     {% for path in S._pathways | sort(attribute='name') %}
@@ -449,6 +648,7 @@ void _init_arrays()
     const double to_MB = 1.0 / (1024.0 * 1024.0);
     double tot_memory_MB = (used_device_memory - used_device_memory_start) * to_MB;
     double time_passed = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start_timer).count();
+    sync_all_dev_ptrs();
     std::cout << "INFO: _init_arrays() took " <<  time_passed << "s";
     if (tot_memory_MB > 0)
         std::cout << " and used " << tot_memory_MB << "MB of device memory.";
@@ -777,6 +977,35 @@ extern const int _num_{{name}};
 {% endif %}
 {% endfor %}
 
+//////////////// dynamic arrays 1d (pimpl pointers) ///////////
+{# varname is '_dynamic_array_<name>'; expose <name> only #}
+{% set DYNAMIC_ARRAY_PREFIX_LEN = 15 %}  {# len('_dynamic_array_') #}
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
+extern {{c_data_type(var.dtype)}}* host_array_{{ N }};
+extern int _num_host_array_{{ N }};
+extern {{c_data_type(var.dtype)}}* dev_array_{{ N }};
+extern int _num_dev_array_{{ N }};
+{% endfor %}
+
+//////////////// eventspaces (pimpl pointers) ///////////////
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+extern {{c_data_type(var.dtype)}}** dev{{ varname }}_view;
+extern int _num_dev{{ varname }};
+{% endfor %}
+
+//////////////// dynamic arrays 2d (pimpl pointers) ///////////////
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+extern {{c_data_type(var.dtype)}}** monitor_addresses_{{ varname }};
+extern int _num_monitor_addresses_{{ varname }};
+{% endfor %}
+
+//////////////// subgroup eventspace buffers (pimpl pointers) ///////////////
+{% for varname in subgroups_with_spikemonitor %}
+extern int32_t* dev_array_subgroup_eventspace_{{varname}};
+extern int _num_subgroup_eventspace_{{varname}};
+{% endfor %}
+
 //////////////// synapses /////////////////
 {% for S in synapses | sort(attribute='name') %}
 // {{S.name}}
@@ -873,4 +1102,66 @@ extern thrust::device_vector<{{c_data_type(var.dtype)}}>* {{varname}};
 
 }
 #endif // _BRIAN_OBJECTS_STORAGE_H
+{% endmacro %}
+
+{% macro h_api_file() %}
+#ifndef _BRIAN_OBJECTS_API_H
+#define _BRIAN_OBJECTS_API_H
+
+#include <cstddef>
+#include <cstdint>
+
+struct curandGenerator_st;
+typedef struct curandGenerator_st* curandGenerator_t;
+
+namespace brian {
+
+{# Public: full refresh after _init_arrays. Per-array sync_* stay internal to objects.cu. #}
+void sync_all_dev_ptrs();
+
+void random_number_buffer_set_seed(unsigned long long seed);
+void random_number_buffer_ensure_enough_curand_states();
+void random_number_buffer_run_finished();
+
+void _run_random_number_buffer();
+
+void curand_generate_normal_double(
+        curandGenerator_t gen, double* out, size_t n, double mean, double stddev);
+void curand_generate_uniform_double(curandGenerator_t gen, double* out, size_t n);
+void curand_generate_normal_float(
+        curandGenerator_t gen, float* out, size_t n, float mean, float stddev);
+void curand_generate_uniform_float(curandGenerator_t gen, float* out, size_t n);
+void curand_generate_poisson(
+        curandGenerator_t gen, unsigned int* out, size_t n, double lambda);
+
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+void expand_eventspace{{ varname }}(int num_queues);
+{% endfor %}
+void sort_by_key_int_int32(int* keys, int32_t* values, size_t n);
+void fill_sequence_int(int* out, size_t n);
+size_t unique_by_key_int_int(int* keys, int* values, size_t n);
+int filter_subgroup_eventspace(int32_t* src, int n, int32_t* dst, int32_t start, int32_t stop);
+{% for varname in subgroups_with_spikemonitor %}
+void resize_subgroup_eventspace_{{varname}}(size_t n);
+{% endfor %}
+{% set DYNAMIC_ARRAY_PREFIX_LEN = 15 %}  {# len('_dynamic_array_') #}
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = varname[DYNAMIC_ARRAY_PREFIX_LEN:] %}
+void resize_host_array_{{ N }}(size_t n);
+void push_back_host_array_{{ N }}({{c_data_type(var.dtype)}} v);
+void resize_dev_array_{{ N }}(size_t n);
+void clear_dev_array_{{ N }}();
+void copy_dev_to_host_array_{{ N }}();
+void copy_host_to_dev_array_{{ N }}();
+{% endfor %}
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+void clear_monitor_addresses_{{ varname }}();
+void resize_monitor_row_{{ varname }}(int row, size_t n);
+void push_monitor_address_{{ varname }}(int row);
+void set_monitor_address_{{ varname }}(int row);
+{% endfor %}
+
+}
+
+#endif
 {% endmacro %}

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -65,18 +65,18 @@ template<class T> void set_variable_from_value(std::string varname, T* var_point
 }
 
 template<class T> void set_variable_from_file(std::string varname, T* var_pointer, size_t data_size, std::string filename) {
-    ifstream f;
-    streampos size;
+    std::ifstream f;
+    std::streampos size;
     #ifdef DEBUG
     std::cout << "Setting '" << varname << "' from file '" << filename << "'" << std::endl;
     #endif
-    f.open(filename, ios::in | ios::binary | ios::ate);
+    f.open(filename, std::ios::in | std::ios::binary | std::ios::ate);
     size = f.tellg();
     if (size != data_size) {
         std::cerr << "Error reading '" << filename << "': file size " << size << " does not match expected size " << data_size << std::endl;
         return;
     }
-    f.seekg(0, ios::beg);
+    f.seekg(0, std::ios::beg);
     if (f.is_open())
         f.read(reinterpret_cast<char *>(var_pointer), data_size);
     else

--- a/brian2cuda/templates/rand.cu
+++ b/brian2cuda/templates/rand.cu
@@ -4,6 +4,7 @@
 #include "rand.h"
 #include "synapses_classes.h"
 #include "brianlib/clocks.h"
+#define BRIAN2CUDA_CURAND_HOST
 #include "brianlib/cuda_utils.h"
 #include "network.h"
 #include <curand.h>
@@ -14,6 +15,32 @@
 //      https://github.com/brian-team/brian2cuda/wiki/Random-number-generation
 
 using namespace brian;
+
+//////////////random numbers//////////////////
+curandGenerator_t brian::curand_generator;
+__device__ unsigned long long* brian::d_curand_seed;
+unsigned long long* brian::dev_curand_seed;
+// dev_{co.name}_{rng_type}_allocator
+//      pointer to start of generated random numbers array
+//      at each generation cycle this array is refilled
+// dev_{co.name}_{rng_type}
+//      pointer moving through generated random number array
+//      until it is regenerated at the next generation cycle
+{% for rng_type in all_codeobj_with_host_rng.keys() %}
+{% for co in all_codeobj_with_host_rng[rng_type] | sort(attribute='name') %}
+{% if rng_type in ['rand', 'randn'] %}
+{% set dtype = 'randomNumber_t' %}
+{% else %}  {# rng_type = 'poisson_<idx>' #}
+{% set dtype = 'unsigned int' %}
+{% endif %}
+{{dtype}}* brian::dev_{{co.name}}_{{rng_type}}_allocator;
+{{dtype}}* brian::dev_{{co.name}}_{{rng_type}};
+__device__ {{dtype}}* brian::_array_{{co.name}}_{{rng_type}};
+{% endfor %}{# rng_type #}
+{% endfor %}{# co #}
+curandState* brian::dev_curand_states;
+__device__ curandState* brian::d_curand_states;
+RandomNumberBuffer brian::random_number_buffer;
 
 // TODO make this a class member function
 // TODO don't call one kernel per codeobject but instead on kernel which takes
@@ -47,7 +74,7 @@ namespace {
 // method, which is of different type
 void _run_random_number_buffer()
 {
-    // random_number_buffer is a RandomNumberBuffer instance, declared in objects.cu
+    // random_number_buffer is a RandomNumberBuffer instance, declared in rand.cu
     random_number_buffer.next_time_step();
 }
 
@@ -470,7 +497,7 @@ void RandomNumberBuffer::next_time_step()
 #ifndef _BRIAN_RAND_H
 #define _BRIAN_RAND_H
 
-#include <curand.h>
+#include "objects.h"
 
 void _run_random_number_buffer();
 
@@ -559,6 +586,35 @@ public:
     void run_finished();
     void ensure_enough_curand_states();
 };
+
+namespace brian {
+
+//////////////// random numbers /////////////////
+extern curandGenerator_t curand_generator;
+extern unsigned long long* dev_curand_seed;
+extern __device__ unsigned long long* d_curand_seed;
+
+{% for rng_type in all_codeobj_with_host_rng.keys() %}
+{% for co in all_codeobj_with_host_rng[rng_type] | sort(attribute='name') %}
+{% if rng_type in ['rand', 'randn'] %}
+{% set dtype = 'randomNumber_t' %}
+{% else %}  {# rng_type = 'poisson_<idx>' #}
+{% set dtype = 'unsigned int' %}
+{% endif %}
+// pointer to start of generated random numbers array
+// at each generation cycle this array is refilled
+extern {{dtype}}* dev_{{co.name}}_{{rng_type}}_allocator;
+// pointer moving through generated random number array
+// until it is regenerated at the next generation cycle
+extern {{dtype}}* dev_{{co.name}}_{{rng_type}};
+extern __device__ {{dtype}}* _array_{{co.name}}_{{rng_type}};
+{% endfor %}{# rng_type #}
+{% endfor %}{# co #}
+extern curandState* dev_curand_states;
+extern __device__ curandState* d_curand_states;
+extern RandomNumberBuffer random_number_buffer;
+
+}
 
 #endif
 

--- a/brian2cuda/templates/rand.cu
+++ b/brian2cuda/templates/rand.cu
@@ -1,6 +1,7 @@
 {% macro cu_file() %}
 
 #include "objects.h"
+#include "objects_api.h"
 #include "rand.h"
 #include "synapses_classes.h"
 #include "brianlib/clocks.h"
@@ -488,6 +489,26 @@ void RandomNumberBuffer::next_time_step()
     }// run_counter == {{run_i}}
     {% endfor %}{# run_i #}
 }
+
+namespace brian {
+
+void random_number_buffer_set_seed(unsigned long long seed)
+{
+    random_number_buffer.set_seed(seed);
+}
+
+void random_number_buffer_ensure_enough_curand_states()
+{
+    random_number_buffer.ensure_enough_curand_states();
+}
+
+void random_number_buffer_run_finished()
+{
+    random_number_buffer.run_finished();
+}
+
+}  // namespace brian
+
 {% endmacro %}
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -2,6 +2,9 @@
                     _num_source_neurons, _source_start, _source_stop } #}
 {# WRITES_TO_READ_ONLY_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
+{% block extra_headers}
+#include "objects_thrust.h"
+{% endblock %}
 
 {% block define_N %}
 {% endblock %}

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -3,7 +3,7 @@
 {# WRITES_TO_READ_ONLY_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 {% endblock %}
 
 {% block define_N %}

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -2,7 +2,7 @@
                     _num_source_neurons, _source_start, _source_stop } #}
 {# WRITES_TO_READ_ONLY_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
-{% block extra_headers}
+{% block extra_headers %}
 #include "objects_thrust.h"
 {% endblock %}
 

--- a/brian2cuda/templates/reset.cu
+++ b/brian2cuda/templates/reset.cu
@@ -1,5 +1,9 @@
 {# USES_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}
+
 {% block kernel_maincode %}
 
     {#  Get the name of the array that stores these events (e.g. the spikespace array) #}

--- a/brian2cuda/templates/reset.cu
+++ b/brian2cuda/templates/reset.cu
@@ -1,7 +1,7 @@
 {# USES_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 {% endblock %}
 
 {% block kernel_maincode %}

--- a/brian2cuda/templates/run.cu
+++ b/brian2cuda/templates/run.cu
@@ -2,6 +2,7 @@
 #include<stdlib.h>
 #include "brianlib/cuda_utils.h"
 #include "objects.h"
+#include "rand.h"
 #include<ctime>
 
 {% for codeobj in code_objects | sort(attribute='name') %}

--- a/brian2cuda/templates/spatialstateupdate.cu
+++ b/brian2cuda/templates/spatialstateupdate.cu
@@ -13,7 +13,7 @@
 
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 {% endblock %}
 
 

--- a/brian2cuda/templates/spatialstateupdate.cu
+++ b/brian2cuda/templates/spatialstateupdate.cu
@@ -12,6 +12,9 @@
 
 
 {% extends 'common_group.cu' %}
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}
 
 
 {### BEFORE RUN ###}

--- a/brian2cuda/templates/spikegenerator.cu
+++ b/brian2cuda/templates/spikegenerator.cu
@@ -38,6 +38,9 @@
                    t_in_timesteps, N}
 #}
 {% extends 'common_group.cu' %}
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}
 {% block kernel_maincode %}
     // The period in multiples of dt
     const int32_t _the_period = {{_period_bins}};

--- a/brian2cuda/templates/spikegenerator.cu
+++ b/brian2cuda/templates/spikegenerator.cu
@@ -39,7 +39,7 @@
 #}
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 {% endblock %}
 {% block kernel_maincode %}
     // The period in multiples of dt

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -4,6 +4,7 @@
 
 
 {% block extra_headers %}
+#include "objects_thrust.h"
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -4,7 +4,7 @@
 
 
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>

--- a/brian2cuda/templates/statemonitor.cu
+++ b/brian2cuda/templates/statemonitor.cu
@@ -2,7 +2,7 @@
 {# WRITES_TO_READ_ONLY_VARIABLES { t, N } #}
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 {% endblock %}
 
 {% block define_N %}

--- a/brian2cuda/templates/statemonitor.cu
+++ b/brian2cuda/templates/statemonitor.cu
@@ -1,6 +1,9 @@
 {# USES_VARIABLES { t, _indices, N } #}
 {# WRITES_TO_READ_ONLY_VARIABLES { t, N } #}
 {% extends 'common_group.cu' %}
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}
 
 {% block define_N %}
 {% endblock %}

--- a/brian2cuda/templates/stateupdate.cu
+++ b/brian2cuda/templates/stateupdate.cu
@@ -2,5 +2,5 @@
 {# ALLOWS_SCALAR_WRITE #}
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 {% endblock %}

--- a/brian2cuda/templates/stateupdate.cu
+++ b/brian2cuda/templates/stateupdate.cu
@@ -1,3 +1,6 @@
 {# USES_VARIABLES { N } #}
 {# ALLOWS_SCALAR_WRITE #}
 {% extends 'common_group.cu' %}
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}

--- a/brian2cuda/templates/summed_variable.cu
+++ b/brian2cuda/templates/summed_variable.cu
@@ -1,6 +1,8 @@
 {# USES_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
-
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}
 
 {% block extra_kernel_call %}
 {# Get the device pointer from the thrust device vector for usage in host code #}

--- a/brian2cuda/templates/summed_variable.cu
+++ b/brian2cuda/templates/summed_variable.cu
@@ -1,7 +1,7 @@
 {# USES_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 {% endblock %}
 
 {% block extra_kernel_call %}

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -2,7 +2,7 @@
 
 {% block extra_headers %}
 {{ super() }}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 #include<map>
 {% endblock %}
 

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -2,6 +2,7 @@
 
 {% block extra_headers %}
 {{ super() }}
+#include "objects_thrust.h"
 #include<map>
 {% endblock %}
 

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -9,7 +9,7 @@
 
 {% block extra_headers %}
 {{ super() }}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 #include "rand.h"
 #include<iostream>
 #include<curand.h>

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -9,6 +9,7 @@
 
 {% block extra_headers %}
 {{ super() }}
+#include "objects_thrust.h"
 #include<iostream>
 #include<curand.h>
 #include<brianlib/curand_buffer.h>

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -10,6 +10,7 @@
 {% block extra_headers %}
 {{ super() }}
 #include "objects_thrust.h"
+#include "rand.h"
 #include<iostream>
 #include<curand.h>
 #include<brianlib/curand_buffer.h>

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -35,6 +35,8 @@
  # sorted by their delay (if they have any).
  #}
 {% block before_run_headers %}
+{{super()}}
+#include "objects_thrust.h"
 #include <thrust/sort.h>
 #include <thrust/reduce.h>
 #include <thrust/unique.h>

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -4,6 +4,10 @@
 {# Get the name of the array that stores these events (e.g. the spikespace array) #}
 {% set _eventspace = get_array_name(eventspace_variable, access_data=False) %}
 
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}
+
 {### BEFORE RUN ###}
 {# TEMPLATE INFO
  # This template creates the connectivity matrix for this SynapticPathway

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -5,7 +5,7 @@
 {% set _eventspace = get_array_name(eventspace_variable, access_data=False) %}
 
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 {% endblock %}
 
 {### BEFORE RUN ###}
@@ -40,7 +40,7 @@
  #}
 {% block before_run_headers %}
 {{super()}}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 #include <thrust/sort.h>
 #include <thrust/reduce.h>
 #include <thrust/unique.h>

--- a/brian2cuda/templates/threshold.cu
+++ b/brian2cuda/templates/threshold.cu
@@ -1,12 +1,12 @@
 {# USES_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 {% endblock %}
 
 {% block after_run_headers %}
 {{ super() }}
-#include "objects_thrust.h"
+#include "objects_storage.h"
 {% endblock %}
 
 {# not_refractory and lastspike are added as needed_variables in the

--- a/brian2cuda/templates/threshold.cu
+++ b/brian2cuda/templates/threshold.cu
@@ -1,5 +1,8 @@
 {# USES_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
+{% block extra_headers %}
+#include "objects_thrust.h"
+{% endblock %}
 
 {# not_refractory and lastspike are added as needed_variables in the
    Thresholder class, we cannot use the USES_VARIABLE mechanism

--- a/brian2cuda/templates/threshold.cu
+++ b/brian2cuda/templates/threshold.cu
@@ -4,6 +4,11 @@
 #include "objects_thrust.h"
 {% endblock %}
 
+{% block after_run_headers %}
+{{ super() }}
+#include "objects_thrust.h"
+{% endblock %}
+
 {# not_refractory and lastspike are added as needed_variables in the
    Thresholder class, we cannot use the USES_VARIABLE mechanism
    conditionally

--- a/examples/mushroombody.py
+++ b/examples/mushroombody.py
@@ -103,6 +103,8 @@ set_device(params['devicename'], directory=codefolder, compile=True, run=True,
 
 if params['seed'] is not None:
     seed(params['seed'])
+    np.random.seed(params['seed'])
+    py_random.seed(params['seed'])
 
 # Number of neurons
 N_MB = params['N']
@@ -274,7 +276,7 @@ if params['profiling']:
 
 if params['monitors']:
     style_file = os.path.join(os.path.dirname(__file__), 'figures.mplstyle')
-    plt.style.use(['seaborn-paper', style_file])
+    #plt.style.use(['seaborn-paper', style_file])
     fig = plt.figure(constrained_layout=True, figsize=(7.08, 7.08))
     axs = fig.subplot_mosaic(
     """

--- a/examples/stdp.py
+++ b/examples/stdp.py
@@ -89,6 +89,7 @@ update_from_command_line(params, choices=choices)
 
 # do the imports after parsing command line arguments (quicker --help)
 import os
+import random as py_random
 import matplotlib
 matplotlib.use('Agg')
 
@@ -116,6 +117,8 @@ set_device(params['devicename'], directory=codefolder, compile=True, run=True,
 
 if params['seed'] is not None:
     seed(params['seed'])
+    np.random.seed(params['seed'])
+    py_random.seed(params['seed'])
 
 # On average `K_poisson` Poisson neurons are connected to each LIF neuron
 N_poisson = params['N']
@@ -195,7 +198,7 @@ if params['profiling']:
         print('profiling information saved in {}'.format(profilingpath))
 
 style_file = os.path.join(os.path.dirname(__file__), 'figures.mplstyle')
-plt.style.use(['seaborn-paper', style_file])
+#plt.style.use(['seaborn-paper', style_file])
 
 if params['monitors']:
     # We show only the first second of activity, but show the weight development


### PR DESCRIPTION
This PR introduces PIMPL as we talked in meetings, reducing the cost of parsing heavy header files like Thrust during compilation of various codeobjects. Specifically: `objects_storage.h` holds the actual Thrust container. The lean `objects.h` exposes raw pointers (such as `dev_array_*` / `host_array_*`). And the newly generated `objects_api.h` inside `device.py` provides resize/clear/copy, eventspace extensions, and wrappers for some algorithms and cuRAND-related code previously scattered across other TUs. Most `.cu` files access data via raw pointers and the API, concentrating Thrust usage primarily in `objects.cu`.

## Pointers:
`sync_all_dev_ptrs()` is called once at the end of `_init_arrays()` for a full refresh. If the container is modified via the API (such as `resize_*`), only the relevant pointers are synchronized. Therefore, as long as mutates use the API, the global PIMPL pointer can remain consistent with the container. The trade-off is the generation of a large number of API symbols in arrays(which is quite ugly right now). A more general template could be considered later to reduce the amount of generated code. And also I haven't apply PIMPL also for host vector, which will be add soon in following commits.
## Outcome
On MushroomBody (N=1000), cold compilation with `make -j1` is reduced to approximately ~100s (compared to approximately ~200s on master under the same environment RTX3080Ti 12GB).