### PR TITLE
Issue 179 thrust isolation

### DIFF
--- a/brian2cuda/brianlib/device_buffer.cu
+++ b/brian2cuda/brianlib/device_buffer.cu
@@ -25,44 +25,9 @@ DeviceBuffer::DeviceBuffer(size_t elem_size)
 
 DeviceBuffer::~DeviceBuffer() = default;
 
-DeviceBuffer::DeviceBuffer(DeviceBuffer&& other) noexcept
-    : impl_(std::move(other.impl_)),
-      ptr_(other.ptr_),
-      elem_size_(other.elem_size_),
-      n_(other.n_)
-{
-    other.ptr_ = nullptr;
-    other.elem_size_ = 0;
-    other.n_ = 0;
-}
-
-DeviceBuffer& DeviceBuffer::operator=(DeviceBuffer&& other) noexcept
-{
-    if (this != &other)
-    {
-        impl_ = std::move(other.impl_);
-        ptr_ = other.ptr_;
-        elem_size_ = other.elem_size_;
-        n_ = other.n_;
-        other.ptr_ = nullptr;
-        other.elem_size_ = 0;
-        other.n_ = 0;
-    }
-    return *this;
-}
-
-void DeviceBuffer::init(size_t elem_size)
-{
-    if (!impl_)
-        impl_ = std::make_unique<Impl>();
-    if (elem_size_ != 0 && elem_size_ != elem_size && n_ > 0)
-        clear();
-    elem_size_ = elem_size;
-}
-
 void DeviceBuffer::refresh_ptr()
 {
-    if (!impl_ || impl_->bytes.empty())
+    if (impl_->bytes.empty())
         ptr_ = nullptr;
     else
         ptr_ = thrust::raw_pointer_cast(impl_->bytes.data());
@@ -70,11 +35,9 @@ void DeviceBuffer::refresh_ptr()
 
 void DeviceBuffer::resize(size_t n)
 {
-    if (!impl_)
-        impl_ = std::make_unique<Impl>();
     if (elem_size_ == 0)
     {
-        fprintf(stderr, "ERROR: DeviceBuffer used before init()\n");
+        fprintf(stderr, "ERROR: DeviceBuffer used before elem_size was set\n");
         exit(EXIT_FAILURE);
     }
     if (n == 0)
@@ -104,31 +67,10 @@ void DeviceBuffer::copy_to_host(void* dst) const
         dst, ptr_, n_ * elem_size_, cudaMemcpyDeviceToHost));
 }
 
-void DeviceBuffer::store(size_t i, const void* elem)
-{
-    if (elem == nullptr || i >= n_ || ptr_ == nullptr)
-        return;
-    CUDA_SAFE_CALL(cudaMemcpy(
-        static_cast<char*>(ptr_) + i * elem_size_,
-        elem,
-        elem_size_,
-        cudaMemcpyHostToDevice));
-}
-
-void DeviceBuffer::append(const void* elem)
-{
-    const size_t i = n_;
-    resize(n_ + 1);
-    store(i, elem);
-}
-
 void DeviceBuffer::clear()
 {
-    if (impl_)
-    {
-        THRUST_CHECK_ERROR(impl_->bytes.clear());
-        THRUST_CHECK_ERROR(impl_->bytes.shrink_to_fit());
-    }
+    THRUST_CHECK_ERROR(impl_->bytes.clear());
+    THRUST_CHECK_ERROR(impl_->bytes.shrink_to_fit());
     ptr_ = nullptr;
     n_ = 0;
 }

--- a/brian2cuda/brianlib/device_buffer.cu
+++ b/brian2cuda/brianlib/device_buffer.cu
@@ -13,21 +13,17 @@ struct DeviceBuffer<T>::Impl
 
 template<typename T>
 DeviceBuffer<T>::DeviceBuffer()
-    : impl_(new Impl()), ptr_(nullptr), n_(0)
+    : impl_(std::make_unique<Impl>()), ptr_(nullptr), n_(0)
 {
 }
 
 template<typename T>
-DeviceBuffer<T>::~DeviceBuffer()
-{
-    delete impl_;
-}
+DeviceBuffer<T>::~DeviceBuffer() = default;
 
 template<typename T>
 DeviceBuffer<T>::DeviceBuffer(DeviceBuffer&& other) noexcept
-    : impl_(other.impl_), ptr_(other.ptr_), n_(other.n_)
+    : impl_(std::move(other.impl_)), ptr_(other.ptr_), n_(other.n_)
 {
-    other.impl_ = nullptr;
     other.ptr_ = nullptr;
     other.n_ = 0;
 }
@@ -37,11 +33,9 @@ DeviceBuffer<T>& DeviceBuffer<T>::operator=(DeviceBuffer&& other) noexcept
 {
     if (this != &other)
     {
-        delete impl_;
-        impl_ = other.impl_;
+        impl_ = std::move(other.impl_);
         ptr_ = other.ptr_;
         n_ = other.n_;
-        other.impl_ = nullptr;
         other.ptr_ = nullptr;
         other.n_ = 0;
     }
@@ -51,7 +45,7 @@ DeviceBuffer<T>& DeviceBuffer<T>::operator=(DeviceBuffer&& other) noexcept
 template<typename T>
 void DeviceBuffer<T>::refresh_ptr()
 {
-    if (impl_ == nullptr || impl_->vec.empty())
+    if (!impl_ || impl_->vec.empty())
         ptr_ = nullptr;
     else
         ptr_ = thrust::raw_pointer_cast(impl_->vec.data());
@@ -60,8 +54,8 @@ void DeviceBuffer<T>::refresh_ptr()
 template<typename T>
 void DeviceBuffer<T>::resize(size_t n)
 {
-    if (impl_ == nullptr)
-        impl_ = new Impl();
+    if (!impl_)
+        impl_ = std::make_unique<Impl>();
     if (n == 0)
     {
         clear();
@@ -111,7 +105,7 @@ void DeviceBuffer<T>::append(const T& elem)
 template<typename T>
 void DeviceBuffer<T>::clear()
 {
-    if (impl_ != nullptr)
+    if (impl_)
     {
         THRUST_CHECK_ERROR(impl_->vec.clear());
         THRUST_CHECK_ERROR(impl_->vec.shrink_to_fit());

--- a/brian2cuda/brianlib/device_buffer.cu
+++ b/brian2cuda/brianlib/device_buffer.cu
@@ -1,0 +1,139 @@
+#include "brianlib/device_buffer.h"
+#include "brianlib/cuda_utils.h"
+
+#include <thrust/device_vector.h>
+
+namespace brian {
+
+template<typename T>
+struct DeviceBuffer<T>::Impl
+{
+    thrust::device_vector<T> vec;
+};
+
+template<typename T>
+DeviceBuffer<T>::DeviceBuffer()
+    : impl_(new Impl()), ptr_(nullptr), n_(0)
+{
+}
+
+template<typename T>
+DeviceBuffer<T>::~DeviceBuffer()
+{
+    delete impl_;
+}
+
+template<typename T>
+DeviceBuffer<T>::DeviceBuffer(DeviceBuffer&& other) noexcept
+    : impl_(other.impl_), ptr_(other.ptr_), n_(other.n_)
+{
+    other.impl_ = nullptr;
+    other.ptr_ = nullptr;
+    other.n_ = 0;
+}
+
+template<typename T>
+DeviceBuffer<T>& DeviceBuffer<T>::operator=(DeviceBuffer&& other) noexcept
+{
+    if (this != &other)
+    {
+        delete impl_;
+        impl_ = other.impl_;
+        ptr_ = other.ptr_;
+        n_ = other.n_;
+        other.impl_ = nullptr;
+        other.ptr_ = nullptr;
+        other.n_ = 0;
+    }
+    return *this;
+}
+
+template<typename T>
+void DeviceBuffer<T>::refresh_ptr()
+{
+    if (impl_ == nullptr || impl_->vec.empty())
+        ptr_ = nullptr;
+    else
+        ptr_ = thrust::raw_pointer_cast(impl_->vec.data());
+}
+
+template<typename T>
+void DeviceBuffer<T>::resize(size_t n)
+{
+    if (impl_ == nullptr)
+        impl_ = new Impl();
+    if (n == 0)
+    {
+        clear();
+        return;
+    }
+    THRUST_CHECK_ERROR(impl_->vec.resize(n));
+    n_ = n;
+    refresh_ptr();
+}
+
+template<typename T>
+void DeviceBuffer<T>::copy_from_host(const T* src, size_t n)
+{
+    resize(n);
+    if (n == 0 || src == nullptr)
+        return;
+    CUDA_SAFE_CALL(cudaMemcpy(
+        ptr_, src, n * sizeof(T), cudaMemcpyHostToDevice));
+}
+
+template<typename T>
+void DeviceBuffer<T>::copy_to_host(T* dst) const
+{
+    if (n_ == 0 || dst == nullptr || ptr_ == nullptr)
+        return;
+    CUDA_SAFE_CALL(cudaMemcpy(
+        dst, ptr_, n_ * sizeof(T), cudaMemcpyDeviceToHost));
+}
+
+template<typename T>
+void DeviceBuffer<T>::store(size_t i, const T& elem)
+{
+    if (i >= n_ || ptr_ == nullptr)
+        return;
+    CUDA_SAFE_CALL(cudaMemcpy(
+        ptr_ + i, &elem, sizeof(T), cudaMemcpyHostToDevice));
+}
+
+template<typename T>
+void DeviceBuffer<T>::append(const T& elem)
+{
+    const size_t i = n_;
+    resize(n_ + 1);
+    store(i, elem);
+}
+
+template<typename T>
+void DeviceBuffer<T>::clear()
+{
+    if (impl_ != nullptr)
+    {
+        THRUST_CHECK_ERROR(impl_->vec.clear());
+        THRUST_CHECK_ERROR(impl_->vec.shrink_to_fit());
+    }
+    ptr_ = nullptr;
+    n_ = 0;
+}
+
+// Explicit instantiations for types used by generated brian2cuda code.
+template class DeviceBuffer<char>;
+template class DeviceBuffer<int32_t>;
+template class DeviceBuffer<int64_t>;
+template class DeviceBuffer<uint32_t>;
+template class DeviceBuffer<uint64_t>;
+template class DeviceBuffer<float>;
+template class DeviceBuffer<double>;
+template class DeviceBuffer<char*>;
+template class DeviceBuffer<int32_t*>;
+template class DeviceBuffer<int64_t*>;
+template class DeviceBuffer<uint32_t*>;
+template class DeviceBuffer<uint64_t*>;
+template class DeviceBuffer<float*>;
+template class DeviceBuffer<double*>;
+
+}  // namespace brian

--- a/brian2cuda/brianlib/device_buffer.cu
+++ b/brian2cuda/brianlib/device_buffer.cu
@@ -3,131 +3,134 @@
 
 #include <thrust/device_vector.h>
 
+#include <cstdio>
+#include <cstdlib>
+
 namespace brian {
 
-template<typename T>
-struct DeviceBuffer<T>::Impl
+struct DeviceBuffer::Impl
 {
-    thrust::device_vector<T> vec;
+    thrust::device_vector<char> bytes;
 };
 
-template<typename T>
-DeviceBuffer<T>::DeviceBuffer()
-    : impl_(std::make_unique<Impl>()), ptr_(nullptr), n_(0)
+DeviceBuffer::DeviceBuffer()
+    : impl_(std::make_unique<Impl>()), ptr_(nullptr), elem_size_(0), n_(0)
 {
 }
 
-template<typename T>
-DeviceBuffer<T>::~DeviceBuffer() = default;
+DeviceBuffer::DeviceBuffer(size_t elem_size)
+    : impl_(std::make_unique<Impl>()), ptr_(nullptr), elem_size_(elem_size), n_(0)
+{
+}
 
-template<typename T>
-DeviceBuffer<T>::DeviceBuffer(DeviceBuffer&& other) noexcept
-    : impl_(std::move(other.impl_)), ptr_(other.ptr_), n_(other.n_)
+DeviceBuffer::~DeviceBuffer() = default;
+
+DeviceBuffer::DeviceBuffer(DeviceBuffer&& other) noexcept
+    : impl_(std::move(other.impl_)),
+      ptr_(other.ptr_),
+      elem_size_(other.elem_size_),
+      n_(other.n_)
 {
     other.ptr_ = nullptr;
+    other.elem_size_ = 0;
     other.n_ = 0;
 }
 
-template<typename T>
-DeviceBuffer<T>& DeviceBuffer<T>::operator=(DeviceBuffer&& other) noexcept
+DeviceBuffer& DeviceBuffer::operator=(DeviceBuffer&& other) noexcept
 {
     if (this != &other)
     {
         impl_ = std::move(other.impl_);
         ptr_ = other.ptr_;
+        elem_size_ = other.elem_size_;
         n_ = other.n_;
         other.ptr_ = nullptr;
+        other.elem_size_ = 0;
         other.n_ = 0;
     }
     return *this;
 }
 
-template<typename T>
-void DeviceBuffer<T>::refresh_ptr()
-{
-    if (!impl_ || impl_->vec.empty())
-        ptr_ = nullptr;
-    else
-        ptr_ = thrust::raw_pointer_cast(impl_->vec.data());
-}
-
-template<typename T>
-void DeviceBuffer<T>::resize(size_t n)
+void DeviceBuffer::init(size_t elem_size)
 {
     if (!impl_)
         impl_ = std::make_unique<Impl>();
+    if (elem_size_ != 0 && elem_size_ != elem_size && n_ > 0)
+        clear();
+    elem_size_ = elem_size;
+}
+
+void DeviceBuffer::refresh_ptr()
+{
+    if (!impl_ || impl_->bytes.empty())
+        ptr_ = nullptr;
+    else
+        ptr_ = thrust::raw_pointer_cast(impl_->bytes.data());
+}
+
+void DeviceBuffer::resize(size_t n)
+{
+    if (!impl_)
+        impl_ = std::make_unique<Impl>();
+    if (elem_size_ == 0)
+    {
+        fprintf(stderr, "ERROR: DeviceBuffer used before init()\n");
+        exit(EXIT_FAILURE);
+    }
     if (n == 0)
     {
         clear();
         return;
     }
-    THRUST_CHECK_ERROR(impl_->vec.resize(n));
+    THRUST_CHECK_ERROR(impl_->bytes.resize(n * elem_size_));
     n_ = n;
     refresh_ptr();
 }
 
-template<typename T>
-void DeviceBuffer<T>::copy_from_host(const T* src, size_t n)
+void DeviceBuffer::copy_from_host(const void* src, size_t n)
 {
     resize(n);
     if (n == 0 || src == nullptr)
         return;
     CUDA_SAFE_CALL(cudaMemcpy(
-        ptr_, src, n * sizeof(T), cudaMemcpyHostToDevice));
+        ptr_, src, n * elem_size_, cudaMemcpyHostToDevice));
 }
 
-template<typename T>
-void DeviceBuffer<T>::copy_to_host(T* dst) const
+void DeviceBuffer::copy_to_host(void* dst) const
 {
     if (n_ == 0 || dst == nullptr || ptr_ == nullptr)
         return;
     CUDA_SAFE_CALL(cudaMemcpy(
-        dst, ptr_, n_ * sizeof(T), cudaMemcpyDeviceToHost));
+        dst, ptr_, n_ * elem_size_, cudaMemcpyDeviceToHost));
 }
 
-template<typename T>
-void DeviceBuffer<T>::store(size_t i, const T& elem)
+void DeviceBuffer::store(size_t i, const void* elem)
 {
-    if (i >= n_ || ptr_ == nullptr)
+    if (elem == nullptr || i >= n_ || ptr_ == nullptr)
         return;
     CUDA_SAFE_CALL(cudaMemcpy(
-        ptr_ + i, &elem, sizeof(T), cudaMemcpyHostToDevice));
+        static_cast<char*>(ptr_) + i * elem_size_,
+        elem,
+        elem_size_,
+        cudaMemcpyHostToDevice));
 }
 
-template<typename T>
-void DeviceBuffer<T>::append(const T& elem)
+void DeviceBuffer::append(const void* elem)
 {
     const size_t i = n_;
     resize(n_ + 1);
     store(i, elem);
 }
 
-template<typename T>
-void DeviceBuffer<T>::clear()
+void DeviceBuffer::clear()
 {
     if (impl_)
     {
-        THRUST_CHECK_ERROR(impl_->vec.clear());
-        THRUST_CHECK_ERROR(impl_->vec.shrink_to_fit());
+        THRUST_CHECK_ERROR(impl_->bytes.clear());
+        THRUST_CHECK_ERROR(impl_->bytes.shrink_to_fit());
     }
     ptr_ = nullptr;
     n_ = 0;
 }
-
-// Explicit instantiations for types used by generated brian2cuda code.
-template class DeviceBuffer<char>;
-template class DeviceBuffer<int32_t>;
-template class DeviceBuffer<int64_t>;
-template class DeviceBuffer<uint32_t>;
-template class DeviceBuffer<uint64_t>;
-template class DeviceBuffer<float>;
-template class DeviceBuffer<double>;
-template class DeviceBuffer<char*>;
-template class DeviceBuffer<int32_t*>;
-template class DeviceBuffer<int64_t*>;
-template class DeviceBuffer<uint32_t*>;
-template class DeviceBuffer<uint64_t*>;
-template class DeviceBuffer<float*>;
-template class DeviceBuffer<double*>;
 
 }  // namespace brian

--- a/brian2cuda/brianlib/device_buffer.h
+++ b/brian2cuda/brianlib/device_buffer.h
@@ -1,0 +1,47 @@
+#ifndef BRIAN_DEVICE_BUFFER_H
+#define BRIAN_DEVICE_BUFFER_H
+
+#include <cstddef>
+#include <stdint.h>
+
+namespace brian {
+
+// Typed resizable device storage. Header is Thrust-free; thrust::device_vector<T>
+// lives only in device_buffer.cu behind Impl (PImpl).
+template<typename T>
+class DeviceBuffer
+{
+public:
+    DeviceBuffer();
+    ~DeviceBuffer();
+
+    DeviceBuffer(const DeviceBuffer&) = delete;
+    DeviceBuffer& operator=(const DeviceBuffer&) = delete;
+    DeviceBuffer(DeviceBuffer&& other) noexcept;
+    DeviceBuffer& operator=(DeviceBuffer&& other) noexcept;
+
+    size_t size() const { return n_; }
+    bool empty() const { return n_ == 0; }
+
+    T* data() { return ptr_; }
+    const T* data() const { return ptr_; }
+
+    void resize(size_t n);
+    void copy_from_host(const T* src, size_t n);
+    void copy_to_host(T* dst) const;
+    void append(const T& elem);
+    void store(size_t i, const T& elem);
+    void clear();
+
+private:
+    struct Impl;
+    Impl* impl_;
+    T* ptr_;
+    size_t n_;
+
+    void refresh_ptr();
+};
+
+}  // namespace brian
+
+#endif

--- a/brian2cuda/brianlib/device_buffer.h
+++ b/brian2cuda/brianlib/device_buffer.h
@@ -18,10 +18,6 @@ public:
 
     DeviceBuffer(const DeviceBuffer&) = delete;
     DeviceBuffer& operator=(const DeviceBuffer&) = delete;
-    DeviceBuffer(DeviceBuffer&& other) noexcept;
-    DeviceBuffer& operator=(DeviceBuffer&& other) noexcept;
-
-    void init(size_t elem_size);
 
     size_t size() const { return n_; }
     bool empty() const { return n_ == 0; }
@@ -34,16 +30,17 @@ public:
     template<typename T>
     const T* data_as() const { return static_cast<const T*>(data()); }
 
+    void set_elem_size(size_t elem_size) { elem_size_ = elem_size; }
+
     void resize(size_t n);
     void copy_from_host(const void* src, size_t n);
     void copy_to_host(void* dst) const;
-    void append(const void* elem);
-    void store(size_t i, const void* elem);
     void clear();
 
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_;
+    // Cached from impl_->bytes; must stay in sync via refresh_ptr().
     void* ptr_;
     size_t elem_size_;
     size_t n_;

--- a/brian2cuda/brianlib/device_buffer.h
+++ b/brian2cuda/brianlib/device_buffer.h
@@ -2,6 +2,7 @@
 #define BRIAN_DEVICE_BUFFER_H
 
 #include <cstddef>
+#include <memory>
 #include <stdint.h>
 
 namespace brian {
@@ -35,7 +36,7 @@ public:
 
 private:
     struct Impl;
-    Impl* impl_;
+    std::unique_ptr<Impl> impl_;
     T* ptr_;
     size_t n_;
 

--- a/brian2cuda/brianlib/device_buffer.h
+++ b/brian2cuda/brianlib/device_buffer.h
@@ -3,17 +3,17 @@
 
 #include <cstddef>
 #include <memory>
-#include <stdint.h>
 
 namespace brian {
 
-// Typed resizable device storage. Header is Thrust-free; thrust::device_vector<T>
-// lives only in device_buffer.cu behind Impl (PImpl).
-template<typename T>
+// Type-erased resizable device storage. Header is Thrust-free;
+// thrust::device_vector<char> lives only in device_buffer.cu behind Impl (PImpl).
+// One TU instantiates a single device_vector type instead of one per dtype.
 class DeviceBuffer
 {
 public:
     DeviceBuffer();
+    explicit DeviceBuffer(size_t elem_size);
     ~DeviceBuffer();
 
     DeviceBuffer(const DeviceBuffer&) = delete;
@@ -21,23 +21,31 @@ public:
     DeviceBuffer(DeviceBuffer&& other) noexcept;
     DeviceBuffer& operator=(DeviceBuffer&& other) noexcept;
 
+    void init(size_t elem_size);
+
     size_t size() const { return n_; }
     bool empty() const { return n_ == 0; }
 
-    T* data() { return ptr_; }
-    const T* data() const { return ptr_; }
+    void* data() { return ptr_; }
+    const void* data() const { return ptr_; }
+
+    template<typename T>
+    T* data_as() { return static_cast<T*>(data()); }
+    template<typename T>
+    const T* data_as() const { return static_cast<const T*>(data()); }
 
     void resize(size_t n);
-    void copy_from_host(const T* src, size_t n);
-    void copy_to_host(T* dst) const;
-    void append(const T& elem);
-    void store(size_t i, const T& elem);
+    void copy_from_host(const void* src, size_t n);
+    void copy_to_host(void* dst) const;
+    void append(const void* elem);
+    void store(size_t i, const void* elem);
     void clear();
 
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_;
-    T* ptr_;
+    void* ptr_;
+    size_t elem_size_;
     size_t n_;
 
     void refresh_ptr();

--- a/brian2cuda/brianlib/host_algorithms.h
+++ b/brian2cuda/brianlib/host_algorithms.h
@@ -1,0 +1,51 @@
+#ifndef BRIAN_HOST_ALGORITHMS_H
+#define BRIAN_HOST_ALGORITHMS_H
+
+#include <algorithm>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+namespace brian {
+
+template<typename Key, typename Value>
+void sort_by_key(Key* keys, Value* values, size_t n)
+{
+    if (n <= 1)
+        return;
+    std::vector<std::pair<Key, Value> > zipped(n);
+    for (size_t i = 0; i < n; ++i)
+        zipped[i] = std::pair<Key, Value>(keys[i], values[i]);
+    std::sort(zipped.begin(), zipped.end(),
+              [](const std::pair<Key, Value>& a,
+                 const std::pair<Key, Value>& b) {
+                  return a.first < b.first;
+              });
+    for (size_t i = 0; i < n; ++i)
+    {
+        keys[i] = zipped[i].first;
+        values[i] = zipped[i].second;
+    }
+}
+
+template<typename Key, typename Value>
+size_t unique_by_key(Key* keys, Value* values, size_t n)
+{
+    if (n == 0)
+        return 0;
+    size_t out_n = 1;
+    for (size_t i = 1; i < n; ++i)
+    {
+        if (keys[i] != keys[out_n - 1])
+        {
+            keys[out_n] = keys[i];
+            values[out_n] = values[i];
+            ++out_n;
+        }
+    }
+    return out_n;
+}
+
+}  // namespace brian
+
+#endif

--- a/brian2cuda/brianlib/thrust_algorithms.cu
+++ b/brian2cuda/brianlib/thrust_algorithms.cu
@@ -1,0 +1,39 @@
+#include "brianlib/cuda_utils.h"
+
+#include <thrust/copy.h>
+#include <thrust/device_ptr.h>
+
+#include <stdint.h>
+
+namespace brian {
+
+struct is_in_subgroup
+{
+    int32_t start;
+    int32_t stop;
+
+    __host__ __device__
+    bool operator()(const int32_t& neuron) const
+    {
+        return start <= neuron && neuron < stop;
+    }
+};
+
+int filter_subgroup_eventspace(
+        int32_t* src, int n, int32_t* dst, int32_t start, int32_t stop)
+{
+    if (n <= 0)
+        return 0;
+
+    thrust::device_ptr<int32_t> src_ptr(src);
+    thrust::device_ptr<int32_t> dst_ptr(dst);
+    is_in_subgroup pred{start, stop};
+
+    thrust::device_ptr<int32_t> end = dst_ptr;
+    THRUST_CHECK_ERROR(
+        end = thrust::copy_if(src_ptr, src_ptr + n, dst_ptr, pred)
+    );
+    return static_cast<int>(end - dst_ptr);
+}
+
+}  // namespace brian

--- a/brian2cuda/codeobject.py
+++ b/brian2cuda/codeobject.py
@@ -27,6 +27,18 @@ from brian2cuda.cuda_generator import (
 __all__ = ['CUDAStandaloneCodeObject',
            'CUDAStandaloneAtomicsCodeObject']
 
+_DYNAMIC_ARRAY_PREFIX = '_dynamic_array_'
+_DEV_DYNAMIC_ARRAY_PREFIX = 'dev_dynamic_array_'
+
+
+def array_basename(arrayname):
+    """Map '_dynamic_array_foo' / 'dev_dynamic_array_foo' -> 'foo', else None."""
+    if arrayname.startswith(_DYNAMIC_ARRAY_PREFIX):
+        return arrayname[len(_DYNAMIC_ARRAY_PREFIX):]
+    if arrayname.startswith(_DEV_DYNAMIC_ARRAY_PREFIX):
+        return arrayname[len(_DEV_DYNAMIC_ARRAY_PREFIX):]
+    return None
+
 
 class CUDAStandaloneCodeObject(CPPStandaloneCodeObject):
     '''
@@ -40,7 +52,8 @@ class CUDAStandaloneCodeObject(CPPStandaloneCodeObject):
                           env_globals={'c_data_type': c_data_type,
                                        'constant_or_scalar': constant_or_scalar,
                                        'prefs': prefs,
-                                       'zip': zip
+                                       'zip': zip,
+                                       'array_basename': array_basename,
                                        })
     generator_class = CUDACodeGenerator
 

--- a/brian2cuda/codeobject.py
+++ b/brian2cuda/codeobject.py
@@ -27,18 +27,6 @@ from brian2cuda.cuda_generator import (
 __all__ = ['CUDAStandaloneCodeObject',
            'CUDAStandaloneAtomicsCodeObject']
 
-_DYNAMIC_ARRAY_PREFIX = '_dynamic_array_'
-_DEV_DYNAMIC_ARRAY_PREFIX = 'dev_dynamic_array_'
-
-
-def array_basename(arrayname):
-    """Map '_dynamic_array_foo' / 'dev_dynamic_array_foo' -> 'foo', else None."""
-    if arrayname.startswith(_DYNAMIC_ARRAY_PREFIX):
-        return arrayname[len(_DYNAMIC_ARRAY_PREFIX):]
-    if arrayname.startswith(_DEV_DYNAMIC_ARRAY_PREFIX):
-        return arrayname[len(_DEV_DYNAMIC_ARRAY_PREFIX):]
-    return None
-
 
 class CUDAStandaloneCodeObject(CPPStandaloneCodeObject):
     '''
@@ -53,7 +41,6 @@ class CUDAStandaloneCodeObject(CPPStandaloneCodeObject):
                                        'constant_or_scalar': constant_or_scalar,
                                        'prefs': prefs,
                                        'zip': zip,
-                                       'array_basename': array_basename,
                                        })
     generator_class = CUDACodeGenerator
 

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -35,14 +35,17 @@ from brian2cuda.utils.stringtools import replace_floating_point_literals
 from brian2cuda.utils.gputools import select_gpu, get_nvcc_path, get_cuda_path
 from brian2cuda.utils.logger import report_issue_message
 
-from .codeobject import CUDAStandaloneCodeObject, CUDAStandaloneAtomicsCodeObject
+from .codeobject import (
+    CUDAStandaloneCodeObject,
+    CUDAStandaloneAtomicsCodeObject,
+    array_basename,
+)
 
 
 __all__ = []
 
 logger = get_logger(__name__)
 
-# Required C++ standard for nvcc; passed to generate_makefile and makefile templates.
 CUDA_CPP_STD = '-std=c++17'
 CUDA_CPP_STD_MSVC = '/std:c++17'
 
@@ -64,6 +67,10 @@ class CUDAWriter(CPPWriter):
         elif filename.endswith('.*'):
             self.write(filename[:-1]+'cu', contents.cu_file)
             self.write(filename[:-1]+'h', contents.h_file)
+            if hasattr(contents, 'h_storage_file'):
+                self.write(filename[:-2]+'_storage.h', contents.h_storage_file)
+            if hasattr(contents, 'h_api_file'):
+                self.write(filename[:-2]+'_api.h', contents.h_api_file)
             return
         fullfilename = os.path.join(self.project_dir, filename)
         if os.path.exists(fullfilename):
@@ -1217,7 +1224,6 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
         nvcc_flags_str = ' '.join(nvcc_compiler_flags)
         gpu_arch_str = ' '.join(gpu_arch_flags)
         linker_flags_str = ' '.join(cpp_linker_flags)
-        # Determine the C++ standard for the host compiler
         if cpp_compiler == 'msvc':
             host_cpp_std = CUDA_CPP_STD_MSVC
             std_prefixes = ('/std:',)
@@ -1230,7 +1236,6 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
             return any(flag_lower.startswith(prefix) for prefix in std_prefixes)
 
         std_flags = [flag for flag in cpp_compiler_flags if _is_std_flag(flag)]
-        # If the host compiler flag for the C++ standard is set, override it with the CUDA C++ standard
         if std_flags:
             overridden = [flag for flag in std_flags if flag != host_cpp_std]
             if overridden:
@@ -1239,7 +1244,6 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     f"Overriding host compiler flag(s) {overridden!r} from Brian 2 "
                     f"preferences with {host_cpp_std!r}."
                 )
-            # Override the host compiler flag for the C++ standard with the CUDA C++ standard
             cpp_compiler_flags = [
                 host_cpp_std if _is_std_flag(arg) else arg
                 for arg in cpp_compiler_flags

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -568,7 +568,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     size_str = f'_num_{arrayname}'
                     pointer_arrayname = f"dev{arrayname}"
                     if arrayname.endswith('space'):
-                        pointer_arrayname += f'_view[current_idx{arrayname}]'
+                        pointer_arrayname += f'[current_idx{arrayname}]'
                 rendered_value = CPPNodeRenderer().render_expr(repr(value))
                 code = f'''
                     for(int i=0; i<{size_str}; i++)
@@ -604,7 +604,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     host_ptr = arrayname
                     dest_expr = f"dev{arrayname}"
                     if arrayname.endswith('space'):
-                        dest_expr += f'_view[current_idx{arrayname}]'
+                        dest_expr += f'[current_idx{arrayname}]'
                     dest_expr = f'{dest_expr} + {item}'
                 code = f"{host_arrayname}[{item}] = {value};"
                 if arrayname not in self.variables_on_host_only:
@@ -961,7 +961,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                     idx = ''
                                     if k.endswith('space'):
                                         bare_array_name = self.get_array_name(v)
-                                        idx = f'_view[current_idx{bare_array_name}]'
+                                        idx = f'[current_idx{bare_array_name}]'
                                     host_parameters_lines.append(f"{array_name}{idx}")
                                     kernel_parameters_lines.append(f'{dtype}* {ptr_array_name}')
 

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -906,10 +906,24 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                             dtype = c_data_type(v.dtype)
                             if isinstance(v, DynamicArrayVariable):
                                 if v.ndim == 1:
-
-                                    code_object_defs_lines.append(
-                                        f'{dtype}* const {array_name} = thrust::raw_pointer_cast(&{dyn_array_name}[0]);'
-                                    )
+                                    short = array_basename(dyn_array_name)
+                                    if short is not None:
+                                        if prefix == 'dev':
+                                            pimpl_ptr = f'dev_array_{short}'
+                                        else:
+                                            pimpl_ptr = f'host_array_{short}'
+                                        # Avoid `T* const x = x;` when array_name coincides
+                                        # with the global pointer name.
+                                        if array_name != pimpl_ptr:
+                                            code_object_defs_lines.append(
+                                                f'{dtype}* const {array_name} = {pimpl_ptr};'
+                                            )
+                                    else:
+                                        code_object_defs_lines.append(
+                                            f'{dtype}* const {array_name} = '
+                                            f'thrust::raw_pointer_cast('
+                                            f'&{dyn_array_name}[0]);'
+                                        )
 
                                     # Add host and kernel parameters only for device pointers
                                     if prefix == 'dev':
@@ -928,8 +942,14 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                     # there are two prefixes, base it on host array
                                     # `{array}.size()`
                                     if len(prefixes) == 1 or prefix == '':
+                                        if short is None:
+                                            num_expr = f'{dyn_array_name}.size()'
+                                        elif prefix == '' or len(prefixes) > 1:
+                                            num_expr = f'_num_host_array_{short}'
+                                        else:
+                                            num_expr = f'_num_dev_array_{short}'
                                         code_object_defs_lines.append(
-                                            f'const int _num{k} = {dyn_array_name}.size();'
+                                            f'const int _num{k} = {num_expr};'
                                         )
                                         host_parameters_lines.append(f"_num{k}")
                                         kernel_parameters_lines.append(f"const int _num{k}")
@@ -940,7 +960,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                     idx = ''
                                     if k.endswith('space'):
                                         bare_array_name = self.get_array_name(v)
-                                        idx = f'[current_idx{bare_array_name}]'
+                                        idx = f'_view[current_idx{bare_array_name}]'
                                     host_parameters_lines.append(f"{array_name}{idx}")
                                     kernel_parameters_lines.append(f'{dtype}* {ptr_array_name}')
 

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -543,43 +543,37 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     # TODO: Move this into before_run_synapses_push_spikes
                     for synaptic_pre, delete in self.delete_synaptic_pre.items():
                         if delete:
-                            code = f'''
-                                dev{synaptic_pre}.clear();
-                                dev{synaptic_pre}.shrink_to_fit();
-                            '''
-                            main_lines.extend(stripped_deindented_lines(code))
+                            short = array_basename(synaptic_pre)
+                            main_lines.append(f'clear_dev_array_{short}();')
                     for synaptic_post, delete in self.delete_synaptic_post.items():
                         if delete:
-                            code = f'''
-                                dev{synaptic_post}.clear();
-                                dev{synaptic_post}.shrink_to_fit();
-                            '''
-                            main_lines.extend(stripped_deindented_lines(code))
+                            short = array_basename(synaptic_post)
+                            main_lines.append(f'clear_dev_array_{short}();')
                     for synaptic_delay, delete in self.delete_synaptic_delay.items():
                         if delete:
-                            code = f'''
-                                dev{synaptic_delay}.clear();
-                                dev{synaptic_delay}.shrink_to_fit();
-                            '''
-                            main_lines.extend(stripped_deindented_lines(code))
+                            short = array_basename(synaptic_delay)
+                            main_lines.append(f'clear_dev_array_{short}();')
                 # The actual network code
                 main_lines.extend(netcode)
                 # Increment run counter
                 run_counter += 1
             elif func=='set_by_constant':
                 arrayname, value, is_dynamic = args
-                size_str = f"{arrayname}.size()" if is_dynamic else f"_num_{arrayname}"
+                short = array_basename(arrayname)
+                host_arrayname = f'host_array_{short}' if short is not None else arrayname
+                size_str = (f'_num_host_array_{short}' if (is_dynamic and short is not None)
+                            else f'_num_{arrayname}')
                 rendered_value = CPPNodeRenderer().render_expr(repr(value))
                 pointer_arrayname = f"dev{arrayname}"
                 if arrayname.endswith('space'):  # eventspace
-                    pointer_arrayname += f'[current_idx{arrayname}]'
-                if is_dynamic:
-                    pointer_arrayname = f"thrust::raw_pointer_cast(&dev{arrayname}[0])"
+                    pointer_arrayname += f'_view[current_idx{arrayname}]'
+                if is_dynamic and short is not None:
+                    pointer_arrayname = f'dev_array_{short}'
                 # Set on host
                 code = f'''
                     for(int i=0; i<{size_str}; i++)
                     {{
-                        {arrayname}[i] = {rendered_value};
+                        {host_arrayname}[i] = {rendered_value};
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
@@ -588,8 +582,8 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
                             {pointer_arrayname},
-                            &{arrayname}[0],
-                            sizeof({arrayname}[0])*{size_str},
+                            {host_arrayname},
+                            sizeof({host_arrayname}[0])*{size_str},
                             cudaMemcpyHostToDevice
                         )
                     );
@@ -597,21 +591,23 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_by_single_value':
                 arrayname, item, value = args
+                short = array_basename(arrayname)
+                host_arrayname = f'host_array_{short}' if short is not None else arrayname
                 pointer_arrayname = f"dev{arrayname}"
                 if arrayname.endswith('space'):  # eventspace
-                    pointer_arrayname += f'[current_idx{arrayname}]'
-                if arrayname in self.dynamic_arrays.values():
-                    pointer_arrayname = f"thrust::raw_pointer_cast(&dev{arrayname}[0])"
+                    pointer_arrayname += f'_view[current_idx{arrayname}]'
+                if short is not None:
+                    pointer_arrayname = f'dev_array_{short}'
                 # Set on host
-                code = f"{arrayname}[{item}] = {value};"
+                code = f"{host_arrayname}[{item}] = {value};"
                 if arrayname not in self.variables_on_host_only:
                     # Copy to device
                     code += f'''
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
                             {pointer_arrayname} + {item},
-                            &{arrayname}[{item}],
-                            sizeof({arrayname}[{item}]),
+                            {host_arrayname} + {item},
+                            sizeof({host_arrayname}[{item}]),
                             cudaMemcpyHostToDevice
                         )
                     );
@@ -619,17 +615,18 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_by_array':
                 arrayname, staticarrayname, is_dynamic = args
-                size_str = "_num_" + arrayname
-                if is_dynamic:
-                    size_str = arrayname + ".size()"
+                short = array_basename(arrayname)
+                host_arrayname = f'host_array_{short}' if short is not None else arrayname
+                size_str = (f'_num_host_array_{short}' if (is_dynamic and short is not None)
+                            else f'_num_{arrayname}')
                 pointer_arrayname = f"dev{arrayname}"
-                if arrayname in self.dynamic_arrays.values():
-                    pointer_arrayname = f"thrust::raw_pointer_cast(&dev{arrayname}[0])"
+                if short is not None:
+                    pointer_arrayname = f'dev_array_{short}'
                 # Set on host
                 code = f'''
                     for(int i=0; i<_num_{staticarrayname}; i++)
                     {{
-                        {arrayname}[i] = {staticarrayname}[i];
+                        {host_arrayname}[i] = {staticarrayname}[i];
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
@@ -638,8 +635,8 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
                             {pointer_arrayname},
-                            &{arrayname}[0],
-                            sizeof({arrayname}[0])*{size_str},
+                            {host_arrayname},
+                            sizeof({host_arrayname}[0])*{size_str},
                             cudaMemcpyHostToDevice
                         )
                     );
@@ -647,11 +644,19 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_array_by_array':
                 arrayname, staticarrayname_index, staticarrayname_value = args
+                short = array_basename(arrayname)
+                host_arrayname = f'host_array_{short}' if short is not None else arrayname
+                if short is not None:
+                    dev_ptr = f'dev_array_{short}'
+                    memcpy_size = f'_num_host_array_{short}'
+                else:
+                    dev_ptr = f'dev{arrayname}'
+                    memcpy_size = f'_num_{arrayname}'
                 # Set on host
                 code = f'''
                     for(int i=0; i<_num_{staticarrayname_index}; i++)
                     {{
-                        {arrayname}[{staticarrayname_index}[i]] = {staticarrayname_value}[i];
+                        {host_arrayname}[{staticarrayname_index}[i]] = {staticarrayname_value}[i];
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
@@ -659,9 +664,9 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     code += f'''
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
-                            dev{arrayname},
-                            &{arrayname}[0],
-                            sizeof({arrayname}[0])*_num_{arrayname},
+                            {dev_ptr},
+                            {host_arrayname},
+                            sizeof({host_arrayname}[0])*{memcpy_size},
                             cudaMemcpyHostToDevice
                         )
                     );
@@ -669,10 +674,11 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='resize_array':
                 array_name, new_size = args
-                code = f'''
-                    {array_name}.resize({new_size});
-                    THRUST_CHECK_ERROR(dev{array_name}.resize({new_size}));
-                '''
+                short = array_basename(array_name)
+                code = (
+                    f'resize_host_array_{short}({new_size});\n'
+                    f'resize_dev_array_{short}({new_size});'
+                )
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='insert_code':
                 main_lines.append(args)

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -554,13 +554,11 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 arrayname, value, is_dynamic = args
                 short = array_basename(arrayname)
                 if is_dynamic and short is not None:
-                    host_arrayname = arrayname
                     host_ptr = f'{arrayname}.data()'
                     size_str = f'{arrayname}.size()'
                     # data() is void*; cudaMemcpy accepts it without a typed cast.
                     pointer_arrayname = f'dev{arrayname}.data()'
                 else:
-                    host_arrayname = arrayname
                     host_ptr = arrayname
                     size_str = f'_num_{arrayname}'
                     pointer_arrayname = f"dev{arrayname}"
@@ -570,7 +568,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 code = f'''
                     for(int i=0; i<{size_str}; i++)
                     {{
-                        {host_arrayname}[i] = {rendered_value};
+                        {arrayname}[i] = {rendered_value};
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
@@ -579,7 +577,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                         cudaMemcpy(
                             {pointer_arrayname},
                             {host_ptr},
-                            sizeof({host_arrayname}[0])*{size_str},
+                            sizeof({arrayname}[0])*{size_str},
                             cudaMemcpyHostToDevice
                         )
                     );
@@ -589,28 +587,26 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 arrayname, item, value = args
                 short = array_basename(arrayname)
                 if short is not None:
-                    host_arrayname = arrayname
                     host_ptr = f'{arrayname}.data()'
                     # void* + offset is illegal; advance by element size in bytes.
                     dest_expr = (
                         f'static_cast<char*>(dev{arrayname}.data()) + '
-                        f'({item}) * sizeof({host_arrayname}[0])'
+                        f'({item}) * sizeof({arrayname}[0])'
                     )
                 else:
-                    host_arrayname = arrayname
                     host_ptr = arrayname
                     dest_expr = f"dev{arrayname}"
                     if arrayname.endswith('space'):
                         dest_expr += f'[current_idx{arrayname}]'
                     dest_expr = f'{dest_expr} + {item}'
-                code = f"{host_arrayname}[{item}] = {value};"
+                code = f"{arrayname}[{item}] = {value};"
                 if arrayname not in self.variables_on_host_only:
                     code += f'''
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
                             {dest_expr},
                             {host_ptr} + {item},
-                            sizeof({host_arrayname}[{item}]),
+                            sizeof({arrayname}[{item}]),
                             cudaMemcpyHostToDevice
                         )
                     );
@@ -620,20 +616,18 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 arrayname, staticarrayname, is_dynamic = args
                 short = array_basename(arrayname)
                 if is_dynamic and short is not None:
-                    host_arrayname = arrayname
                     host_ptr = f'{arrayname}.data()'
                     size_str = f'{arrayname}.size()'
                     # data() is void*; cudaMemcpy accepts it without a typed cast.
                     pointer_arrayname = f'dev{arrayname}.data()'
                 else:
-                    host_arrayname = arrayname
                     host_ptr = arrayname
                     size_str = f'_num_{arrayname}'
                     pointer_arrayname = f"dev{arrayname}"
                 code = f'''
                     for(int i=0; i<_num_{staticarrayname}; i++)
                     {{
-                        {host_arrayname}[i] = {staticarrayname}[i];
+                        {arrayname}[i] = {staticarrayname}[i];
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
@@ -642,7 +636,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                         cudaMemcpy(
                             {pointer_arrayname},
                             {host_ptr},
-                            sizeof({host_arrayname}[0])*{size_str},
+                            sizeof({arrayname}[0])*{size_str},
                             cudaMemcpyHostToDevice
                         )
                     );
@@ -652,19 +646,17 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 arrayname, staticarrayname_index, staticarrayname_value = args
                 short = array_basename(arrayname)
                 if short is not None:
-                    host_arrayname = arrayname
                     host_ptr = f'{arrayname}.data()'
                     dev_ptr = f'dev{arrayname}.data()'
                     memcpy_size = f'{arrayname}.size()'
                 else:
-                    host_arrayname = arrayname
                     host_ptr = arrayname
                     dev_ptr = f'dev{arrayname}'
                     memcpy_size = f'_num_{arrayname}'
                 code = f'''
                     for(int i=0; i<_num_{staticarrayname_index}; i++)
                     {{
-                        {host_arrayname}[{staticarrayname_index}[i]] = {staticarrayname_value}[i];
+                        {arrayname}[{staticarrayname_index}[i]] = {staticarrayname_value}[i];
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
@@ -673,7 +665,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                         cudaMemcpy(
                             {dev_ptr},
                             {host_ptr},
-                            sizeof({host_arrayname}[0])*{memcpy_size},
+                            sizeof({arrayname}[0])*{memcpy_size},
                             cudaMemcpyHostToDevice
                         )
                     );
@@ -919,10 +911,9 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                         array_ptr = f'{bare}.data()'
                                     # Host local alias: generated kernel name is
                                     # `dev_array_*`; DeviceBuffer is `dev{bare}`.
-                                    if array_name != array_ptr:
-                                        code_object_defs_lines.append(
-                                            f'{dtype}* const {array_name} = {array_ptr};'
-                                        )
+                                    code_object_defs_lines.append(
+                                        f'{dtype}* const {array_name} = {array_ptr};'
+                                    )
 
                                     # Add host and kernel parameters only for device pointers
                                     if prefix == 'dev':

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -539,16 +539,13 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     # TODO: Move this into before_run_synapses_push_spikes
                     for synaptic_pre, delete in self.delete_synaptic_pre.items():
                         if delete:
-                            short = array_basename(synaptic_pre)
-                            main_lines.append(f'clear_dev_array_{short}();')
+                            main_lines.append(f'dev{synaptic_pre}.clear();')
                     for synaptic_post, delete in self.delete_synaptic_post.items():
                         if delete:
-                            short = array_basename(synaptic_post)
-                            main_lines.append(f'clear_dev_array_{short}();')
+                            main_lines.append(f'dev{synaptic_post}.clear();')
                     for synaptic_delay, delete in self.delete_synaptic_delay.items():
                         if delete:
-                            short = array_basename(synaptic_delay)
-                            main_lines.append(f'clear_dev_array_{short}();')
+                            main_lines.append(f'dev{synaptic_delay}.clear();')
                 # The actual network code
                 main_lines.extend(netcode)
                 # Increment run counter
@@ -684,10 +681,9 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='resize_array':
                 array_name, new_size = args
-                short = array_basename(array_name)
                 code = (
                     f'{array_name}.resize({new_size});\n'
-                    f'resize_dev_array_{short}({new_size});'
+                    f'dev{array_name}.resize({new_size});'
                 )
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='insert_code':

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -1141,7 +1141,8 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
         writer.write('network.*', network_tmp)
 
     def generate_synapses_classes_source(self, writer):
-        synapses_classes_tmp = self.code_object_class().templater.synapses_classes(None, None)
+        synapses_classes_tmp = self.code_object_class().templater.synapses_classes(
+            None, None, synapses=self.synapses)
         writer.write('synapses_classes.*', synapses_classes_tmp)
 
     def generate_run_source(self, writer):

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -560,7 +560,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     host_arrayname = arrayname
                     host_ptr = f'{arrayname}.data()'
                     size_str = f'{arrayname}.size()'
-                    pointer_arrayname = f'dev_array_{short}'
+                    pointer_arrayname = f'dev{arrayname}.data()'
                 else:
                     host_arrayname = arrayname
                     host_ptr = arrayname
@@ -593,19 +593,20 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 if short is not None:
                     host_arrayname = arrayname
                     host_ptr = f'{arrayname}.data()'
-                    pointer_arrayname = f'dev_array_{short}'
+                    dest_expr = f'dev{arrayname}.data() + {item}'
                 else:
                     host_arrayname = arrayname
                     host_ptr = arrayname
-                    pointer_arrayname = f"dev{arrayname}"
+                    dest_expr = f"dev{arrayname}"
                     if arrayname.endswith('space'):
-                        pointer_arrayname += f'_view[current_idx{arrayname}]'
+                        dest_expr += f'_view[current_idx{arrayname}]'
+                    dest_expr = f'{dest_expr} + {item}'
                 code = f"{host_arrayname}[{item}] = {value};"
                 if arrayname not in self.variables_on_host_only:
                     code += f'''
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
-                            {pointer_arrayname} + {item},
+                            {dest_expr},
                             {host_ptr} + {item},
                             sizeof({host_arrayname}[{item}]),
                             cudaMemcpyHostToDevice
@@ -620,7 +621,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     host_arrayname = arrayname
                     host_ptr = f'{arrayname}.data()'
                     size_str = f'{arrayname}.size()'
-                    pointer_arrayname = f'dev_array_{short}'
+                    pointer_arrayname = f'dev{arrayname}.data()'
                 else:
                     host_arrayname = arrayname
                     host_ptr = arrayname
@@ -650,7 +651,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 if short is not None:
                     host_arrayname = arrayname
                     host_ptr = f'{arrayname}.data()'
-                    dev_ptr = f'dev_array_{short}'
+                    dev_ptr = f'dev{arrayname}.data()'
                     memcpy_size = f'{arrayname}.size()'
                 else:
                     host_arrayname = arrayname
@@ -910,13 +911,12 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                             if isinstance(v, DynamicArrayVariable):
                                 if v.ndim == 1:
                                     bare = self.get_array_name(v, access_data=False)
-                                    short = array_basename(bare)
                                     if prefix == 'dev':
-                                        array_ptr = f'dev_array_{short}'
+                                        array_ptr = f'dev{bare}.data()'
                                     else:
                                         array_ptr = f'{bare}.data()'
-                                    # Avoid `T* const x = x;` when array_name coincides
-                                    # with the global pointer name.
+                                    # Host local alias: generated kernel name is
+                                    # `dev_array_*`; DeviceBuffer is `dev{bare}`.
                                     if array_name != array_ptr:
                                         code_object_defs_lines.append(
                                             f'{dtype}* const {array_name} = {array_ptr};'
@@ -924,10 +924,10 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
 
                                     # Add host and kernel parameters only for device pointers
                                     if prefix == 'dev':
-                                        # These lines are used to define the kernel call parameters, that
-                                        # means only for codeobjects running on the device. The array names
-                                        # always have a `_dev` prefix.
-                                        host_parameters_lines.append(f"{array_name}")
+                                        # Pass data() at the launch site so a later
+                                        # resize in this function does not freeze a
+                                        # stale pointer from HOST_CONSTANTS.
+                                        host_parameters_lines.append(array_ptr)
 
                                         # These lines declare kernel parameters as the `_ptr` variables that
                                         # are used in `scalar_code` and `vector_code`.
@@ -942,11 +942,11 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                         if prefix == '' or len(prefixes) > 1:
                                             num_expr = f'static_cast<int>({bare}.size())'
                                         else:
-                                            num_expr = f'_num_dev_array_{short}'
+                                            num_expr = f'static_cast<int>(dev{bare}.size())'
                                         code_object_defs_lines.append(
                                             f'const int _num{k} = {num_expr};'
                                         )
-                                        host_parameters_lines.append(f"_num{k}")
+                                        host_parameters_lines.append(num_expr)
                                         kernel_parameters_lines.append(f"const int _num{k}")
 
                             else:  # v is ArrayVariable but not DynamicArrayVariable

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -67,10 +67,6 @@ class CUDAWriter(CPPWriter):
         elif filename.endswith('.*'):
             self.write(filename[:-1]+'cu', contents.cu_file)
             self.write(filename[:-1]+'h', contents.h_file)
-            if hasattr(contents, 'h_storage_file'):
-                self.write(filename[:-2]+'_storage.h', contents.h_storage_file)
-            if hasattr(contents, 'h_api_file'):
-                self.write(filename[:-2]+'_api.h', contents.h_api_file)
             return
         fullfilename = os.path.join(self.project_dir, filename)
         if os.path.exists(fullfilename):
@@ -916,14 +912,14 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                     bare = self.get_array_name(v, access_data=False)
                                     short = array_basename(bare)
                                     if prefix == 'dev':
-                                        pimpl_ptr = f'dev_array_{short}'
+                                        array_ptr = f'dev_array_{short}'
                                     else:
-                                        pimpl_ptr = f'{bare}.data()'
+                                        array_ptr = f'{bare}.data()'
                                     # Avoid `T* const x = x;` when array_name coincides
                                     # with the global pointer name.
-                                    if array_name != pimpl_ptr:
+                                    if array_name != array_ptr:
                                         code_object_defs_lines.append(
-                                            f'{dtype}* const {array_name} = {pimpl_ptr};'
+                                            f'{dtype}* const {array_name} = {array_ptr};'
                                         )
 
                                     # Add host and kernel parameters only for device pointers

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -25,7 +25,7 @@ from brian2.utils.stringtools import get_identifiers, stripped_deindented_lines
 from brian2.codegen.generators.cpp_generator import c_data_type
 from brian2.utils.logger import get_logger
 from brian2.units import second
-from brian2.monitors import SpikeMonitor, StateMonitor, EventMonitor
+from brian2.monitors import SpikeMonitor, StateMonitor, EventMonitor, PopulationRateMonitor
 from brian2.groups import Subgroup
 
 from brian2.devices.cpp_standalone.device import CPPWriter, CPPStandaloneDevice
@@ -928,9 +928,10 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                         #       for variables that are e.g. only read in the kernel
                                         kernel_parameters_lines.append(f"{dtype}* {ptr_array_name}")
 
-                                    # Add size variables `_num{array}` only once and if
-                                    # there are two prefixes, base it on host array
-                                    # `{array}.size()`
+                                    # Add size variables `_num{k}`. Pass the host
+                                    # local by name (not the size expression) so
+                                    # aliases that share a DynamicArray are not
+                                    # collapsed by HOST_PARAMETERS string dedup.
                                     if len(prefixes) == 1 or prefix == '':
                                         if prefix == '' or len(prefixes) > 1:
                                             num_expr = f'static_cast<int>({bare}.size())'
@@ -939,8 +940,8 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                         code_object_defs_lines.append(
                                             f'const int _num{k} = {num_expr};'
                                         )
-                                        host_parameters_lines.append(num_expr)
-                                        kernel_parameters_lines.append(f"const int _num{k}")
+                                        host_parameters_lines.append(f'_num{k}')
+                                        kernel_parameters_lines.append(f'const int _num{k}')
 
                             else:  # v is ArrayVariable but not DynamicArrayVariable
                                 # Add host and kernel parameters only for device pointers
@@ -1491,7 +1492,10 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
         self.variables_on_host_only = []
         for var, varname in self.arrays.items():
             try:
-                is_mon = isinstance(var.owner, (StateMonitor, SpikeMonitor, EventMonitor))
+                is_mon = isinstance(
+                    var.owner,
+                    (StateMonitor, SpikeMonitor, EventMonitor, PopulationRateMonitor),
+                )
             except ReferenceError:
                 # some variable ownders are weakreference that don't exist anymore
                 # https://github.com/brian-team/brian2cuda/issues/296#issuecomment-1145085524

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -560,16 +560,19 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
             elif func=='set_by_constant':
                 arrayname, value, is_dynamic = args
                 short = array_basename(arrayname)
-                host_arrayname = f'host_array_{short}' if short is not None else arrayname
-                size_str = (f'_num_host_array_{short}' if (is_dynamic and short is not None)
-                            else f'_num_{arrayname}')
-                rendered_value = CPPNodeRenderer().render_expr(repr(value))
-                pointer_arrayname = f"dev{arrayname}"
-                if arrayname.endswith('space'):  # eventspace
-                    pointer_arrayname += f'_view[current_idx{arrayname}]'
                 if is_dynamic and short is not None:
+                    host_arrayname = arrayname
+                    host_ptr = f'{arrayname}.data()'
+                    size_str = f'{arrayname}.size()'
                     pointer_arrayname = f'dev_array_{short}'
-                # Set on host
+                else:
+                    host_arrayname = arrayname
+                    host_ptr = arrayname
+                    size_str = f'_num_{arrayname}'
+                    pointer_arrayname = f"dev{arrayname}"
+                    if arrayname.endswith('space'):
+                        pointer_arrayname += f'_view[current_idx{arrayname}]'
+                rendered_value = CPPNodeRenderer().render_expr(repr(value))
                 code = f'''
                     for(int i=0; i<{size_str}; i++)
                     {{
@@ -577,12 +580,11 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
-                    # Copy to device
                     code += f'''
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
                             {pointer_arrayname},
-                            {host_arrayname},
+                            {host_ptr},
                             sizeof({host_arrayname}[0])*{size_str},
                             cudaMemcpyHostToDevice
                         )
@@ -592,21 +594,23 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
             elif func=='set_by_single_value':
                 arrayname, item, value = args
                 short = array_basename(arrayname)
-                host_arrayname = f'host_array_{short}' if short is not None else arrayname
-                pointer_arrayname = f"dev{arrayname}"
-                if arrayname.endswith('space'):  # eventspace
-                    pointer_arrayname += f'_view[current_idx{arrayname}]'
                 if short is not None:
+                    host_arrayname = arrayname
+                    host_ptr = f'{arrayname}.data()'
                     pointer_arrayname = f'dev_array_{short}'
-                # Set on host
+                else:
+                    host_arrayname = arrayname
+                    host_ptr = arrayname
+                    pointer_arrayname = f"dev{arrayname}"
+                    if arrayname.endswith('space'):
+                        pointer_arrayname += f'_view[current_idx{arrayname}]'
                 code = f"{host_arrayname}[{item}] = {value};"
                 if arrayname not in self.variables_on_host_only:
-                    # Copy to device
                     code += f'''
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
                             {pointer_arrayname} + {item},
-                            {host_arrayname} + {item},
+                            {host_ptr} + {item},
                             sizeof({host_arrayname}[{item}]),
                             cudaMemcpyHostToDevice
                         )
@@ -616,13 +620,16 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
             elif func=='set_by_array':
                 arrayname, staticarrayname, is_dynamic = args
                 short = array_basename(arrayname)
-                host_arrayname = f'host_array_{short}' if short is not None else arrayname
-                size_str = (f'_num_host_array_{short}' if (is_dynamic and short is not None)
-                            else f'_num_{arrayname}')
-                pointer_arrayname = f"dev{arrayname}"
-                if short is not None:
+                if is_dynamic and short is not None:
+                    host_arrayname = arrayname
+                    host_ptr = f'{arrayname}.data()'
+                    size_str = f'{arrayname}.size()'
                     pointer_arrayname = f'dev_array_{short}'
-                # Set on host
+                else:
+                    host_arrayname = arrayname
+                    host_ptr = arrayname
+                    size_str = f'_num_{arrayname}'
+                    pointer_arrayname = f"dev{arrayname}"
                 code = f'''
                     for(int i=0; i<_num_{staticarrayname}; i++)
                     {{
@@ -630,12 +637,11 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
-                    # Copy to device
                     code += f'''
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
                             {pointer_arrayname},
-                            {host_arrayname},
+                            {host_ptr},
                             sizeof({host_arrayname}[0])*{size_str},
                             cudaMemcpyHostToDevice
                         )
@@ -645,14 +651,16 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
             elif func=='set_array_by_array':
                 arrayname, staticarrayname_index, staticarrayname_value = args
                 short = array_basename(arrayname)
-                host_arrayname = f'host_array_{short}' if short is not None else arrayname
                 if short is not None:
+                    host_arrayname = arrayname
+                    host_ptr = f'{arrayname}.data()'
                     dev_ptr = f'dev_array_{short}'
-                    memcpy_size = f'_num_host_array_{short}'
+                    memcpy_size = f'{arrayname}.size()'
                 else:
+                    host_arrayname = arrayname
+                    host_ptr = arrayname
                     dev_ptr = f'dev{arrayname}'
                     memcpy_size = f'_num_{arrayname}'
-                # Set on host
                 code = f'''
                     for(int i=0; i<_num_{staticarrayname_index}; i++)
                     {{
@@ -660,12 +668,11 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
-                    # Copy to device
                     code += f'''
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
                             {dev_ptr},
-                            {host_arrayname},
+                            {host_ptr},
                             sizeof({host_arrayname}[0])*{memcpy_size},
                             cudaMemcpyHostToDevice
                         )
@@ -676,7 +683,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 array_name, new_size = args
                 short = array_basename(array_name)
                 code = (
-                    f'resize_host_array_{short}({new_size});\n'
+                    f'{array_name}.resize({new_size});\n'
                     f'resize_dev_array_{short}({new_size});'
                 )
                 main_lines.extend(stripped_deindented_lines(code))
@@ -906,23 +913,17 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                             dtype = c_data_type(v.dtype)
                             if isinstance(v, DynamicArrayVariable):
                                 if v.ndim == 1:
-                                    short = array_basename(dyn_array_name)
-                                    if short is not None:
-                                        if prefix == 'dev':
-                                            pimpl_ptr = f'dev_array_{short}'
-                                        else:
-                                            pimpl_ptr = f'host_array_{short}'
-                                        # Avoid `T* const x = x;` when array_name coincides
-                                        # with the global pointer name.
-                                        if array_name != pimpl_ptr:
-                                            code_object_defs_lines.append(
-                                                f'{dtype}* const {array_name} = {pimpl_ptr};'
-                                            )
+                                    bare = self.get_array_name(v, access_data=False)
+                                    short = array_basename(bare)
+                                    if prefix == 'dev':
+                                        pimpl_ptr = f'dev_array_{short}'
                                     else:
+                                        pimpl_ptr = f'{bare}.data()'
+                                    # Avoid `T* const x = x;` when array_name coincides
+                                    # with the global pointer name.
+                                    if array_name != pimpl_ptr:
                                         code_object_defs_lines.append(
-                                            f'{dtype}* const {array_name} = '
-                                            f'thrust::raw_pointer_cast('
-                                            f'&{dyn_array_name}[0]);'
+                                            f'{dtype}* const {array_name} = {pimpl_ptr};'
                                         )
 
                                     # Add host and kernel parameters only for device pointers
@@ -942,10 +943,8 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                     # there are two prefixes, base it on host array
                                     # `{array}.size()`
                                     if len(prefixes) == 1 or prefix == '':
-                                        if short is None:
-                                            num_expr = f'{dyn_array_name}.size()'
-                                        elif prefix == '' or len(prefixes) > 1:
-                                            num_expr = f'_num_host_array_{short}'
+                                        if prefix == '' or len(prefixes) > 1:
+                                            num_expr = f'static_cast<int>({bare}.size())'
                                         else:
                                             num_expr = f'_num_dev_array_{short}'
                                         code_object_defs_lines.append(

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -560,6 +560,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     host_arrayname = arrayname
                     host_ptr = f'{arrayname}.data()'
                     size_str = f'{arrayname}.size()'
+                    # data() is void*; cudaMemcpy accepts it without a typed cast.
                     pointer_arrayname = f'dev{arrayname}.data()'
                 else:
                     host_arrayname = arrayname
@@ -593,7 +594,11 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 if short is not None:
                     host_arrayname = arrayname
                     host_ptr = f'{arrayname}.data()'
-                    dest_expr = f'dev{arrayname}.data() + {item}'
+                    # void* + offset is illegal; advance by element size in bytes.
+                    dest_expr = (
+                        f'static_cast<char*>(dev{arrayname}.data()) + '
+                        f'({item}) * sizeof({host_arrayname}[0])'
+                    )
                 else:
                     host_arrayname = arrayname
                     host_ptr = arrayname
@@ -621,6 +626,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     host_arrayname = arrayname
                     host_ptr = f'{arrayname}.data()'
                     size_str = f'{arrayname}.size()'
+                    # data() is void*; cudaMemcpy accepts it without a typed cast.
                     pointer_arrayname = f'dev{arrayname}.data()'
                 else:
                     host_arrayname = arrayname
@@ -912,7 +918,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                                 if v.ndim == 1:
                                     bare = self.get_array_name(v, access_data=False)
                                     if prefix == 'dev':
-                                        array_ptr = f'dev{bare}.data()'
+                                        array_ptr = f'dev{bare}.data_as<{dtype}>()'
                                     else:
                                         array_ptr = f'{bare}.data()'
                                     # Host local alias: generated kernel name is

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -38,7 +38,6 @@ from brian2cuda.utils.logger import report_issue_message
 from .codeobject import (
     CUDAStandaloneCodeObject,
     CUDAStandaloneAtomicsCodeObject,
-    array_basename,
 )
 
 
@@ -552,8 +551,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 run_counter += 1
             elif func=='set_by_constant':
                 arrayname, value, is_dynamic = args
-                short = array_basename(arrayname)
-                if is_dynamic and short is not None:
+                if is_dynamic and arrayname.startswith('_dynamic_array_'):
                     host_ptr = f'{arrayname}.data()'
                     size_str = f'{arrayname}.size()'
                     # data() is void*; cudaMemcpy accepts it without a typed cast.
@@ -585,8 +583,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_by_single_value':
                 arrayname, item, value = args
-                short = array_basename(arrayname)
-                if short is not None:
+                if arrayname.startswith('_dynamic_array_'):
                     host_ptr = f'{arrayname}.data()'
                     # void* + offset is illegal; advance by element size in bytes.
                     dest_expr = (
@@ -614,8 +611,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_by_array':
                 arrayname, staticarrayname, is_dynamic = args
-                short = array_basename(arrayname)
-                if is_dynamic and short is not None:
+                if is_dynamic and arrayname.startswith('_dynamic_array_'):
                     host_ptr = f'{arrayname}.data()'
                     size_str = f'{arrayname}.size()'
                     # data() is void*; cudaMemcpy accepts it without a typed cast.
@@ -644,8 +640,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_array_by_array':
                 arrayname, staticarrayname_index, staticarrayname_value = args
-                short = array_basename(arrayname)
-                if short is not None:
+                if arrayname.startswith('_dynamic_array_'):
                     host_ptr = f'{arrayname}.data()'
                     dev_ptr = f'dev{arrayname}.data()'
                     memcpy_size = f'{arrayname}.size()'

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -551,7 +551,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 run_counter += 1
             elif func=='set_by_constant':
                 arrayname, value, is_dynamic = args
-                if is_dynamic and arrayname.startswith('_dynamic_array_'):
+                if is_dynamic:
                     host_ptr = f'{arrayname}.data()'
                     size_str = f'{arrayname}.size()'
                     # data() is void*; cudaMemcpy accepts it without a typed cast.
@@ -583,7 +583,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_by_single_value':
                 arrayname, item, value = args
-                if arrayname.startswith('_dynamic_array_'):
+                if arrayname in self.dynamic_arrays.values():
                     host_ptr = f'{arrayname}.data()'
                     # void* + offset is illegal; advance by element size in bytes.
                     dest_expr = (
@@ -611,7 +611,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_by_array':
                 arrayname, staticarrayname, is_dynamic = args
-                if is_dynamic and arrayname.startswith('_dynamic_array_'):
+                if is_dynamic:
                     host_ptr = f'{arrayname}.data()'
                     size_str = f'{arrayname}.size()'
                     # data() is void*; cudaMemcpy accepts it without a typed cast.
@@ -640,7 +640,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_array_by_array':
                 arrayname, staticarrayname_index, staticarrayname_value = args
-                if arrayname.startswith('_dynamic_array_'):
+                if arrayname in self.dynamic_arrays.values():
                     host_ptr = f'{arrayname}.data()'
                     dev_ptr = f'dev{arrayname}.data()'
                     memcpy_size = f'{arrayname}.size()'

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -551,17 +551,9 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 run_counter += 1
             elif func=='set_by_constant':
                 arrayname, value, is_dynamic = args
-                if is_dynamic:
-                    host_ptr = f'{arrayname}.data()'
-                    size_str = f'{arrayname}.size()'
-                    # data() is void*; cudaMemcpy accepts it without a typed cast.
-                    pointer_arrayname = f'dev{arrayname}.data()'
-                else:
-                    host_ptr = arrayname
-                    size_str = f'_num_{arrayname}'
-                    pointer_arrayname = f"dev{arrayname}"
-                    if arrayname.endswith('space'):
-                        pointer_arrayname += f'[current_idx{arrayname}]'
+                size_str = (
+                    f'{arrayname}.size()' if is_dynamic else f'_num_{arrayname}'
+                )
                 rendered_value = CPPNodeRenderer().render_expr(repr(value))
                 code = f'''
                     for(int i=0; i<{size_str}; i++)
@@ -570,11 +562,20 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
-                    code += f'''
+                    if is_dynamic:
+                        code += f'''
+                    dev{arrayname}.copy_from_host(
+                        {arrayname}.data(), {arrayname}.size());
+                '''
+                    else:
+                        pointer_arrayname = f"dev{arrayname}"
+                        if arrayname.endswith('space'):
+                            pointer_arrayname += f'[current_idx{arrayname}]'
+                        code += f'''
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
                             {pointer_arrayname},
-                            {host_ptr},
+                            {arrayname},
                             sizeof({arrayname}[0])*{size_str},
                             cudaMemcpyHostToDevice
                         )
@@ -584,12 +585,13 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
             elif func=='set_by_single_value':
                 arrayname, item, value = args
                 if arrayname in self.dynamic_arrays.values():
-                    host_ptr = f'{arrayname}.data()'
-                    # void* + offset is illegal; advance by element size in bytes.
-                    dest_expr = (
-                        f'static_cast<char*>(dev{arrayname}.data()) + '
-                        f'({item}) * sizeof({arrayname}[0])'
+                    dtype = next(
+                        c_data_type(var.dtype)
+                        for var, name in self.dynamic_arrays.items()
+                        if name == arrayname
                     )
+                    host_ptr = f'{arrayname}.data()'
+                    dest_expr = f'dev{arrayname}.data_as<{dtype}>() + {item}'
                 else:
                     host_ptr = arrayname
                     dest_expr = f"dev{arrayname}"
@@ -611,15 +613,6 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_by_array':
                 arrayname, staticarrayname, is_dynamic = args
-                if is_dynamic:
-                    host_ptr = f'{arrayname}.data()'
-                    size_str = f'{arrayname}.size()'
-                    # data() is void*; cudaMemcpy accepts it without a typed cast.
-                    pointer_arrayname = f'dev{arrayname}.data()'
-                else:
-                    host_ptr = arrayname
-                    size_str = f'_num_{arrayname}'
-                    pointer_arrayname = f"dev{arrayname}"
                 code = f'''
                     for(int i=0; i<_num_{staticarrayname}; i++)
                     {{
@@ -627,12 +620,18 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
-                    code += f'''
+                    if is_dynamic:
+                        code += f'''
+                    dev{arrayname}.copy_from_host(
+                        {arrayname}.data(), {arrayname}.size());
+                '''
+                    else:
+                        code += f'''
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
-                            {pointer_arrayname},
-                            {host_ptr},
-                            sizeof({arrayname}[0])*{size_str},
+                            dev{arrayname},
+                            {arrayname},
+                            sizeof({arrayname}[0])*_num_{arrayname},
                             cudaMemcpyHostToDevice
                         )
                     );
@@ -640,14 +639,6 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 main_lines.extend(stripped_deindented_lines(code))
             elif func=='set_array_by_array':
                 arrayname, staticarrayname_index, staticarrayname_value = args
-                if arrayname in self.dynamic_arrays.values():
-                    host_ptr = f'{arrayname}.data()'
-                    dev_ptr = f'dev{arrayname}.data()'
-                    memcpy_size = f'{arrayname}.size()'
-                else:
-                    host_ptr = arrayname
-                    dev_ptr = f'dev{arrayname}'
-                    memcpy_size = f'_num_{arrayname}'
                 code = f'''
                     for(int i=0; i<_num_{staticarrayname_index}; i++)
                     {{
@@ -655,12 +646,18 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                     }}
                 '''
                 if arrayname not in self.variables_on_host_only:
-                    code += f'''
+                    if arrayname in self.dynamic_arrays.values():
+                        code += f'''
+                    dev{arrayname}.copy_from_host(
+                        {arrayname}.data(), {arrayname}.size());
+                '''
+                    else:
+                        code += f'''
                     CUDA_SAFE_CALL(
                         cudaMemcpy(
-                            {dev_ptr},
-                            {host_ptr},
-                            sizeof({arrayname}[0])*{memcpy_size},
+                            dev{arrayname},
+                            {arrayname},
+                            sizeof({arrayname}[0])*_num_{arrayname},
                             cudaMemcpyHostToDevice
                         )
                     );

--- a/brian2cuda/templates/common_synapses.cu
+++ b/brian2cuda/templates/common_synapses.cu
@@ -1,6 +1,6 @@
 {# USES_VARIABLES { N, no_delay_mode } #}
 {% extends 'common_group.cu' %}
 {% block extra_headers %}
-#include <stdint.h>
 #include "synapses_classes.h"
+#include "brianlib/spikequeue.h"
 {% endblock %}

--- a/brian2cuda/templates/group_variable_set.cu
+++ b/brian2cuda/templates/group_variable_set.cu
@@ -2,7 +2,7 @@
 {% extends 'common_group.cu' %}
 
 {% block extra_headers %}
-#include "rand.h"
+#include "objects_api.h"
 {% endblock %}
 
 {% block kernel_maincode %}
@@ -28,7 +28,7 @@
     #}
     {% for var, varname in written_variables.items() %}
     {% if var.dynamic %}
-    {{varname}} = dev{{varname}};
+    copy_dev_to_host_array_{{ array_basename(varname) }}();
     {% else %}
     CUDA_SAFE_CALL(
         cudaMemcpy(

--- a/brian2cuda/templates/group_variable_set.cu
+++ b/brian2cuda/templates/group_variable_set.cu
@@ -28,7 +28,8 @@
     #}
     {% for var, varname in written_variables.items() %}
     {% if var.dynamic %}
-    copy_dev_to_host_array_{{ array_basename(varname) }}();
+    {% set N = array_basename(varname) %}
+    copy_dev_to_host_array_{{ N }}();
     {% else %}
     CUDA_SAFE_CALL(
         cudaMemcpy(

--- a/brian2cuda/templates/group_variable_set.cu
+++ b/brian2cuda/templates/group_variable_set.cu
@@ -1,10 +1,6 @@
 {# USES_VARIABLES { _group_idx } #}
 {% extends 'common_group.cu' %}
 
-{% block extra_headers %}
-#include "objects_api.h"
-{% endblock %}
-
 {% block kernel_maincode %}
     ///// block kernel_maincode /////
 

--- a/brian2cuda/templates/group_variable_set.cu
+++ b/brian2cuda/templates/group_variable_set.cu
@@ -24,8 +24,9 @@
     #}
     {% for var, varname in written_variables.items() %}
     {% if var.dynamic %}
-    {% set N = array_basename(varname) %}
-    copy_dev_to_host_array_{{ N }}();
+    {{ varname }}.resize(dev{{ varname }}.size());
+    dev{{ varname }}.copy_to_host(
+        {{ varname }}.empty() ? nullptr : {{ varname }}.data());
     {% else %}
     CUDA_SAFE_CALL(
         cudaMemcpy(

--- a/brian2cuda/templates/group_variable_set.cu
+++ b/brian2cuda/templates/group_variable_set.cu
@@ -26,7 +26,7 @@
     {% if var.dynamic %}
     {{ varname }}.resize(dev{{ varname }}.size());
     dev{{ varname }}.copy_to_host(
-        {{ varname }}.empty() ? nullptr : {{ varname }}.data());
+        {{ varname }}.data());
     {% else %}
     CUDA_SAFE_CALL(
         cudaMemcpy(

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -36,7 +36,8 @@
     #}
     {% for var, varname in written_variables.items() %}
     {% if var.dynamic %}
-    copy_dev_to_host_array_{{ array_basename(varname) }}();
+    {% set N = array_basename(varname) %}
+    copy_dev_to_host_array_{{ N }}();
     {% else %}
     CUDA_SAFE_CALL(
         cudaMemcpy(

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -2,10 +2,6 @@
 {# ALLOWS_SCALAR_WRITE #}
 {% extends 'common_group.cu' %}
 
-{% block extra_headers %}
-#include "objects_api.h"
-{% endblock %}
-
 {% block kernel_maincode %}
     ///// block kernel_maincode /////
 

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -2,6 +2,7 @@
 {# ALLOWS_SCALAR_WRITE #}
 {% extends 'common_group.cu' %}
 
+
 {% block kernel_maincode %}
     ///// block kernel_maincode /////
 

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -2,6 +2,9 @@
 {# ALLOWS_SCALAR_WRITE #}
 {% extends 'common_group.cu' %}
 
+{% block extra_headers %}
+#include "objects_api.h"
+{% endblock %}
 
 {% block kernel_maincode %}
     ///// block kernel_maincode /////
@@ -33,7 +36,7 @@
     #}
     {% for var, varname in written_variables.items() %}
     {% if var.dynamic %}
-    {{varname}} = dev{{varname}};
+    copy_dev_to_host_array_{{ array_basename(varname) }}();
     {% else %}
     CUDA_SAFE_CALL(
         cudaMemcpy(

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -33,8 +33,9 @@
     #}
     {% for var, varname in written_variables.items() %}
     {% if var.dynamic %}
-    {% set N = array_basename(varname) %}
-    copy_dev_to_host_array_{{ N }}();
+    {{ varname }}.resize(dev{{ varname }}.size());
+    dev{{ varname }}.copy_to_host(
+        {{ varname }}.empty() ? nullptr : {{ varname }}.data());
     {% else %}
     CUDA_SAFE_CALL(
         cudaMemcpy(

--- a/brian2cuda/templates/group_variable_set_conditional.cu
+++ b/brian2cuda/templates/group_variable_set_conditional.cu
@@ -35,7 +35,7 @@
     {% if var.dynamic %}
     {{ varname }}.resize(dev{{ varname }}.size());
     dev{{ varname }}.copy_to_host(
-        {{ varname }}.empty() ? nullptr : {{ varname }}.data());
+        {{ varname }}.data());
     {% else %}
     CUDA_SAFE_CALL(
         cudaMemcpy(

--- a/brian2cuda/templates/main.cu
+++ b/brian2cuda/templates/main.cu
@@ -1,5 +1,7 @@
 #include <stdlib.h>
 #include "objects.h"
+#include "objects_api.h"
+#include "network.h"
 #include <csignal>
 #include <ctime>
 #include <time.h>

--- a/brian2cuda/templates/main.cu
+++ b/brian2cuda/templates/main.cu
@@ -1,6 +1,5 @@
 #include <stdlib.h>
 #include "objects.h"
-#include "objects_api.h"
 #include "network.h"
 #include <csignal>
 #include <ctime>

--- a/brian2cuda/templates/network.cu
+++ b/brian2cuda/templates/network.cu
@@ -98,7 +98,7 @@ void Network::run(const double duration, void (*report_func)(const double, const
         {% if varname in spikegenerator_eventspaces %}
         brian::previous_idx{{varname}} = brian::current_idx{{varname}};
         {% endif %}
-        brian::current_idx{{varname}} = (brian::current_idx{{varname}} + 1) % brian::dev{{varname}}.size();
+        brian::current_idx{{varname}} = (brian::current_idx{{varname}} + 1) % brian::_num_dev{{ varname }};
         {% endfor %}
 
         {% if maximum_run_time is not none %}

--- a/brian2cuda/templates/network.cu
+++ b/brian2cuda/templates/network.cu
@@ -98,7 +98,7 @@ void Network::run(const double duration, void (*report_func)(const double, const
         {% if varname in spikegenerator_eventspaces %}
         brian::previous_idx{{varname}} = brian::current_idx{{varname}};
         {% endif %}
-        brian::current_idx{{varname}} = (brian::current_idx{{varname}} + 1) % brian::_num_dev{{ varname }};
+        brian::current_idx{{varname}} = (brian::current_idx{{varname}} + 1) % static_cast<int>(brian::dev{{ varname }}.size());
         {% endfor %}
 
         {% if maximum_run_time is not none %}

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -29,9 +29,6 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 #include <algorithm>
 #include <vector>
 #include <thrust/device_vector.h>
-#include <thrust/sequence.h>
-#include <thrust/sort.h>
-#include <thrust/unique.h>
 #include <curand.h>
 
 size_t brian::used_device_memory = 0;
@@ -417,20 +414,6 @@ void set_monitor_address_{{ varname }}(int row) {
     sync_monitor_addresses_{{ varname }}();
 }
 {% endfor %}
-void sort_by_key_int_int32(int* keys, int32_t* values, size_t n) {
-    if (n <= 1) {
-        return;
-    }
-    thrust::sort_by_key(keys, keys + n, values);
-}
-void fill_sequence_int(int* out, size_t n) {
-    thrust::sequence(out, out + n);
-}
-size_t unique_by_key_int_int(int* keys, int* values, size_t n) {
-    if (n == 0) return 0;
-    auto out_pair = thrust::unique_by_key(keys, keys + n, values);
-    return static_cast<size_t>(out_pair.first - keys);
-}
 }  // namespace brian
 
 /////////////// static arrays /////////////
@@ -1118,9 +1101,6 @@ void clear_dev_array_{{ N }}();
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 void expand_eventspace{{ varname }}(int num_queues);
 {% endfor %}
-void sort_by_key_int_int32(int* keys, int32_t* values, size_t n);
-void fill_sequence_int(int* out, size_t n);
-size_t unique_by_key_int_int(int* keys, int* values, size_t n);
 int filter_subgroup_eventspace(int32_t* src, int n, int32_t* dst, int32_t start, int32_t stop);
 {% for varname in subgroups_with_spikemonitor %}
 void resize_subgroup_eventspace_{{varname}}(size_t n);

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -14,21 +14,28 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 {% endif %}
 {%- endmacro %}
 
+#define BRIAN2CUDA_CURAND_HOST
+#include "objects_storage.h"
 #include "objects.h"
-#include "synapses_classes.h"
-#include "brianlib/clocks.h"
-#include "brianlib/cuda_utils.h"
+#include "objects_api.h"
 #include "network.h"
+{% if synapses %}
+#include "synapses_classes.h"
+{% endif %}
+#include "brianlib/cuda_utils.h"
 #include "rand.h"
-#include <stdint.h>
 #include <iostream>
 #include <fstream>
 #include <chrono>
 #include <ctime>
-#include <utility>
-
-#include <thrust/host_vector.h>
-#include <thrust/device_vector.h>
+#include <algorithm>
+#include <vector>
+#include <thrust/copy.h>
+#include <thrust/count.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+#include <thrust/unique.h>
+#include <curand.h>
 
 size_t brian::used_device_memory = 0;
 std::string brian::results_dir = "results/";  // can be overwritten by --results_dir command line arg
@@ -221,6 +228,306 @@ thrust::device_vector<{{c_data_type(var.dtype)}}*> brian::addresses_monitor_{{va
 thrust::device_vector<{{c_data_type(var.dtype)}}>* brian::{{varname}};
 {% endfor %}
 
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = array_basename(varname) %}
+{{c_data_type(var.dtype)}}* brian::host_array_{{ N }} = nullptr;
+int brian::_num_host_array_{{ N }} = 0;
+{{c_data_type(var.dtype)}}* brian::dev_array_{{ N }} = nullptr;
+int brian::_num_dev_array_{{ N }} = 0;
+{% endfor %}
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+{{c_data_type(var.dtype)}}** brian::dev{{ varname }}_view = nullptr;
+int brian::_num_dev{{ varname }} = 0;
+{% endfor %}
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+{{c_data_type(var.dtype)}}** brian::monitor_addresses_{{ varname }} = nullptr;
+int brian::_num_monitor_addresses_{{ varname }} = 0;
+{% endfor %}
+{% for varname in subgroups_with_spikemonitor %}
+int32_t* brian::dev_array_subgroup_eventspace_{{varname}} = nullptr;
+int brian::_num_subgroup_eventspace_{{varname}} = 0;
+{% endfor %}
+
+namespace brian {
+
+namespace dyn_array {
+
+template <typename T>
+void sync_host_dev(
+        thrust::host_vector<T>& host,
+        thrust::device_vector<T>& device,
+        T*& host_ptr, int& host_n,
+        T*& device_ptr, int& device_n)
+{
+    host_n = static_cast<int>(host.size());
+    host_ptr = host_n ? &host[0] : nullptr;
+    device_n = static_cast<int>(device.size());
+    device_ptr = device_n
+        ? thrust::raw_pointer_cast(&device[0]) : nullptr;
+}
+
+template <typename T>
+void push_back_host(
+        thrust::host_vector<T>& host,
+        thrust::device_vector<T>& device,
+        T v,
+        T*& host_ptr, int& host_n,
+        T*& device_ptr, int& device_n)
+{
+    host.push_back(v);
+    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
+}
+
+template <typename T>
+void resize_host(
+        thrust::host_vector<T>& host,
+        thrust::device_vector<T>& device,
+        size_t n,
+        T*& host_ptr, int& host_n,
+        T*& device_ptr, int& device_n)
+{
+    host.resize(n);
+    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
+}
+
+template <typename T>
+void resize_dev(
+        thrust::host_vector<T>& host,
+        thrust::device_vector<T>& device,
+        size_t n,
+        T*& host_ptr, int& host_n,
+        T*& device_ptr, int& device_n)
+{
+    THRUST_CHECK_ERROR(device.resize(n));
+    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
+}
+
+template <typename T>
+void copy_dev_to_host(
+        thrust::host_vector<T>& host,
+        thrust::device_vector<T>& device,
+        T*& host_ptr, int& host_n,
+        T*& device_ptr, int& device_n)
+{
+    host = device;
+    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
+}
+
+template <typename T>
+void copy_host_to_dev(
+        thrust::host_vector<T>& host,
+        thrust::device_vector<T>& device,
+        T*& host_ptr, int& host_n,
+        T*& device_ptr, int& device_n)
+{
+    device = host;
+    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
+}
+
+template <typename T>
+void clear_dev(
+        thrust::host_vector<T>& host,
+        thrust::device_vector<T>& device,
+        T*& host_ptr, int& host_n,
+        T*& device_ptr, int& device_n)
+{
+    device.clear();
+    device.shrink_to_fit();
+    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
+}
+
+template <typename T>
+void sync_device_ptr(
+        thrust::device_vector<T>& device,
+        T*& device_ptr, int& device_n)
+{
+    device_n = static_cast<int>(device.size());
+    device_ptr = device_n
+        ? thrust::raw_pointer_cast(&device[0]) : nullptr;
+}
+
+}  // namespace dyn_array
+
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+void sync_eventspace_{{ varname }}() {
+    _num_dev{{ varname }} = static_cast<int>(dev{{ varname }}.size());
+    dev{{ varname }}_view = dev{{ varname }}.empty() ? nullptr : &dev{{ varname }}[0];
+}
+{% endfor %}
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+void sync_monitor_addresses_{{ varname }}() {
+    dyn_array::sync_device_ptr(
+        addresses_monitor_{{ varname }},
+        monitor_addresses_{{ varname }},
+        _num_monitor_addresses_{{ varname }});
+}
+{% endfor %}
+{% for varname in subgroups_with_spikemonitor %}
+void sync_subgroup_eventspace_{{varname}}() {
+    dyn_array::sync_device_ptr(
+        _dev_{{varname}}_eventspace,
+        dev_array_subgroup_eventspace_{{varname}},
+        _num_subgroup_eventspace_{{varname}});
+}
+{% endfor %}
+
+void sync_all_dev_ptrs() {
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = array_basename(varname) %}
+    dyn_array::sync_host_dev(
+        {{ varname }}, dev{{ varname }},
+        host_array_{{ N }}, _num_host_array_{{ N }},
+        dev_array_{{ N }}, _num_dev_array_{{ N }});
+{% endfor %}
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+    sync_eventspace_{{ varname }}();
+{% endfor %}
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+    sync_monitor_addresses_{{ varname }}();
+{% endfor %}
+{% for varname in subgroups_with_spikemonitor %}
+    sync_subgroup_eventspace_{{varname}}();
+{% endfor %}
+}
+
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = array_basename(varname) %}
+void push_back_host_array_{{ N }}({{c_data_type(var.dtype)}} v) {
+    dyn_array::push_back_host(
+        {{ varname }}, dev{{ varname }}, v,
+        host_array_{{ N }}, _num_host_array_{{ N }},
+        dev_array_{{ N }}, _num_dev_array_{{ N }});
+}
+void resize_host_array_{{ N }}(size_t n) {
+    dyn_array::resize_host(
+        {{ varname }}, dev{{ varname }}, n,
+        host_array_{{ N }}, _num_host_array_{{ N }},
+        dev_array_{{ N }}, _num_dev_array_{{ N }});
+}
+void resize_dev_array_{{ N }}(size_t n) {
+    dyn_array::resize_dev(
+        {{ varname }}, dev{{ varname }}, n,
+        host_array_{{ N }}, _num_host_array_{{ N }},
+        dev_array_{{ N }}, _num_dev_array_{{ N }});
+}
+void copy_dev_to_host_array_{{ N }}() {
+    dyn_array::copy_dev_to_host(
+        {{ varname }}, dev{{ varname }},
+        host_array_{{ N }}, _num_host_array_{{ N }},
+        dev_array_{{ N }}, _num_dev_array_{{ N }});
+}
+void copy_host_to_dev_array_{{ N }}() {
+    dyn_array::copy_host_to_dev(
+        {{ varname }}, dev{{ varname }},
+        host_array_{{ N }}, _num_host_array_{{ N }},
+        dev_array_{{ N }}, _num_dev_array_{{ N }});
+}
+void clear_dev_array_{{ N }}() {
+    dyn_array::clear_dev(
+        {{ varname }}, dev{{ varname }},
+        host_array_{{ N }}, _num_host_array_{{ N }},
+        dev_array_{{ N }}, _num_dev_array_{{ N }});
+}
+{% endfor %}
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+void expand_eventspace{{ varname }}(int num_queues) {
+    int num_eventspaces = static_cast<int>(dev{{ varname }}.size());
+    if (num_queues <= num_eventspaces) return;
+    std::rotate(
+        dev{{ varname }}.begin(),
+        dev{{ varname }}.begin() + current_idx{{ varname }},
+        dev{{ varname }}.end());
+    current_idx{{ varname }} = 0;
+    for (int i = num_eventspaces; i < num_queues; i++) {
+        {{c_data_type(var.dtype)}}* new_eventspace;
+        CUDA_SAFE_CALL(cudaMalloc(
+            (void**)&new_eventspace,
+            sizeof({{c_data_type(var.dtype)}}) * _num_{{ varname }}));
+        CUDA_SAFE_CALL(cudaMemcpy(
+            new_eventspace, {{ varname }},
+            sizeof({{c_data_type(var.dtype)}}) * _num_{{ varname }},
+            cudaMemcpyHostToDevice));
+        dev{{ varname }}.push_back(new_eventspace);
+    }
+    sync_eventspace_{{ varname }}();
+}
+{% endfor %}
+{% for varname in subgroups_with_spikemonitor %}
+void resize_subgroup_eventspace_{{varname}}(size_t n) {
+    THRUST_CHECK_ERROR(_dev_{{varname}}_eventspace.resize(n));
+    sync_subgroup_eventspace_{{varname}}();
+}
+{% endfor %}
+// Namespace-scope: nvcc/CUB reject local classes as thrust predicates.
+struct is_in_subgroup
+{
+    int32_t start;
+    int32_t stop;
+
+    __host__ __device__
+    bool operator()(const int32_t& neuron) const
+    {
+        return start <= neuron && neuron < stop;
+    }
+};
+
+int filter_subgroup_eventspace(
+        int32_t* src, int n, int32_t* dst, int32_t start, int32_t stop) {
+    if (n <= 0) return 0;
+
+    thrust::device_ptr<int32_t> src_ptr(src);
+    thrust::device_ptr<int32_t> dst_ptr(dst);
+    is_in_subgroup pred{start, stop};
+
+    // Count the elements in eventspace that are in the subgroup
+    int out_n = 0;
+    THRUST_CHECK_ERROR(
+        out_n = static_cast<int>(
+            thrust::count_if(src_ptr, src_ptr + n, pred)
+        )
+    );
+    // Copy all neuron IDs that are in this subgroup to the new device pointer
+    THRUST_CHECK_ERROR(
+        thrust::copy_if(src_ptr, src_ptr + n, dst_ptr, pred)
+    );
+    return out_n;
+}
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+void clear_monitor_addresses_{{ varname }}() {
+    addresses_monitor_{{ varname }}.clear();
+    sync_monitor_addresses_{{ varname }}();
+}
+void resize_monitor_row_{{ varname }}(int row, size_t n) {
+    {{ varname }}[row].resize(n);
+    sync_monitor_addresses_{{ varname }}();
+}
+void push_monitor_address_{{ varname }}(int row) {
+    addresses_monitor_{{ varname }}.push_back(
+        thrust::raw_pointer_cast(&{{ varname }}[row][0]));
+    sync_monitor_addresses_{{ varname }}();
+}
+void set_monitor_address_{{ varname }}(int row) {
+    addresses_monitor_{{ varname }}[row] =
+        thrust::raw_pointer_cast(&{{ varname }}[row][0]);
+    sync_monitor_addresses_{{ varname }}();
+}
+{% endfor %}
+void sort_by_key_int_int32(int* keys, int32_t* values, size_t n) {
+    if (n <= 1) {
+        return;
+    }
+    thrust::sort_by_key(keys, keys + n, values);
+}
+void fill_sequence_int(int* out, size_t n) {
+    thrust::sequence(out, out + n);
+}
+size_t unique_by_key_int_int(int* keys, int* values, size_t n) {
+    if (n == 0) return 0;
+    auto out_pair = thrust::unique_by_key(keys, keys + n, values);
+    return static_cast<size_t>(out_pair.first - keys);
+}
+}  // namespace brian
+
 /////////////// static arrays /////////////
 {% for (name, dtype_spec, N, filename) in static_array_specs | sort %}
 {# arrays that are initialized from static data are already declared #}
@@ -269,29 +576,6 @@ int brian::max_threads_per_sm;
 int brian::max_shared_mem_size;
 int brian::num_threads_per_warp;
 
-{% for S in synapses | sort(attribute='name') %}
-{% for path in S._pathways | sort(attribute='name') %}
-__global__ void {{path.name}}_init(
-                int32_t* sources,
-                int32_t* targets,
-                double dt,
-                int32_t source_start,
-                int32_t source_stop
-        )
-{
-    using namespace brian;
-
-    {{path.name}}.init(
-            sources,
-            targets,
-            dt,
-            // TODO: called source here, spikes in SynapticPathway (use same name)
-            source_start,
-            source_stop);
-}
-{% endfor %}
-{% endfor %}
-
 {% if profiled_codeobjects is defined %}
 // Profiling information for each code object
 {% for codeobj in profiled_codeobjects | sort %}
@@ -308,6 +592,33 @@ std::chrono::nanoseconds brian::{{codeobj}}_kernel_currents_profiling_info(0);
 #}
 {% endfor %}
 {% endif %}
+
+
+//////////////random numbers//////////////////
+curandGenerator_t brian::curand_generator;
+__device__ unsigned long long* brian::d_curand_seed;
+unsigned long long* brian::dev_curand_seed;
+// dev_{co.name}_{rng_type}_allocator
+//      pointer to start of generated random numbers array
+//      at each generation cycle this array is refilled
+// dev_{co.name}_{rng_type}
+//      pointer moving through generated random number array
+//      until it is regenerated at the next generation cycle
+{% for rng_type in all_codeobj_with_host_rng.keys() %}
+{% for co in all_codeobj_with_host_rng[rng_type] | sort(attribute='name') %}
+{% if rng_type in ['rand', 'randn'] %}
+{% set dtype = 'randomNumber_t' %}
+{% else %}  {# rng_type = 'poisson_<idx>' #}
+{% set dtype = 'unsigned int' %}
+{% endif %}
+{{dtype}}* brian::dev_{{co.name}}_{{rng_type}}_allocator;
+{{dtype}}* brian::dev_{{co.name}}_{{rng_type}};
+__device__ {{dtype}}* brian::_array_{{co.name}}_{{rng_type}};
+{% endfor %}{# rng_type #}
+{% endfor %}{# co #}
+curandState* brian::dev_curand_states;
+__device__ curandState* brian::d_curand_states;
+RandomNumberBuffer brian::random_number_buffer;
 
 void _init_arrays()
 {
@@ -454,6 +765,7 @@ void _init_arrays()
     const double to_MB = 1.0 / (1024.0 * 1024.0);
     double tot_memory_MB = (used_device_memory - used_device_memory_start) * to_MB;
     double time_passed = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start_timer).count();
+    sync_all_dev_ptrs();
     std::cout << "INFO: _init_arrays() took " <<  time_passed << "s";
     if (tot_memory_MB > 0)
         std::cout << " and used " << tot_memory_MB << "MB of device memory.";
@@ -465,8 +777,8 @@ void _load_arrays()
     using namespace brian;
 
     {% for (name, dtype_spec, N, filename) in static_array_specs | sort %}
-    ifstream f{{name}};
-    f{{name}}.open("static_arrays/{{name}}", ios::in | ios::binary);
+    std::ifstream f{{name}};
+    f{{name}}.open("static_arrays/{{name}}", std::ios::in | std::ios::binary);
     if(f{{name}}.is_open())
     {
         {% if name in dynamic_array_specs.values() %}
@@ -476,7 +788,7 @@ void _load_arrays()
         {% endif %}
     } else
     {
-        std::cout << "Error opening static array {{name}}." << endl;
+        std::cout << "Error opening static array {{name}}." << std::endl;
     }
     {% if not (name in dynamic_array_specs.values()) %}
     CUDA_SAFE_CALL(
@@ -506,15 +818,15 @@ void _write_arrays()
             cudaMemcpy({{varname}}, dev{{varname}}, sizeof({{c_data_type(var.dtype)}})*_num_{{varname}}, cudaMemcpyDeviceToHost)
             );
     {% endif %}
-    ofstream outfile_{{varname}};
-    outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", ios::binary | ios::out);
+    std::ofstream outfile_{{varname}};
+    outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", std::ios::binary | std::ios::out);
     if(outfile_{{varname}}.is_open())
     {
         outfile_{{varname}}.write(reinterpret_cast<char*>({{varname}}), {{var.size}}*sizeof({{c_data_type(var.dtype)}}));
         outfile_{{varname}}.close();
     } else
     {
-        std::cout << "Error writing output file for {{varname}}." << endl;
+        std::cout << "Error writing output file for {{varname}}." << std::endl;
     }
     {% endif %}
     {% endfor %}
@@ -523,15 +835,15 @@ void _write_arrays()
     {% if varname not in variables_on_host_only %}
     {{varname}} = dev{{varname}};
     {% endif %}
-    ofstream outfile_{{varname}};
-    outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", ios::binary | ios::out);
+    std::ofstream outfile_{{varname}};
+    outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", std::ios::binary | std::ios::out);
     if(outfile_{{varname}}.is_open())
     {
         outfile_{{varname}}.write(reinterpret_cast<char*>(thrust::raw_pointer_cast(&{{varname}}[0])), {{varname}}.size()*sizeof({{c_data_type(var.dtype)}}));
         outfile_{{varname}}.close();
     } else
     {
-        std::cout << "Error writing output file for {{varname}}." << endl;
+        std::cout << "Error writing output file for {{varname}}." << std::endl;
     }
     {% endfor %}
 
@@ -539,11 +851,11 @@ void _write_arrays()
         {% if var in profile_statemonitor_vars %}
         {# Record copying statemonitor variable from device to host for benchmarking #}
         std::chrono::nanoseconds before_copy_statemon;
-        string profile_statemonitor_copy_to_host_varname = "{{var.owner.name}}_copy_to_host_{{profile_statemonitor_copy_to_host}}";
+        std::string profile_statemonitor_copy_to_host_varname = "{{var.owner.name}}_copy_to_host_{{profile_statemonitor_copy_to_host}}";
         std::chrono::nanoseconds copy_time_statemon;
         {% endif %}
-        ofstream outfile_{{varname}};
-        outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", ios::binary | ios::out);
+        std::ofstream outfile_{{varname}};
+        outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", std::ios::binary | std::ios::out);
         if(outfile_{{varname}}.is_open())
         {
             {% if var in profile_statemonitor_vars %}
@@ -555,7 +867,7 @@ void _write_arrays()
                 temp_array{{varname}}[n] = {{varname}}[n];
             }
             {% if var in profile_statemonitor_vars %}
-            string profile_statemonitor_copy_to_host_varname = "{{varname}}_copy_to_host";
+            std::string profile_statemonitor_copy_to_host_varname = "{{varname}}_copy_to_host";
             copy_time_statemon += std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - before_copy_statemon);
             {% endif %}
             for(int j = 0; j < temp_array{{varname}}[0].size(); j++)
@@ -568,14 +880,14 @@ void _write_arrays()
             outfile_{{varname}}.close();
         } else
         {
-            std::cout << "Error writing output file for {{varname}}." << endl;
+            std::cout << "Error writing output file for {{varname}}." << std::endl;
         }
     {% endfor %}
 
     {% if profiled_codeobjects is defined and profiled_codeobjects %}
     // Write profiling info to disk
-    ofstream outfile_profiling_info;
-    outfile_profiling_info.open(results_dir + "profiling_info.txt", ios::out);
+    std::ofstream outfile_profiling_info;
+    outfile_profiling_info.open(results_dir + "profiling_info.txt", std::ios::out);
     if(outfile_profiling_info.is_open())
     {
     {% for codeobj in profiled_codeobjects | sort %}
@@ -600,8 +912,8 @@ void _write_arrays()
     }
     {% endif %}
     // Write last run info to disk
-    ofstream outfile_last_run_info;
-    outfile_last_run_info.open(results_dir + "last_run_info.txt", ios::out);
+    std::ofstream outfile_last_run_info;
+    outfile_last_run_info.open(results_dir + "last_run_info.txt", std::ios::out);
     if(outfile_last_run_info.is_open())
     {
         outfile_last_run_info << (Network::_last_run_time) << " " << (Network::_last_run_completed_fraction) << std::endl;
@@ -611,17 +923,6 @@ void _write_arrays()
         std::cout << "Error writing last run info to file." << std::endl;
     }
 }
-
-{% for S in synapses | sort(attribute='name') %}
-{% for path in S._pathways | sort(attribute='name') %}
-__global__ void {{path.name}}_destroy()
-{
-    using namespace brian;
-
-    {{path.name}}.destroy();
-}
-{% endfor %}
-{% endfor %}
 
 void _dealloc_arrays()
 {
@@ -702,23 +1003,34 @@ void _dealloc_arrays()
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 
 {% macro h_file() %}
-#include <ctime>
+
 // typedefs need to be outside the include guards to
 // be visible to all files including objects.h
 typedef {{curand_float_type}} randomNumber_t;  // random number type
 
+struct curandGenerator_st;
+typedef struct curandGenerator_st* curandGenerator_t;
+#ifndef CURAND_KERNEL_H_
+struct curandStateXORWOW;
+typedef struct curandStateXORWOW curandState;
+#endif
+
 #ifndef _BRIAN_OBJECTS_H
 #define _BRIAN_OBJECTS_H
 
-#include<vector>
-#include<stdint.h>
-#include "synapses_classes.h"
+#include <vector>
+#include <string>
+#include <stdint.h>
 #include "brianlib/clocks.h"
-#include "network.h"
-
-#include <thrust/device_vector.h>
-#include <thrust/host_vector.h>
+#include "rand.h"
+{% if profiled_codeobjects is defined %}
 #include <chrono>
+{% endif %}
+
+class Network;
+{% if synapses %}
+class SynapticPathway;
+{% endif %}
 
 namespace brian {
 
@@ -741,14 +1053,6 @@ extern Network {{net.name}};
 
 extern void set_variable_by_name(std::string, std::string);
 
-//////////////// dynamic arrays 1d ///////////
-{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-extern thrust::host_vector<{{c_data_type(var.dtype)}}> {{varname}};
-extern thrust::device_vector<{{c_data_type(var.dtype)}}> dev{{varname}};
-{% endfor %}
-{% for varname in subgroups_with_spikemonitor %}
-extern thrust::device_vector<int32_t> _dev_{{varname}}_eventspace;
-{% endfor %}
 
 //////////////// arrays ///////////////////
 {% for var, varname in array_specs | dictsort(by='value') %}
@@ -763,18 +1067,11 @@ extern const int _num_{{varname}};
 //////////////// eventspaces ///////////////
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 extern {{c_data_type(var.dtype)}} * {{varname}};
-extern thrust::host_vector<{{c_data_type(var.dtype)}}*> dev{{varname}};
 extern const int _num_{{varname}};
 extern int current_idx{{varname}};
 {% if varname in spikegenerator_eventspaces %}
 extern int previous_idx{{varname}};
 {% endif %}
-{% endfor %}
-
-//////////////// dynamic arrays 2d /////////
-{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
-extern thrust::device_vector<{{c_data_type(var.dtype)}}*> addresses_monitor_{{varname}};
-extern thrust::device_vector<{{c_data_type(var.dtype)}}>* {{varname}};
 {% endfor %}
 
 /////////////// static arrays /////////////
@@ -786,6 +1083,33 @@ extern {{dtype_spec}} *dev{{name}};
 extern __device__ {{dtype_spec}} *d{{name}};
 extern const int _num_{{name}};
 {% endif %}
+{% endfor %}
+
+//////////////// dynamic arrays 1d ///////////
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = array_basename(varname) %}
+extern {{c_data_type(var.dtype)}}* host_array_{{ N }};
+extern int _num_host_array_{{ N }};
+extern {{c_data_type(var.dtype)}}* dev_array_{{ N }};
+extern int _num_dev_array_{{ N }};
+{% endfor %}
+
+//////////////// eventspaces (synced views) ///////////////
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+extern {{c_data_type(var.dtype)}}** dev{{ varname }}_view;
+extern int _num_dev{{ varname }};
+{% endfor %}
+
+//////////////// dynamic arrays 2d (synced views) ///////////////
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+extern {{c_data_type(var.dtype)}}** monitor_addresses_{{ varname }};
+extern int _num_monitor_addresses_{{ varname }};
+{% endfor %}
+
+//////////////// subgroup eventspace buffers ///////////////
+{% for varname in subgroups_with_spikemonitor %}
+extern int32_t* dev_array_subgroup_eventspace_{{varname}};
+extern int _num_subgroup_eventspace_{{varname}};
 {% endfor %}
 
 //////////////// synapses /////////////////
@@ -833,6 +1157,32 @@ extern std::chrono::nanoseconds {{codeobj}}_kernel_currents_profiling_info;
 {% endfor %}
 {% endif %}
 
+
+//////////////// random numbers /////////////////
+extern curandGenerator_t curand_generator;
+extern unsigned long long* dev_curand_seed;
+extern __device__ unsigned long long* d_curand_seed;
+
+{% for rng_type in all_codeobj_with_host_rng.keys() %}
+{% for co in all_codeobj_with_host_rng[rng_type] | sort(attribute='name') %}
+{% if rng_type in ['rand', 'randn'] %}
+{% set dtype = 'randomNumber_t' %}
+{% else %}  {# rng_type = 'poisson_<idx>' #}
+{% set dtype = 'unsigned int' %}
+{% endif %}
+// pointer to start of generated random numbers array
+// at each generation cycle this array is refilled
+extern {{dtype}}* dev_{{co.name}}_{{rng_type}}_allocator;
+// pointer moving through generated random number array
+// until it is regenerated at the next generation cycle
+extern {{dtype}}* dev_{{co.name}}_{{rng_type}};
+extern __device__ {{dtype}}* _array_{{co.name}}_{{rng_type}};
+{% endfor %}{# rng_type #}
+{% endfor %}{# co #}
+extern curandState* dev_curand_states;
+extern __device__ curandState* d_curand_states;
+extern RandomNumberBuffer random_number_buffer;
+
 //CUDA
 extern int num_parallel_blocks;
 extern int max_threads_per_block;
@@ -850,4 +1200,80 @@ void _dealloc_arrays();
 #endif
 
 
+{% endmacro %}
+
+{% macro h_storage_file() %}
+#include "objects.h"
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+#ifndef _BRIAN_OBJECTS_STORAGE_H
+#define _BRIAN_OBJECTS_STORAGE_H
+
+namespace brian {
+
+//////////////// dynamic arrays 1d ///////////
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+extern thrust::host_vector<{{c_data_type(var.dtype)}}> {{varname}};
+extern thrust::device_vector<{{c_data_type(var.dtype)}}> dev{{varname}};
+{% endfor %}
+{% for varname in subgroups_with_spikemonitor %}
+extern thrust::device_vector<int32_t> _dev_{{varname}}_eventspace;
+{% endfor %}
+
+//////////////// eventspaces ///////////////
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+extern thrust::host_vector<{{c_data_type(var.dtype)}}*> dev{{varname}};
+{% endfor %}
+
+//////////////// dynamic arrays 2d /////////
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+extern thrust::device_vector<{{c_data_type(var.dtype)}}*> addresses_monitor_{{varname}};
+extern thrust::device_vector<{{c_data_type(var.dtype)}}>* {{varname}};
+{% endfor %}
+
+}
+#endif // _BRIAN_OBJECTS_STORAGE_H
+{% endmacro %}
+
+{% macro h_api_file() %}
+#ifndef _BRIAN_OBJECTS_API_H
+#define _BRIAN_OBJECTS_API_H
+
+#include <cstddef>
+#include <cstdint>
+
+namespace brian {
+
+void sync_all_dev_ptrs();
+
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+void expand_eventspace{{ varname }}(int num_queues);
+{% endfor %}
+void sort_by_key_int_int32(int* keys, int32_t* values, size_t n);
+void fill_sequence_int(int* out, size_t n);
+size_t unique_by_key_int_int(int* keys, int* values, size_t n);
+int filter_subgroup_eventspace(int32_t* src, int n, int32_t* dst, int32_t start, int32_t stop);
+{% for varname in subgroups_with_spikemonitor %}
+void resize_subgroup_eventspace_{{varname}}(size_t n);
+{% endfor %}
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = array_basename(varname) %}
+void resize_host_array_{{ N }}(size_t n);
+void push_back_host_array_{{ N }}({{c_data_type(var.dtype)}} v);
+void resize_dev_array_{{ N }}(size_t n);
+void clear_dev_array_{{ N }}();
+void copy_dev_to_host_array_{{ N }}();
+void copy_host_to_dev_array_{{ N }}();
+{% endfor %}
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+void clear_monitor_addresses_{{ varname }}();
+void resize_monitor_row_{{ varname }}(int row, size_t n);
+void push_monitor_address_{{ varname }}(int row);
+void set_monitor_address_{{ varname }}(int row);
+{% endfor %}
+
+}
+
+#endif
 {% endmacro %}

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -220,9 +220,6 @@ DeviceBuffer* {{varname}} = nullptr;
 
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
 {% set N = array_basename(varname) %}
-void resize_dev_array_{{ N }}(size_t n) {
-    dev{{ varname }}.resize(n);
-}
 void copy_host_to_dev_array_{{ N }}() {
     dev{{ varname }}.copy_from_host(
         {{ varname }}.empty() ? nullptr : {{ varname }}.data(),
@@ -232,9 +229,6 @@ void copy_dev_to_host_array_{{ N }}() {
     {{ varname }}.resize(dev{{ varname }}.size());
     dev{{ varname }}.copy_to_host(
         {{ varname }}.empty() ? nullptr : {{ varname }}.data());
-}
-void clear_dev_array_{{ N }}() {
-    dev{{ varname }}.clear();
 }
 {% endfor %}
 
@@ -260,11 +254,7 @@ void expand_eventspace{{ varname }}(int num_queues) {
     }
 }
 {% endfor %}
-{% for varname in subgroups_with_spikemonitor %}
-void resize_subgroup_eventspace_{{varname}}(size_t n) {
-    _dev_{{varname}}_eventspace.resize(n);
-}
-{% endfor %}
+
 {% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
 void clear_monitor_addresses_{{ varname }}() {
     addresses_monitor_{{ varname }}.clear();
@@ -480,9 +470,8 @@ void _init_arrays()
     // static arrays
     {% for (name, dtype_spec, N, filename) in static_array_specs | sort %}
     {% if (name in dynamic_array_specs.values())  %}
-    {% set Nbase = array_basename(name) %}
     {{name}}.resize({{N}});
-    resize_dev_array_{{ Nbase }}({{N}});
+    dev{{name}}.resize({{N}});
     {% else %}
     {{name}} = new {{dtype_spec}}[{{N}}];
     CUDA_SAFE_CALL(
@@ -714,8 +703,7 @@ void _dealloc_arrays()
     {% endfor %}
 
     {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-    {% set N = array_basename(varname) %}
-    clear_dev_array_{{ N }}();
+    dev{{varname}}.clear();
     {{varname}}.clear();
     std::vector<{{c_data_type(var.dtype)}}>().swap({{varname}});
     {% endfor %}
@@ -951,19 +939,15 @@ extern int num_threads_per_warp;
 //////////////// host helpers /////////////////
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
 {% set N = array_basename(varname) %}
-void resize_dev_array_{{ N }}(size_t n);
 void copy_host_to_dev_array_{{ N }}();
 void copy_dev_to_host_array_{{ N }}();
-void clear_dev_array_{{ N }}();
 {% endfor %}
 
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 void expand_eventspace{{ varname }}(int num_queues);
 {% endfor %}
 int filter_subgroup_eventspace(int32_t* src, int n, int32_t* dst, int32_t start, int32_t stop);
-{% for varname in subgroups_with_spikemonitor %}
-void resize_subgroup_eventspace_{{varname}}(size_t n);
-{% endfor %}
+
 {% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
 void clear_monitor_addresses_{{ varname }}();
 void resize_monitor_row_{{ varname }}(int row, size_t n);

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -21,7 +21,6 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 #include "synapses_classes.h"
 {% endif %}
 #include "brianlib/cuda_utils.h"
-#include "brianlib/device_buffer.h"
 #include "rand.h"
 #include <iostream>
 #include <fstream>
@@ -193,6 +192,7 @@ const int brian::_num_{{varname}} = {{var.size}};
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 {{c_data_type(var.dtype)}} * brian::{{varname}};
 const int brian::_num_{{varname}} = {{var.size}};
+std::vector<{{c_data_type(var.dtype)}}*> brian::dev{{varname}}(1);
 int brian::current_idx{{varname}} = 0;
 {% if varname in spikegenerator_eventspaces %}
 int brian::previous_idx{{varname}};
@@ -204,17 +204,9 @@ int brian::previous_idx{{varname}};
 std::vector<{{c_data_type(var.dtype)}}> brian::{{varname}};
 {% endfor %}
 
-{% for var, varname in eventspace_arrays | dictsort(by='value') %}
-{{c_data_type(var.dtype)}}** brian::dev{{ varname }}_view = nullptr;
-int brian::_num_dev{{ varname }} = 0;
-{% endfor %}
-
 namespace brian {
 
 //////////////// device storage ///////////
-{% for var, varname in eventspace_arrays | dictsort(by='value') %}
-std::vector<{{c_data_type(var.dtype)}}*> dev{{varname}}(1);
-{% endfor %}
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
 DeviceBuffer dev{{varname}}(sizeof({{c_data_type(var.dtype)}}));
 {% endfor %}
@@ -247,13 +239,6 @@ void clear_dev_array_{{ N }}() {
 {% endfor %}
 
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
-void sync_eventspace_{{ varname }}() {
-    _num_dev{{ varname }} = static_cast<int>(dev{{ varname }}.size());
-    dev{{ varname }}_view = dev{{ varname }}.empty() ? nullptr : &dev{{ varname }}[0];
-}
-{% endfor %}
-
-{% for var, varname in eventspace_arrays | dictsort(by='value') %}
 void expand_eventspace{{ varname }}(int num_queues) {
     int num_eventspaces = static_cast<int>(dev{{ varname }}.size());
     if (num_queues <= num_eventspaces) return;
@@ -273,7 +258,6 @@ void expand_eventspace{{ varname }}(int num_queues) {
             cudaMemcpyHostToDevice));
         dev{{ varname }}.push_back(new_eventspace);
     }
-    sync_eventspace_{{ varname }}();
 }
 {% endfor %}
 {% for varname in subgroups_with_spikemonitor %}
@@ -544,7 +528,6 @@ void _init_arrays()
     double tot_memory_MB = (used_device_memory - used_device_memory_start) * to_MB;
     double time_passed = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start_timer).count();
     {% for var, varname in eventspace_arrays | dictsort(by='value') %}
-    sync_eventspace_{{ varname }}();
     {% endfor %}
     std::cout << "INFO: _init_arrays() took " <<  time_passed << "s";
     if (tot_memory_MB > 0)
@@ -852,6 +835,7 @@ extern const int _num_{{varname}};
 //////////////// eventspaces ///////////////
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 extern {{c_data_type(var.dtype)}} * {{varname}};
+extern std::vector<{{c_data_type(var.dtype)}}*> dev{{varname}};
 extern const int _num_{{varname}};
 extern int current_idx{{varname}};
 {% if varname in spikegenerator_eventspaces %}
@@ -874,12 +858,6 @@ extern const int _num_{{name}};
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
 extern std::vector<{{c_data_type(var.dtype)}}> {{varname}};
 extern DeviceBuffer dev{{varname}};
-{% endfor %}
-
-//////////////// eventspaces (synced views) ///////////////
-{% for var, varname in eventspace_arrays | dictsort(by='value') %}
-extern {{c_data_type(var.dtype)}}** dev{{ varname }}_view;
-extern int _num_dev{{ varname }};
 {% endfor %}
 
 //////////////// dynamic arrays 2d ///////////////

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -326,7 +326,6 @@ std::chrono::nanoseconds brian::{{codeobj}}_kernel_currents_profiling_info(0);
 {% endfor %}
 {% endif %}
 
-
 void _init_arrays()
 {
     using namespace brian;
@@ -853,7 +852,6 @@ extern std::chrono::nanoseconds {{codeobj}}_kernel_currents_profiling_info;
 #}
 {% endfor %}
 {% endif %}
-
 
 //CUDA
 extern int num_parallel_blocks;

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -15,9 +15,7 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 {%- endmacro %}
 
 #define BRIAN2CUDA_CURAND_HOST
-#include "objects_storage.h"
 #include "objects.h"
-#include "objects_api.h"
 #include "network.h"
 {% if synapses %}
 #include "synapses_classes.h"
@@ -32,6 +30,7 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 #include <vector>
 #include <thrust/copy.h>
 #include <thrust/count.h>
+#include <thrust/device_vector.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/unique.h>
@@ -198,7 +197,6 @@ const int brian::_num_{{varname}} = {{var.size}};
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 {{c_data_type(var.dtype)}} * brian::{{varname}};
 const int brian::_num_{{varname}} = {{var.size}};
-std::vector<{{c_data_type(var.dtype)}}*> brian::dev{{varname}}(1);
 int brian::current_idx{{varname}} = 0;
 {% if varname in spikegenerator_eventspaces %}
 int brian::previous_idx{{varname}};
@@ -209,19 +207,8 @@ int brian::previous_idx{{varname}};
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
 {% set N = array_basename(varname) %}
 std::vector<{{c_data_type(var.dtype)}}> brian::{{varname}};
-thrust::device_vector<{{c_data_type(var.dtype)}}> brian::dev{{varname}};
 {{c_data_type(var.dtype)}}* brian::dev_array_{{ N }} = nullptr;
 int brian::_num_dev_array_{{ N }} = 0;
-{% endfor %}
-{# Dynamic vectors for subgroup eventspaces for spikemonitors on subgroups #}
-{% for varname in subgroups_with_spikemonitor %}
-thrust::device_vector<int32_t> brian::_dev_{{varname}}_eventspace;
-{% endfor %}
-
-//////////////// dynamic arrays 2d /////////
-{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
-thrust::device_vector<{{c_data_type(var.dtype)}}*> brian::addresses_monitor_{{varname}};
-thrust::device_vector<{{c_data_type(var.dtype)}}>* brian::{{varname}};
 {% endfor %}
 
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
@@ -238,6 +225,21 @@ int brian::_num_subgroup_eventspace_{{varname}} = 0;
 {% endfor %}
 
 namespace brian {
+
+//////////////// device storage ///////////
+{% for var, varname in eventspace_arrays | dictsort(by='value') %}
+std::vector<{{c_data_type(var.dtype)}}*> dev{{varname}}(1);
+{% endfor %}
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+thrust::device_vector<{{c_data_type(var.dtype)}}> dev{{varname}};
+{% endfor %}
+{% for varname in subgroups_with_spikemonitor %}
+thrust::device_vector<int32_t> _dev_{{varname}}_eventspace;
+{% endfor %}
+{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+thrust::device_vector<{{c_data_type(var.dtype)}}*> addresses_monitor_{{varname}};
+thrust::device_vector<{{c_data_type(var.dtype)}}>* {{varname}};
+{% endfor %}
 
 namespace {
 
@@ -1138,60 +1140,7 @@ extern int max_threads_per_sm;
 extern int max_shared_mem_size;
 extern int num_threads_per_warp;
 
-}
-
-void _init_arrays();
-void _load_arrays();
-void _write_arrays();
-void _dealloc_arrays();
-
-#endif
-
-
-{% endmacro %}
-
-{% macro h_storage_file() %}
-#include "objects.h"
-#include <vector>
-#include <thrust/device_vector.h>
-
-#ifndef _BRIAN_OBJECTS_STORAGE_H
-#define _BRIAN_OBJECTS_STORAGE_H
-
-namespace brian {
-
-//////////////// dynamic arrays 1d ///////////
-{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-extern thrust::device_vector<{{c_data_type(var.dtype)}}> dev{{varname}};
-{% endfor %}
-{% for varname in subgroups_with_spikemonitor %}
-extern thrust::device_vector<int32_t> _dev_{{varname}}_eventspace;
-{% endfor %}
-
-//////////////// eventspaces ///////////////
-{% for var, varname in eventspace_arrays | dictsort(by='value') %}
-extern std::vector<{{c_data_type(var.dtype)}}*> dev{{varname}};
-{% endfor %}
-
-//////////////// dynamic arrays 2d /////////
-{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
-extern thrust::device_vector<{{c_data_type(var.dtype)}}*> addresses_monitor_{{varname}};
-extern thrust::device_vector<{{c_data_type(var.dtype)}}>* {{varname}};
-{% endfor %}
-
-}
-#endif // _BRIAN_OBJECTS_STORAGE_H
-{% endmacro %}
-
-{% macro h_api_file() %}
-#ifndef _BRIAN_OBJECTS_API_H
-#define _BRIAN_OBJECTS_API_H
-
-#include <cstddef>
-#include <cstdint>
-
-namespace brian {
-
+//////////////// host helpers /////////////////
 void sync_all_dev_ptrs();
 
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
@@ -1221,5 +1170,12 @@ void set_monitor_address_{{ varname }}(int row);
 
 }
 
+void _init_arrays();
+void _load_arrays();
+void _write_arrays();
+void _dealloc_arrays();
+
 #endif
+
+
 {% endmacro %}

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -216,14 +216,14 @@ namespace brian {
 std::vector<{{c_data_type(var.dtype)}}*> dev{{varname}}(1);
 {% endfor %}
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-DeviceBuffer<{{c_data_type(var.dtype)}}> dev{{varname}};
+DeviceBuffer dev{{varname}}(sizeof({{c_data_type(var.dtype)}}));
 {% endfor %}
 {% for varname in subgroups_with_spikemonitor %}
-DeviceBuffer<int32_t> _dev_{{varname}}_eventspace;
+DeviceBuffer _dev_{{varname}}_eventspace(sizeof(int32_t));
 {% endfor %}
 {% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
-DeviceBuffer<{{c_data_type(var.dtype)}}*> addresses_monitor_{{varname}};
-DeviceBuffer<{{c_data_type(var.dtype)}}>* {{varname}} = nullptr;
+DeviceBuffer addresses_monitor_{{varname}}(sizeof({{c_data_type(var.dtype)}}*));
+DeviceBuffer* {{varname}} = nullptr;
 {% endfor %}
 
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
@@ -289,10 +289,14 @@ void resize_monitor_row_{{ varname }}(int row, size_t n) {
     {{ varname }}[row].resize(n);
 }
 void push_monitor_address_{{ varname }}(int row) {
-    addresses_monitor_{{ varname }}.append({{ varname }}[row].data());
+    {{c_data_type(var.dtype)}}* row_ptr =
+        {{ varname }}[row].data_as<{{c_data_type(var.dtype)}}>();
+    addresses_monitor_{{ varname }}.append(&row_ptr);
 }
 void set_monitor_address_{{ varname }}(int row) {
-    addresses_monitor_{{ varname }}.store(static_cast<size_t>(row), {{ varname }}[row].data());
+    {{c_data_type(var.dtype)}}* row_ptr =
+        {{ varname }}[row].data_as<{{c_data_type(var.dtype)}}>();
+    addresses_monitor_{{ varname }}.store(static_cast<size_t>(row), &row_ptr);
 }
 {% endfor %}
 }  // namespace brian
@@ -444,8 +448,8 @@ void _init_arrays()
     {% set src_name = dynamic_array_specs[path.synapse_sources] %}
     {% set tgt_name = dynamic_array_specs[path.synapse_targets] %}
     {{path.name}}_init<<<1,1>>>(
-            dev{{ src_name }}.data(),
-            dev{{ tgt_name }}.data(),
+            dev{{ src_name }}.data_as<{{c_data_type(path.synapse_sources.dtype)}}>(),
+            dev{{ tgt_name }}.data_as<{{c_data_type(path.synapse_targets.dtype)}}>(),
             0,  //was dt, maybe irrelevant?
             {{path.source.start}},
             {{path.source.stop}}
@@ -507,7 +511,9 @@ void _init_arrays()
     {% endfor %}
 
     {% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
-    {{varname}} = new DeviceBuffer<{{c_data_type(var.dtype)}}>[_num__array_{{var.owner.name}}__indices];
+    {{varname}} = new DeviceBuffer[_num__array_{{var.owner.name}}__indices];
+    for (int i = 0; i < _num__array_{{var.owner.name}}__indices; i++)
+        {{varname}}[i].init(sizeof({{c_data_type(var.dtype)}}));
     {% endfor %}
 
     // eventspace_arrays
@@ -867,7 +873,7 @@ extern const int _num_{{name}};
 //////////////// dynamic arrays 1d ///////////
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
 extern std::vector<{{c_data_type(var.dtype)}}> {{varname}};
-extern DeviceBuffer<{{c_data_type(var.dtype)}}> dev{{varname}};
+extern DeviceBuffer dev{{varname}};
 {% endfor %}
 
 //////////////// eventspaces (synced views) ///////////////
@@ -878,12 +884,12 @@ extern int _num_dev{{ varname }};
 
 //////////////// dynamic arrays 2d ///////////////
 {% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
-extern DeviceBuffer<{{c_data_type(var.dtype)}}*> addresses_monitor_{{ varname }};
+extern DeviceBuffer addresses_monitor_{{ varname }};
 {% endfor %}
 
 //////////////// subgroup eventspace buffers ///////////////
 {% for varname in subgroups_with_spikemonitor %}
-extern DeviceBuffer<int32_t> _dev_{{varname}}_eventspace;
+extern DeviceBuffer _dev_{{varname}}_eventspace;
 {% endfor %}
 
 //////////////// synapses /////////////////

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -255,24 +255,13 @@ void expand_eventspace{{ varname }}(int num_queues) {
 }
 {% endfor %}
 
-{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
-void clear_monitor_addresses_{{ varname }}() {
-    addresses_monitor_{{ varname }}.clear();
+void upload_monitor_row_addresses(DeviceBuffer& addresses, DeviceBuffer* rows, int n_rows)
+{
+    std::vector<void*> host_ptrs(n_rows);
+    for (int i = 0; i < n_rows; i++)
+        host_ptrs[i] = rows[i].data();
+    addresses.copy_from_host(host_ptrs.data(), host_ptrs.size());
 }
-void resize_monitor_row_{{ varname }}(int row, size_t n) {
-    {{ varname }}[row].resize(n);
-}
-void push_monitor_address_{{ varname }}(int row) {
-    {{c_data_type(var.dtype)}}* row_ptr =
-        {{ varname }}[row].data_as<{{c_data_type(var.dtype)}}>();
-    addresses_monitor_{{ varname }}.append(&row_ptr);
-}
-void set_monitor_address_{{ varname }}(int row) {
-    {{c_data_type(var.dtype)}}* row_ptr =
-        {{ varname }}[row].data_as<{{c_data_type(var.dtype)}}>();
-    addresses_monitor_{{ varname }}.store(static_cast<size_t>(row), &row_ptr);
-}
-{% endfor %}
 }  // namespace brian
 
 /////////////// static arrays /////////////
@@ -486,7 +475,7 @@ void _init_arrays()
     {% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
     {{varname}} = new DeviceBuffer[_num__array_{{var.owner.name}}__indices];
     for (int i = 0; i < _num__array_{{var.owner.name}}__indices; i++)
-        {{varname}}[i].init(sizeof({{c_data_type(var.dtype)}}));
+        {{varname}}[i].set_elem_size(sizeof({{c_data_type(var.dtype)}}));
     {% endfor %}
 
     // eventspace_arrays
@@ -850,6 +839,7 @@ extern DeviceBuffer dev{{varname}};
 
 //////////////// dynamic arrays 2d ///////////////
 {% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
+extern DeviceBuffer* {{ varname }};
 extern DeviceBuffer addresses_monitor_{{ varname }};
 {% endfor %}
 
@@ -948,12 +938,8 @@ void expand_eventspace{{ varname }}(int num_queues);
 {% endfor %}
 int filter_subgroup_eventspace(int32_t* src, int n, int32_t* dst, int32_t start, int32_t stop);
 
-{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
-void clear_monitor_addresses_{{ varname }}();
-void resize_monitor_row_{{ varname }}(int row, size_t n);
-void push_monitor_address_{{ varname }}(int row);
-void set_monitor_address_{{ varname }}(int row);
-{% endfor %}
+void upload_monitor_row_addresses(DeviceBuffer& addresses, DeviceBuffer* rows, int n_rows);
+
 
 }
 

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -28,8 +28,6 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 #include <ctime>
 #include <algorithm>
 #include <vector>
-#include <thrust/copy.h>
-#include <thrust/count.h>
 #include <thrust/device_vector.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
@@ -399,40 +397,6 @@ void resize_subgroup_eventspace_{{varname}}(size_t n) {
     sync_subgroup_eventspace_{{varname}}();
 }
 {% endfor %}
-// Namespace-scope: nvcc/CUB reject local classes as thrust predicates.
-struct is_in_subgroup
-{
-    int32_t start;
-    int32_t stop;
-
-    __host__ __device__
-    bool operator()(const int32_t& neuron) const
-    {
-        return start <= neuron && neuron < stop;
-    }
-};
-
-int filter_subgroup_eventspace(
-        int32_t* src, int n, int32_t* dst, int32_t start, int32_t stop) {
-    if (n <= 0) return 0;
-
-    thrust::device_ptr<int32_t> src_ptr(src);
-    thrust::device_ptr<int32_t> dst_ptr(dst);
-    is_in_subgroup pred{start, stop};
-
-    // Count the elements in eventspace that are in the subgroup
-    int out_n = 0;
-    THRUST_CHECK_ERROR(
-        out_n = static_cast<int>(
-            thrust::count_if(src_ptr, src_ptr + n, pred)
-        )
-    );
-    // Copy all neuron IDs that are in this subgroup to the new device pointer
-    THRUST_CHECK_ERROR(
-        thrust::copy_if(src_ptr, src_ptr + n, dst_ptr, pred)
-    );
-    return out_n;
-}
 {% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
 void clear_monitor_addresses_{{ varname }}() {
     addresses_monitor_{{ varname }}.clear();

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -14,7 +14,6 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 {% endif %}
 {%- endmacro %}
 
-#define BRIAN2CUDA_CURAND_HOST
 #include "objects.h"
 #include "network.h"
 {% if synapses %}
@@ -29,7 +28,6 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 #include <algorithm>
 #include <cctype>
 #include <vector>
-#include <curand.h>
 
 size_t brian::used_device_memory = 0;
 std::string brian::results_dir = "results/";  // can be overwritten by --results_dir command line arg
@@ -254,7 +252,6 @@ void expand_eventspace{{ varname }}(int num_queues) {
     }
 }
 {% endfor %}
-
 void upload_monitor_row_addresses(DeviceBuffer& addresses, DeviceBuffer* rows, int n_rows)
 {
     std::vector<void*> host_ptrs(n_rows);
@@ -329,32 +326,6 @@ std::chrono::nanoseconds brian::{{codeobj}}_kernel_currents_profiling_info(0);
 {% endfor %}
 {% endif %}
 
-
-//////////////random numbers//////////////////
-curandGenerator_t brian::curand_generator;
-__device__ unsigned long long* brian::d_curand_seed;
-unsigned long long* brian::dev_curand_seed;
-// dev_{co.name}_{rng_type}_allocator
-//      pointer to start of generated random numbers array
-//      at each generation cycle this array is refilled
-// dev_{co.name}_{rng_type}
-//      pointer moving through generated random number array
-//      until it is regenerated at the next generation cycle
-{% for rng_type in all_codeobj_with_host_rng.keys() %}
-{% for co in all_codeobj_with_host_rng[rng_type] | sort(attribute='name') %}
-{% if rng_type in ['rand', 'randn'] %}
-{% set dtype = 'randomNumber_t' %}
-{% else %}  {# rng_type = 'poisson_<idx>' #}
-{% set dtype = 'unsigned int' %}
-{% endif %}
-{{dtype}}* brian::dev_{{co.name}}_{{rng_type}}_allocator;
-{{dtype}}* brian::dev_{{co.name}}_{{rng_type}};
-__device__ {{dtype}}* brian::_array_{{co.name}}_{{rng_type}};
-{% endfor %}{# rng_type #}
-{% endfor %}{# co #}
-curandState* brian::dev_curand_states;
-__device__ curandState* brian::d_curand_states;
-RandomNumberBuffer brian::random_number_buffer;
 
 void _init_arrays()
 {
@@ -505,8 +476,6 @@ void _init_arrays()
     const double to_MB = 1.0 / (1024.0 * 1024.0);
     double tot_memory_MB = (used_device_memory - used_device_memory_start) * to_MB;
     double time_passed = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start_timer).count();
-    {% for var, varname in eventspace_arrays | dictsort(by='value') %}
-    {% endfor %}
     std::cout << "INFO: _init_arrays() took " <<  time_passed << "s";
     if (tot_memory_MB > 0)
         std::cout << " and used " << tot_memory_MB << "MB of device memory.";
@@ -752,13 +721,6 @@ void _dealloc_arrays()
 // be visible to all files including objects.h
 typedef {{curand_float_type}} randomNumber_t;  // random number type
 
-struct curandGenerator_st;
-typedef struct curandGenerator_st* curandGenerator_t;
-#ifndef CURAND_KERNEL_H_
-struct curandStateXORWOW;
-typedef struct curandStateXORWOW curandState;
-#endif
-
 #ifndef _BRIAN_OBJECTS_H
 #define _BRIAN_OBJECTS_H
 
@@ -767,7 +729,6 @@ typedef struct curandStateXORWOW curandState;
 #include <stdint.h>
 #include "brianlib/clocks.h"
 #include "brianlib/device_buffer.h"
-#include "rand.h"
 {% if profiled_codeobjects is defined %}
 #include <chrono>
 {% endif %}
@@ -894,31 +855,6 @@ extern std::chrono::nanoseconds {{codeobj}}_kernel_currents_profiling_info;
 {% endif %}
 
 
-//////////////// random numbers /////////////////
-extern curandGenerator_t curand_generator;
-extern unsigned long long* dev_curand_seed;
-extern __device__ unsigned long long* d_curand_seed;
-
-{% for rng_type in all_codeobj_with_host_rng.keys() %}
-{% for co in all_codeobj_with_host_rng[rng_type] | sort(attribute='name') %}
-{% if rng_type in ['rand', 'randn'] %}
-{% set dtype = 'randomNumber_t' %}
-{% else %}  {# rng_type = 'poisson_<idx>' #}
-{% set dtype = 'unsigned int' %}
-{% endif %}
-// pointer to start of generated random numbers array
-// at each generation cycle this array is refilled
-extern {{dtype}}* dev_{{co.name}}_{{rng_type}}_allocator;
-// pointer moving through generated random number array
-// until it is regenerated at the next generation cycle
-extern {{dtype}}* dev_{{co.name}}_{{rng_type}};
-extern __device__ {{dtype}}* _array_{{co.name}}_{{rng_type}};
-{% endfor %}{# rng_type #}
-{% endfor %}{# co #}
-extern curandState* dev_curand_states;
-extern __device__ curandState* d_curand_states;
-extern RandomNumberBuffer random_number_buffer;
-
 //CUDA
 extern int num_parallel_blocks;
 extern int max_threads_per_block;
@@ -937,9 +873,7 @@ void copy_dev_to_host_array_{{ N }}();
 void expand_eventspace{{ varname }}(int num_queues);
 {% endfor %}
 int filter_subgroup_eventspace(int32_t* src, int n, int32_t* dst, int32_t start, int32_t stop);
-
 void upload_monitor_row_addresses(DeviceBuffer& addresses, DeviceBuffer* rows, int n_rows);
-
 
 }
 

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -21,14 +21,15 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 #include "synapses_classes.h"
 {% endif %}
 #include "brianlib/cuda_utils.h"
+#include "brianlib/device_buffer.h"
 #include "rand.h"
 #include <iostream>
 #include <fstream>
 #include <chrono>
 #include <ctime>
 #include <algorithm>
+#include <cctype>
 #include <vector>
-#include <thrust/device_vector.h>
 #include <curand.h>
 
 size_t brian::used_device_memory = 0;
@@ -200,23 +201,12 @@ int brian::previous_idx{{varname}};
 
 //////////////// dynamic arrays 1d /////////
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-{% set N = array_basename(varname) %}
 std::vector<{{c_data_type(var.dtype)}}> brian::{{varname}};
-{{c_data_type(var.dtype)}}* brian::dev_array_{{ N }} = nullptr;
-int brian::_num_dev_array_{{ N }} = 0;
 {% endfor %}
 
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 {{c_data_type(var.dtype)}}** brian::dev{{ varname }}_view = nullptr;
 int brian::_num_dev{{ varname }} = 0;
-{% endfor %}
-{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
-{{c_data_type(var.dtype)}}** brian::monitor_addresses_{{ varname }} = nullptr;
-int brian::_num_monitor_addresses_{{ varname }} = 0;
-{% endfor %}
-{% for varname in subgroups_with_spikemonitor %}
-int32_t* brian::dev_array_subgroup_eventspace_{{varname}} = nullptr;
-int brian::_num_subgroup_eventspace_{{varname}} = 0;
 {% endfor %}
 
 namespace brian {
@@ -226,101 +216,33 @@ namespace brian {
 std::vector<{{c_data_type(var.dtype)}}*> dev{{varname}}(1);
 {% endfor %}
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-thrust::device_vector<{{c_data_type(var.dtype)}}> dev{{varname}};
+DeviceBuffer<{{c_data_type(var.dtype)}}> dev{{varname}};
 {% endfor %}
 {% for varname in subgroups_with_spikemonitor %}
-thrust::device_vector<int32_t> _dev_{{varname}}_eventspace;
+DeviceBuffer<int32_t> _dev_{{varname}}_eventspace;
 {% endfor %}
 {% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
-thrust::device_vector<{{c_data_type(var.dtype)}}*> addresses_monitor_{{varname}};
-thrust::device_vector<{{c_data_type(var.dtype)}}>* {{varname}};
+DeviceBuffer<{{c_data_type(var.dtype)}}*> addresses_monitor_{{varname}};
+DeviceBuffer<{{c_data_type(var.dtype)}}>* {{varname}} = nullptr;
 {% endfor %}
-
-namespace {
-
-template <typename T>
-void refresh_device_ptrs(
-        thrust::device_vector<T>& device,
-        T*& device_ptr, int& device_n)
-{
-    device_n = static_cast<int>(device.size());
-    device_ptr = device_n
-        ? thrust::raw_pointer_cast(&device[0]) : nullptr;
-}
-
-template <typename T>
-void resize_dev(
-        thrust::device_vector<T>& device,
-        T*& device_ptr, int& device_n,
-        size_t n)
-{
-    THRUST_CHECK_ERROR(device.resize(n));
-    refresh_device_ptrs(device, device_ptr, device_n);
-}
-
-template <typename T>
-void copy_host_to_dev(
-        std::vector<T>& host,
-        thrust::device_vector<T>& device,
-        T*& device_ptr, int& device_n)
-{
-    THRUST_CHECK_ERROR(device.resize(host.size()));
-    if (!host.empty())
-    {
-        CUDA_SAFE_CALL(cudaMemcpy(
-            thrust::raw_pointer_cast(&device[0]),
-            host.data(),
-            sizeof(T) * host.size(),
-            cudaMemcpyHostToDevice));
-    }
-    refresh_device_ptrs(device, device_ptr, device_n);
-}
-
-template <typename T>
-void copy_dev_to_host(
-        std::vector<T>& host,
-        thrust::device_vector<T>& device,
-        T*& device_ptr, int& device_n)
-{
-    host.resize(device.size());
-    if (!device.empty())
-    {
-        CUDA_SAFE_CALL(cudaMemcpy(
-            host.data(),
-            thrust::raw_pointer_cast(&device[0]),
-            sizeof(T) * device.size(),
-            cudaMemcpyDeviceToHost));
-    }
-    refresh_device_ptrs(device, device_ptr, device_n);
-}
-
-template <typename T>
-void clear_dev(
-        thrust::device_vector<T>& device,
-        T*& device_ptr, int& device_n)
-{
-    device.clear();
-    device.shrink_to_fit();
-    refresh_device_ptrs(device, device_ptr, device_n);
-}
-
-}  // namespace
 
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
 {% set N = array_basename(varname) %}
 void resize_dev_array_{{ N }}(size_t n) {
-    resize_dev(dev{{ varname }}, dev_array_{{ N }}, _num_dev_array_{{ N }}, n);
+    dev{{ varname }}.resize(n);
 }
 void copy_host_to_dev_array_{{ N }}() {
-    copy_host_to_dev({{ varname }}, dev{{ varname }},
-               dev_array_{{ N }}, _num_dev_array_{{ N }});
+    dev{{ varname }}.copy_from_host(
+        {{ varname }}.empty() ? nullptr : {{ varname }}.data(),
+        {{ varname }}.size());
 }
 void copy_dev_to_host_array_{{ N }}() {
-    copy_dev_to_host({{ varname }}, dev{{ varname }},
-                 dev_array_{{ N }}, _num_dev_array_{{ N }});
+    {{ varname }}.resize(dev{{ varname }}.size());
+    dev{{ varname }}.copy_to_host(
+        {{ varname }}.empty() ? nullptr : {{ varname }}.data());
 }
 void clear_dev_array_{{ N }}() {
-    clear_dev(dev{{ varname }}, dev_array_{{ N }}, _num_dev_array_{{ N }});
+    dev{{ varname }}.clear();
 }
 {% endfor %}
 
@@ -330,40 +252,6 @@ void sync_eventspace_{{ varname }}() {
     dev{{ varname }}_view = dev{{ varname }}.empty() ? nullptr : &dev{{ varname }}[0];
 }
 {% endfor %}
-{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
-void sync_monitor_addresses_{{ varname }}() {
-    refresh_device_ptrs(
-        addresses_monitor_{{ varname }},
-        monitor_addresses_{{ varname }},
-        _num_monitor_addresses_{{ varname }});
-}
-{% endfor %}
-{% for varname in subgroups_with_spikemonitor %}
-void sync_subgroup_eventspace_{{varname}}() {
-    refresh_device_ptrs(
-        _dev_{{varname}}_eventspace,
-        dev_array_subgroup_eventspace_{{varname}},
-        _num_subgroup_eventspace_{{varname}});
-}
-{% endfor %}
-
-void sync_all_dev_ptrs() {
-{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-{% set N = array_basename(varname) %}
-    refresh_device_ptrs(
-        dev{{ varname }},
-        dev_array_{{ N }}, _num_dev_array_{{ N }});
-{% endfor %}
-{% for var, varname in eventspace_arrays | dictsort(by='value') %}
-    sync_eventspace_{{ varname }}();
-{% endfor %}
-{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
-    sync_monitor_addresses_{{ varname }}();
-{% endfor %}
-{% for varname in subgroups_with_spikemonitor %}
-    sync_subgroup_eventspace_{{varname}}();
-{% endfor %}
-}
 
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 void expand_eventspace{{ varname }}(int num_queues) {
@@ -390,28 +278,21 @@ void expand_eventspace{{ varname }}(int num_queues) {
 {% endfor %}
 {% for varname in subgroups_with_spikemonitor %}
 void resize_subgroup_eventspace_{{varname}}(size_t n) {
-    THRUST_CHECK_ERROR(_dev_{{varname}}_eventspace.resize(n));
-    sync_subgroup_eventspace_{{varname}}();
+    _dev_{{varname}}_eventspace.resize(n);
 }
 {% endfor %}
 {% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
 void clear_monitor_addresses_{{ varname }}() {
     addresses_monitor_{{ varname }}.clear();
-    sync_monitor_addresses_{{ varname }}();
 }
 void resize_monitor_row_{{ varname }}(int row, size_t n) {
     {{ varname }}[row].resize(n);
-    sync_monitor_addresses_{{ varname }}();
 }
 void push_monitor_address_{{ varname }}(int row) {
-    addresses_monitor_{{ varname }}.push_back(
-        thrust::raw_pointer_cast(&{{ varname }}[row][0]));
-    sync_monitor_addresses_{{ varname }}();
+    addresses_monitor_{{ varname }}.append({{ varname }}[row].data());
 }
 void set_monitor_address_{{ varname }}(int row) {
-    addresses_monitor_{{ varname }}[row] =
-        thrust::raw_pointer_cast(&{{ varname }}[row][0]);
-    sync_monitor_addresses_{{ varname }}();
+    addresses_monitor_{{ varname }}.store(static_cast<size_t>(row), {{ varname }}[row].data());
 }
 {% endfor %}
 }  // namespace brian
@@ -563,8 +444,8 @@ void _init_arrays()
     {% set src_name = dynamic_array_specs[path.synapse_sources] %}
     {% set tgt_name = dynamic_array_specs[path.synapse_targets] %}
     {{path.name}}_init<<<1,1>>>(
-            dev_array_{{ array_basename(src_name) }},
-            dev_array_{{ array_basename(tgt_name) }},
+            dev{{ src_name }}.data(),
+            dev{{ tgt_name }}.data(),
             0,  //was dt, maybe irrelevant?
             {{path.source.start}},
             {{path.source.stop}}
@@ -626,7 +507,7 @@ void _init_arrays()
     {% endfor %}
 
     {% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
-    {{varname}} = new thrust::device_vector<{{c_data_type(var.dtype)}}>[_num__array_{{var.owner.name}}__indices];
+    {{varname}} = new DeviceBuffer<{{c_data_type(var.dtype)}}>[_num__array_{{var.owner.name}}__indices];
     {% endfor %}
 
     // eventspace_arrays
@@ -656,7 +537,9 @@ void _init_arrays()
     const double to_MB = 1.0 / (1024.0 * 1024.0);
     double tot_memory_MB = (used_device_memory - used_device_memory_start) * to_MB;
     double time_passed = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start_timer).count();
-    sync_all_dev_ptrs();
+    {% for var, varname in eventspace_arrays | dictsort(by='value') %}
+    sync_eventspace_{{ varname }}();
+    {% endfor %}
     std::cout << "INFO: _init_arrays() took " <<  time_passed << "s";
     if (tot_memory_MB > 0)
         std::cout << " and used " << tot_memory_MB << "MB of device memory.";
@@ -757,11 +640,7 @@ void _write_arrays()
                 temp_array{{varname}}[n].resize({{varname}}[n].size());
                 if (!{{varname}}[n].empty())
                 {
-                    CUDA_SAFE_CALL(cudaMemcpy(
-                        temp_array{{varname}}[n].data(),
-                        thrust::raw_pointer_cast(&{{varname}}[n][0]),
-                        sizeof({{c_data_type(var.dtype)}}) * {{varname}}[n].size(),
-                        cudaMemcpyDeviceToHost));
+                    {{varname}}[n].copy_to_host(temp_array{{varname}}[n].data());
                 }
             }
             {% if var in profile_statemonitor_vars %}
@@ -870,13 +749,14 @@ void _dealloc_arrays()
     {% endfor %}
 
     {% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
-    for(int i = 0; i < _num__array_{{var.owner.name}}__indices; i++)
+    if ({{varname}} != nullptr)
     {
-        {{varname}}[i].clear();
-        thrust::device_vector<{{c_data_type(var.dtype)}}>().swap({{varname}}[i]);
+        for(int i = 0; i < _num__array_{{var.owner.name}}__indices; i++)
+            {{varname}}[i].clear();
+        delete [] {{varname}};
+        {{varname}} = nullptr;
     }
     addresses_monitor_{{varname}}.clear();
-    thrust::device_vector<{{c_data_type(var.dtype)}}*>().swap(addresses_monitor_{{varname}});
     {% endfor %}
 
     // static arrays
@@ -891,7 +771,7 @@ void _dealloc_arrays()
     {% endfor %}
 
     {% for varname in subgroups_with_spikemonitor %}
-    thrust::device_vector<int32_t>().swap(_dev_{{varname}}_eventspace);
+    _dev_{{varname}}_eventspace.clear();
     {% endfor %}
 
 }
@@ -920,6 +800,7 @@ typedef struct curandStateXORWOW curandState;
 #include <string>
 #include <stdint.h>
 #include "brianlib/clocks.h"
+#include "brianlib/device_buffer.h"
 #include "rand.h"
 {% if profiled_codeobjects is defined %}
 #include <chrono>
@@ -985,10 +866,8 @@ extern const int _num_{{name}};
 
 //////////////// dynamic arrays 1d ///////////
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-{% set N = array_basename(varname) %}
 extern std::vector<{{c_data_type(var.dtype)}}> {{varname}};
-extern {{c_data_type(var.dtype)}}* dev_array_{{ N }};
-extern int _num_dev_array_{{ N }};
+extern DeviceBuffer<{{c_data_type(var.dtype)}}> dev{{varname}};
 {% endfor %}
 
 //////////////// eventspaces (synced views) ///////////////
@@ -997,16 +876,14 @@ extern {{c_data_type(var.dtype)}}** dev{{ varname }}_view;
 extern int _num_dev{{ varname }};
 {% endfor %}
 
-//////////////// dynamic arrays 2d (synced views) ///////////////
+//////////////// dynamic arrays 2d ///////////////
 {% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
-extern {{c_data_type(var.dtype)}}** monitor_addresses_{{ varname }};
-extern int _num_monitor_addresses_{{ varname }};
+extern DeviceBuffer<{{c_data_type(var.dtype)}}*> addresses_monitor_{{ varname }};
 {% endfor %}
 
 //////////////// subgroup eventspace buffers ///////////////
 {% for varname in subgroups_with_spikemonitor %}
-extern int32_t* dev_array_subgroup_eventspace_{{varname}};
-extern int _num_subgroup_eventspace_{{varname}};
+extern DeviceBuffer<int32_t> _dev_{{varname}}_eventspace;
 {% endfor %}
 
 //////////////// synapses /////////////////
@@ -1088,8 +965,6 @@ extern int max_shared_mem_size;
 extern int num_threads_per_warp;
 
 //////////////// host helpers /////////////////
-void sync_all_dev_ptrs();
-
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
 {% set N = array_basename(varname) %}
 void resize_dev_array_{{ N }}(size_t n);

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -133,26 +133,19 @@ void brian::set_variable_by_name(std::string name, std::string s_value) {
     // dynamic arrays (1d)
     {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
     {% if not var.read_only %}
+    {% set N = array_basename(varname) %}
     if (name == "{{var.owner.name}}.{{var.name}}") {
         var_size = brian::{{get_array_name(var, access_data=False)}}.size();
         data_size = var_size*sizeof({{c_data_type(var.dtype)}});
         if (s_value[0] == '-' || (s_value[0] >= '0' && s_value[0] <= '9')) {
             // set from single value
-            {{ set_from_value(var.dtype, "&brian::" + get_array_name(var, False) + "[0]") }}
+            {{ set_from_value(var.dtype, "brian::" + get_array_name(var, False) + ".data()") }}
         } else {
             // set from file
-            set_variable_from_file(name, &brian::{{get_array_name(var, False)}}[0], data_size, s_value);
+            set_variable_from_file(name, brian::{{get_array_name(var, False)}}.data(), data_size, s_value);
         }
         {% if get_array_name(var) not in variables_on_host_only %}
-        // copy to device
-        CUDA_SAFE_CALL(
-            cudaMemcpy(
-                thrust::raw_pointer_cast(&brian::dev{{get_array_name(var, False)}}[0]),
-                &brian::{{get_array_name(var, False)}}[0],
-                sizeof(brian::{{get_array_name(var, False)}}[0])*brian::{{get_array_name(var, False)}}.size(),
-                cudaMemcpyHostToDevice
-            )
-        );
+        copy_host_to_dev_array_{{ N }}();
         {% endif %}
         return;
     }
@@ -205,7 +198,7 @@ const int brian::_num_{{varname}} = {{var.size}};
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 {{c_data_type(var.dtype)}} * brian::{{varname}};
 const int brian::_num_{{varname}} = {{var.size}};
-thrust::host_vector<{{c_data_type(var.dtype)}}*> brian::dev{{varname}}(1);
+std::vector<{{c_data_type(var.dtype)}}*> brian::dev{{varname}}(1);
 int brian::current_idx{{varname}} = 0;
 {% if varname in spikegenerator_eventspaces %}
 int brian::previous_idx{{varname}};
@@ -214,8 +207,11 @@ int brian::previous_idx{{varname}};
 
 //////////////// dynamic arrays 1d /////////
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-thrust::host_vector<{{c_data_type(var.dtype)}}> brian::{{varname}};
+{% set N = array_basename(varname) %}
+std::vector<{{c_data_type(var.dtype)}}> brian::{{varname}};
 thrust::device_vector<{{c_data_type(var.dtype)}}> brian::dev{{varname}};
+{{c_data_type(var.dtype)}}* brian::dev_array_{{ N }} = nullptr;
+int brian::_num_dev_array_{{ N }} = 0;
 {% endfor %}
 {# Dynamic vectors for subgroup eventspaces for spikemonitors on subgroups #}
 {% for varname in subgroups_with_spikemonitor %}
@@ -228,13 +224,6 @@ thrust::device_vector<{{c_data_type(var.dtype)}}*> brian::addresses_monitor_{{va
 thrust::device_vector<{{c_data_type(var.dtype)}}>* brian::{{varname}};
 {% endfor %}
 
-{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-{% set N = array_basename(varname) %}
-{{c_data_type(var.dtype)}}* brian::host_array_{{ N }} = nullptr;
-int brian::_num_host_array_{{ N }} = 0;
-{{c_data_type(var.dtype)}}* brian::dev_array_{{ N }} = nullptr;
-int brian::_num_dev_array_{{ N }} = 0;
-{% endfor %}
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 {{c_data_type(var.dtype)}}** brian::dev{{ varname }}_view = nullptr;
 int brian::_num_dev{{ varname }} = 0;
@@ -250,103 +239,93 @@ int brian::_num_subgroup_eventspace_{{varname}} = 0;
 
 namespace brian {
 
-namespace dyn_array {
+namespace {
 
 template <typename T>
-void sync_host_dev(
-        thrust::host_vector<T>& host,
+void refresh_device_ptrs(
         thrust::device_vector<T>& device,
-        T*& host_ptr, int& host_n,
         T*& device_ptr, int& device_n)
 {
-    host_n = static_cast<int>(host.size());
-    host_ptr = host_n ? &host[0] : nullptr;
     device_n = static_cast<int>(device.size());
     device_ptr = device_n
         ? thrust::raw_pointer_cast(&device[0]) : nullptr;
-}
-
-template <typename T>
-void push_back_host(
-        thrust::host_vector<T>& host,
-        thrust::device_vector<T>& device,
-        T v,
-        T*& host_ptr, int& host_n,
-        T*& device_ptr, int& device_n)
-{
-    host.push_back(v);
-    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
-}
-
-template <typename T>
-void resize_host(
-        thrust::host_vector<T>& host,
-        thrust::device_vector<T>& device,
-        size_t n,
-        T*& host_ptr, int& host_n,
-        T*& device_ptr, int& device_n)
-{
-    host.resize(n);
-    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
 }
 
 template <typename T>
 void resize_dev(
-        thrust::host_vector<T>& host,
         thrust::device_vector<T>& device,
-        size_t n,
-        T*& host_ptr, int& host_n,
-        T*& device_ptr, int& device_n)
+        T*& device_ptr, int& device_n,
+        size_t n)
 {
     THRUST_CHECK_ERROR(device.resize(n));
-    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
-}
-
-template <typename T>
-void copy_dev_to_host(
-        thrust::host_vector<T>& host,
-        thrust::device_vector<T>& device,
-        T*& host_ptr, int& host_n,
-        T*& device_ptr, int& device_n)
-{
-    host = device;
-    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
+    refresh_device_ptrs(device, device_ptr, device_n);
 }
 
 template <typename T>
 void copy_host_to_dev(
-        thrust::host_vector<T>& host,
+        std::vector<T>& host,
         thrust::device_vector<T>& device,
-        T*& host_ptr, int& host_n,
         T*& device_ptr, int& device_n)
 {
-    device = host;
-    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
+    THRUST_CHECK_ERROR(device.resize(host.size()));
+    if (!host.empty())
+    {
+        CUDA_SAFE_CALL(cudaMemcpy(
+            thrust::raw_pointer_cast(&device[0]),
+            host.data(),
+            sizeof(T) * host.size(),
+            cudaMemcpyHostToDevice));
+    }
+    refresh_device_ptrs(device, device_ptr, device_n);
+}
+
+template <typename T>
+void copy_dev_to_host(
+        std::vector<T>& host,
+        thrust::device_vector<T>& device,
+        T*& device_ptr, int& device_n)
+{
+    host.resize(device.size());
+    if (!device.empty())
+    {
+        CUDA_SAFE_CALL(cudaMemcpy(
+            host.data(),
+            thrust::raw_pointer_cast(&device[0]),
+            sizeof(T) * device.size(),
+            cudaMemcpyDeviceToHost));
+    }
+    refresh_device_ptrs(device, device_ptr, device_n);
 }
 
 template <typename T>
 void clear_dev(
-        thrust::host_vector<T>& host,
         thrust::device_vector<T>& device,
-        T*& host_ptr, int& host_n,
         T*& device_ptr, int& device_n)
 {
     device.clear();
     device.shrink_to_fit();
-    sync_host_dev(host, device, host_ptr, host_n, device_ptr, device_n);
+    refresh_device_ptrs(device, device_ptr, device_n);
 }
 
-template <typename T>
-void sync_device_ptr(
-        thrust::device_vector<T>& device,
-        T*& device_ptr, int& device_n)
-{
-    device_n = static_cast<int>(device.size());
-    device_ptr = device_n
-        ? thrust::raw_pointer_cast(&device[0]) : nullptr;
-}
+}  // namespace
 
-}  // namespace dyn_array
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = array_basename(varname) %}
+void resize_dev_array_{{ N }}(size_t n) {
+    resize_dev(dev{{ varname }}, dev_array_{{ N }}, _num_dev_array_{{ N }}, n);
+}
+void copy_host_to_dev_array_{{ N }}() {
+    copy_host_to_dev({{ varname }}, dev{{ varname }},
+               dev_array_{{ N }}, _num_dev_array_{{ N }});
+}
+void copy_dev_to_host_array_{{ N }}() {
+    copy_dev_to_host({{ varname }}, dev{{ varname }},
+                 dev_array_{{ N }}, _num_dev_array_{{ N }});
+}
+void clear_dev_array_{{ N }}() {
+    clear_dev(dev{{ varname }}, dev_array_{{ N }}, _num_dev_array_{{ N }});
+}
+{% endfor %}
 
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 void sync_eventspace_{{ varname }}() {
@@ -356,7 +335,7 @@ void sync_eventspace_{{ varname }}() {
 {% endfor %}
 {% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
 void sync_monitor_addresses_{{ varname }}() {
-    dyn_array::sync_device_ptr(
+    refresh_device_ptrs(
         addresses_monitor_{{ varname }},
         monitor_addresses_{{ varname }},
         _num_monitor_addresses_{{ varname }});
@@ -364,7 +343,7 @@ void sync_monitor_addresses_{{ varname }}() {
 {% endfor %}
 {% for varname in subgroups_with_spikemonitor %}
 void sync_subgroup_eventspace_{{varname}}() {
-    dyn_array::sync_device_ptr(
+    refresh_device_ptrs(
         _dev_{{varname}}_eventspace,
         dev_array_subgroup_eventspace_{{varname}},
         _num_subgroup_eventspace_{{varname}});
@@ -374,9 +353,8 @@ void sync_subgroup_eventspace_{{varname}}() {
 void sync_all_dev_ptrs() {
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
 {% set N = array_basename(varname) %}
-    dyn_array::sync_host_dev(
-        {{ varname }}, dev{{ varname }},
-        host_array_{{ N }}, _num_host_array_{{ N }},
+    refresh_device_ptrs(
+        dev{{ varname }},
         dev_array_{{ N }}, _num_dev_array_{{ N }});
 {% endfor %}
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
@@ -390,45 +368,6 @@ void sync_all_dev_ptrs() {
 {% endfor %}
 }
 
-{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-{% set N = array_basename(varname) %}
-void push_back_host_array_{{ N }}({{c_data_type(var.dtype)}} v) {
-    dyn_array::push_back_host(
-        {{ varname }}, dev{{ varname }}, v,
-        host_array_{{ N }}, _num_host_array_{{ N }},
-        dev_array_{{ N }}, _num_dev_array_{{ N }});
-}
-void resize_host_array_{{ N }}(size_t n) {
-    dyn_array::resize_host(
-        {{ varname }}, dev{{ varname }}, n,
-        host_array_{{ N }}, _num_host_array_{{ N }},
-        dev_array_{{ N }}, _num_dev_array_{{ N }});
-}
-void resize_dev_array_{{ N }}(size_t n) {
-    dyn_array::resize_dev(
-        {{ varname }}, dev{{ varname }}, n,
-        host_array_{{ N }}, _num_host_array_{{ N }},
-        dev_array_{{ N }}, _num_dev_array_{{ N }});
-}
-void copy_dev_to_host_array_{{ N }}() {
-    dyn_array::copy_dev_to_host(
-        {{ varname }}, dev{{ varname }},
-        host_array_{{ N }}, _num_host_array_{{ N }},
-        dev_array_{{ N }}, _num_dev_array_{{ N }});
-}
-void copy_host_to_dev_array_{{ N }}() {
-    dyn_array::copy_host_to_dev(
-        {{ varname }}, dev{{ varname }},
-        host_array_{{ N }}, _num_host_array_{{ N }},
-        dev_array_{{ N }}, _num_dev_array_{{ N }});
-}
-void clear_dev_array_{{ N }}() {
-    dyn_array::clear_dev(
-        {{ varname }}, dev{{ varname }},
-        host_array_{{ N }}, _num_host_array_{{ N }},
-        dev_array_{{ N }}, _num_dev_array_{{ N }});
-}
-{% endfor %}
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 void expand_eventspace{{ varname }}(int num_queues) {
     int num_eventspaces = static_cast<int>(dev{{ varname }}.size());
@@ -672,9 +611,11 @@ void _init_arrays()
 
     {% for S in synapses | sort(attribute='name') %}
     {% for path in S._pathways | sort(attribute='name') %}
+    {% set src_name = dynamic_array_specs[path.synapse_sources] %}
+    {% set tgt_name = dynamic_array_specs[path.synapse_targets] %}
     {{path.name}}_init<<<1,1>>>(
-            thrust::raw_pointer_cast(&dev{{dynamic_array_specs[path.synapse_sources]}}[0]),
-            thrust::raw_pointer_cast(&dev{{dynamic_array_specs[path.synapse_targets]}}[0]),
+            dev_array_{{ array_basename(src_name) }},
+            dev_array_{{ array_basename(tgt_name) }},
             0,  //was dt, maybe irrelevant?
             {{path.source.start}},
             {{path.source.stop}}
@@ -686,13 +627,13 @@ void _init_arrays()
     // Arrays initialized to 0
     {% for var, varname in zero_arrays | sort(attribute='1') %}
         {% if varname in dynamic_array_specs.values() %}
+            {% set N = array_basename(varname) %}
             {{varname}}.resize({{var.size}});
-            THRUST_CHECK_ERROR(dev{{varname}}.resize({{var.size}}));
             for(int i=0; i<{{var.size}}; i++)
             {
                 {{varname}}[i] = 0;
-                dev{{varname}}[i] = 0;
             }
+            copy_host_to_dev_array_{{ N }}();
         {% elif not var in eventspace_arrays %}
             {{varname}} = new {{c_data_type(var.dtype)}}[{{var.size}}];
             for(int i=0; i<{{var.size}}; i++) {{varname}}[i] = 0;
@@ -721,8 +662,9 @@ void _init_arrays()
     // static arrays
     {% for (name, dtype_spec, N, filename) in static_array_specs | sort %}
     {% if (name in dynamic_array_specs.values())  %}
+    {% set Nbase = array_basename(name) %}
     {{name}}.resize({{N}});
-    THRUST_CHECK_ERROR(dev{{name}}.resize({{N}}));
+    resize_dev_array_{{ Nbase }}({{N}});
     {% else %}
     {{name}} = new {{dtype_spec}}[{{N}}];
     CUDA_SAFE_CALL(
@@ -782,7 +724,7 @@ void _load_arrays()
     if(f{{name}}.is_open())
     {
         {% if name in dynamic_array_specs.values() %}
-        f{{name}}.read(reinterpret_cast<char*>(&{{name}}[0]), {{N}}*sizeof({{dtype_spec}}));
+        f{{name}}.read(reinterpret_cast<char*>({{name}}.data()), {{N}}*sizeof({{dtype_spec}}));
         {% else %}
         f{{name}}.read(reinterpret_cast<char*>({{name}}), {{N}}*sizeof({{dtype_spec}}));
         {% endif %}
@@ -795,10 +737,8 @@ void _load_arrays()
             cudaMemcpy(dev{{name}}, {{name}}, sizeof({{dtype_spec}})*{{N}}, cudaMemcpyHostToDevice)
             );
     {% else %}
-    for(int i=0; i<{{N}}; i++)
-    {
-        dev{{name}}[i] = {{name}}[i];
-    }
+    {% set Nbase = array_basename(name) %}
+    copy_host_to_dev_array_{{ Nbase }}();
     {% endif %}
     {% endfor %}
 }
@@ -832,14 +772,15 @@ void _write_arrays()
     {% endfor %}
 
     {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+    {% set N = array_basename(varname) %}
     {% if varname not in variables_on_host_only %}
-    {{varname}} = dev{{varname}};
+    copy_dev_to_host_array_{{ N }}();
     {% endif %}
     std::ofstream outfile_{{varname}};
     outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", std::ios::binary | std::ios::out);
     if(outfile_{{varname}}.is_open())
     {
-        outfile_{{varname}}.write(reinterpret_cast<char*>(thrust::raw_pointer_cast(&{{varname}}[0])), {{varname}}.size()*sizeof({{c_data_type(var.dtype)}}));
+        outfile_{{varname}}.write(reinterpret_cast<char*>({{varname}}.data()), {{varname}}.size()*sizeof({{c_data_type(var.dtype)}}));
         outfile_{{varname}}.close();
     } else
     {
@@ -861,10 +802,18 @@ void _write_arrays()
             {% if var in profile_statemonitor_vars %}
             before_copy_statemon = std::chrono::high_resolution_clock::now();
             {% endif %}
-            thrust::host_vector<{{c_data_type(var.dtype)}}>* temp_array{{varname}} = new thrust::host_vector<{{c_data_type(var.dtype)}}>[_num__array_{{var.owner.name}}__indices];
+            std::vector<{{c_data_type(var.dtype)}}>* temp_array{{varname}} = new std::vector<{{c_data_type(var.dtype)}}>[_num__array_{{var.owner.name}}__indices];
             for (int n=0; n<_num__array_{{var.owner.name}}__indices; n++)
             {
-                temp_array{{varname}}[n] = {{varname}}[n];
+                temp_array{{varname}}[n].resize({{varname}}[n].size());
+                if (!{{varname}}[n].empty())
+                {
+                    CUDA_SAFE_CALL(cudaMemcpy(
+                        temp_array{{varname}}[n].data(),
+                        thrust::raw_pointer_cast(&{{varname}}[n][0]),
+                        sizeof({{c_data_type(var.dtype)}}) * {{varname}}[n].size(),
+                        cudaMemcpyDeviceToHost));
+                }
             }
             {% if var in profile_statemonitor_vars %}
             std::string profile_statemonitor_copy_to_host_varname = "{{varname}}_copy_to_host";
@@ -948,10 +897,10 @@ void _dealloc_arrays()
     {% endfor %}
 
     {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-    dev{{varname}}.clear();
-    thrust::device_vector<{{c_data_type(var.dtype)}}>().swap(dev{{varname}});
+    {% set N = array_basename(varname) %}
+    clear_dev_array_{{ N }}();
     {{varname}}.clear();
-    thrust::host_vector<{{c_data_type(var.dtype)}}>().swap({{varname}});
+    std::vector<{{c_data_type(var.dtype)}}>().swap({{varname}});
     {% endfor %}
 
     {% for var, varname in array_specs | dictsort(by='value') %}
@@ -1088,8 +1037,7 @@ extern const int _num_{{name}};
 //////////////// dynamic arrays 1d ///////////
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
 {% set N = array_basename(varname) %}
-extern {{c_data_type(var.dtype)}}* host_array_{{ N }};
-extern int _num_host_array_{{ N }};
+extern std::vector<{{c_data_type(var.dtype)}}> {{varname}};
 extern {{c_data_type(var.dtype)}}* dev_array_{{ N }};
 extern int _num_dev_array_{{ N }};
 {% endfor %}
@@ -1204,8 +1152,8 @@ void _dealloc_arrays();
 
 {% macro h_storage_file() %}
 #include "objects.h"
+#include <vector>
 #include <thrust/device_vector.h>
-#include <thrust/host_vector.h>
 
 #ifndef _BRIAN_OBJECTS_STORAGE_H
 #define _BRIAN_OBJECTS_STORAGE_H
@@ -1214,7 +1162,6 @@ namespace brian {
 
 //////////////// dynamic arrays 1d ///////////
 {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-extern thrust::host_vector<{{c_data_type(var.dtype)}}> {{varname}};
 extern thrust::device_vector<{{c_data_type(var.dtype)}}> dev{{varname}};
 {% endfor %}
 {% for varname in subgroups_with_spikemonitor %}
@@ -1223,7 +1170,7 @@ extern thrust::device_vector<int32_t> _dev_{{varname}}_eventspace;
 
 //////////////// eventspaces ///////////////
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
-extern thrust::host_vector<{{c_data_type(var.dtype)}}*> dev{{varname}};
+extern std::vector<{{c_data_type(var.dtype)}}*> dev{{varname}};
 {% endfor %}
 
 //////////////// dynamic arrays 2d /////////
@@ -1247,6 +1194,14 @@ namespace brian {
 
 void sync_all_dev_ptrs();
 
+{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
+{% set N = array_basename(varname) %}
+void resize_dev_array_{{ N }}(size_t n);
+void copy_host_to_dev_array_{{ N }}();
+void copy_dev_to_host_array_{{ N }}();
+void clear_dev_array_{{ N }}();
+{% endfor %}
+
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 void expand_eventspace{{ varname }}(int num_queues);
 {% endfor %}
@@ -1256,15 +1211,6 @@ size_t unique_by_key_int_int(int* keys, int* values, size_t n);
 int filter_subgroup_eventspace(int32_t* src, int n, int32_t* dst, int32_t start, int32_t stop);
 {% for varname in subgroups_with_spikemonitor %}
 void resize_subgroup_eventspace_{{varname}}(size_t n);
-{% endfor %}
-{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-{% set N = array_basename(varname) %}
-void resize_host_array_{{ N }}(size_t n);
-void push_back_host_array_{{ N }}({{c_data_type(var.dtype)}} v);
-void resize_dev_array_{{ N }}(size_t n);
-void clear_dev_array_{{ N }}();
-void copy_dev_to_host_array_{{ N }}();
-void copy_host_to_dev_array_{{ N }}();
 {% endfor %}
 {% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
 void clear_monitor_addresses_{{ varname }}();

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -239,13 +239,6 @@ void expand_eventspace{{ varname }}(int num_queues) {
     }
 }
 {% endfor %}
-void upload_monitor_row_addresses(DeviceBuffer& addresses, DeviceBuffer* rows, int n_rows)
-{
-    std::vector<void*> host_ptrs(n_rows);
-    for (int i = 0; i < n_rows; i++)
-        host_ptrs[i] = rows[i].data();
-    addresses.copy_from_host(host_ptrs.data(), host_ptrs.size());
-}
 }  // namespace brian
 
 /////////////// static arrays /////////////
@@ -855,7 +848,6 @@ extern int num_threads_per_warp;
 void expand_eventspace{{ varname }}(int num_queues);
 {% endfor %}
 int filter_subgroup_eventspace(int32_t* src, int n, int32_t* dst, int32_t start, int32_t stop);
-void upload_monitor_row_addresses(DeviceBuffer& addresses, DeviceBuffer* rows, int n_rows);
 
 }
 

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -217,20 +217,6 @@ DeviceBuffer addresses_monitor_{{varname}}(sizeof({{c_data_type(var.dtype)}}*));
 DeviceBuffer* {{varname}} = nullptr;
 {% endfor %}
 
-{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-{% set N = array_basename(varname) %}
-void copy_host_to_dev_array_{{ N }}() {
-    dev{{ varname }}.copy_from_host(
-        {{ varname }}.empty() ? nullptr : {{ varname }}.data(),
-        {{ varname }}.size());
-}
-void copy_dev_to_host_array_{{ N }}() {
-    {{ varname }}.resize(dev{{ varname }}.size());
-    dev{{ varname }}.copy_to_host(
-        {{ varname }}.empty() ? nullptr : {{ varname }}.data());
-}
-{% endfor %}
-
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 void expand_eventspace{{ varname }}(int num_queues) {
     int num_eventspaces = static_cast<int>(dev{{ varname }}.size());
@@ -865,12 +851,6 @@ extern int max_shared_mem_size;
 extern int num_threads_per_warp;
 
 //////////////// host helpers /////////////////
-{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-{% set N = array_basename(varname) %}
-void copy_host_to_dev_array_{{ N }}();
-void copy_dev_to_host_array_{{ N }}();
-{% endfor %}
-
 {% for var, varname in eventspace_arrays | dictsort(by='value') %}
 void expand_eventspace{{ varname }}(int num_queues);
 {% endfor %}

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -125,7 +125,6 @@ void brian::set_variable_by_name(std::string name, std::string s_value) {
     // dynamic arrays (1d)
     {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
     {% if not var.read_only %}
-    {% set N = array_basename(varname) %}
     if (name == "{{var.owner.name}}.{{var.name}}") {
         var_size = brian::{{get_array_name(var, access_data=False)}}.size();
         data_size = var_size*sizeof({{c_data_type(var.dtype)}});
@@ -137,7 +136,9 @@ void brian::set_variable_by_name(std::string name, std::string s_value) {
             set_variable_from_file(name, brian::{{get_array_name(var, False)}}.data(), data_size, s_value);
         }
         {% if get_array_name(var) not in variables_on_host_only %}
-        copy_host_to_dev_array_{{ N }}();
+        brian::dev{{ varname }}.copy_from_host(
+            brian::{{ varname }}.empty() ? nullptr : brian::{{ varname }}.data(),
+            brian::{{ varname }}.size());
         {% endif %}
         return;
     }
@@ -394,13 +395,14 @@ void _init_arrays()
     // Arrays initialized to 0
     {% for var, varname in zero_arrays | sort(attribute='1') %}
         {% if varname in dynamic_array_specs.values() %}
-            {% set N = array_basename(varname) %}
             {{varname}}.resize({{var.size}});
             for(int i=0; i<{{var.size}}; i++)
             {
                 {{varname}}[i] = 0;
             }
-            copy_host_to_dev_array_{{ N }}();
+            dev{{ varname }}.copy_from_host(
+                {{ varname }}.empty() ? nullptr : {{ varname }}.data(),
+                {{ varname }}.size());
         {% elif not var in eventspace_arrays %}
             {{varname}} = new {{c_data_type(var.dtype)}}[{{var.size}}];
             for(int i=0; i<{{var.size}}; i++) {{varname}}[i] = 0;
@@ -504,8 +506,9 @@ void _load_arrays()
             cudaMemcpy(dev{{name}}, {{name}}, sizeof({{dtype_spec}})*{{N}}, cudaMemcpyHostToDevice)
             );
     {% else %}
-    {% set Nbase = array_basename(name) %}
-    copy_host_to_dev_array_{{ Nbase }}();
+    dev{{ name }}.copy_from_host(
+        {{ name }}.empty() ? nullptr : {{ name }}.data(),
+        {{ name }}.size());
     {% endif %}
     {% endfor %}
 }
@@ -539,9 +542,10 @@ void _write_arrays()
     {% endfor %}
 
     {% for var, varname in dynamic_array_specs | dictsort(by='value') %}
-    {% set N = array_basename(varname) %}
     {% if varname not in variables_on_host_only %}
-    copy_dev_to_host_array_{{ N }}();
+    {{ varname }}.resize(dev{{ varname }}.size());
+    dev{{ varname }}.copy_to_host(
+        {{ varname }}.empty() ? nullptr : {{ varname }}.data());
     {% endif %}
     std::ofstream outfile_{{varname}};
     outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", std::ios::binary | std::ios::out);

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -137,7 +137,7 @@ void brian::set_variable_by_name(std::string name, std::string s_value) {
         }
         {% if get_array_name(var) not in variables_on_host_only %}
         brian::dev{{ varname }}.copy_from_host(
-            brian::{{ varname }}.empty() ? nullptr : brian::{{ varname }}.data(),
+            brian::{{ varname }}.data(),
             brian::{{ varname }}.size());
         {% endif %}
         return;
@@ -380,7 +380,7 @@ void _init_arrays()
                 {{varname}}[i] = 0;
             }
             dev{{ varname }}.copy_from_host(
-                {{ varname }}.empty() ? nullptr : {{ varname }}.data(),
+                {{ varname }}.data(),
                 {{ varname }}.size());
         {% elif not var in eventspace_arrays %}
             {{varname}} = new {{c_data_type(var.dtype)}}[{{var.size}}];
@@ -486,7 +486,7 @@ void _load_arrays()
             );
     {% else %}
     dev{{ name }}.copy_from_host(
-        {{ name }}.empty() ? nullptr : {{ name }}.data(),
+        {{ name }}.data(),
         {{ name }}.size());
     {% endif %}
     {% endfor %}
@@ -524,7 +524,7 @@ void _write_arrays()
     {% if varname not in variables_on_host_only %}
     {{ varname }}.resize(dev{{ varname }}.size());
     dev{{ varname }}.copy_to_host(
-        {{ varname }}.empty() ? nullptr : {{ varname }}.data());
+        {{ varname }}.data());
     {% endif %}
     std::ofstream outfile_{{varname}};
     outfile_{{varname}}.open(results_dir + "{{get_array_filename(var) | replace('\\', '\\\\')}}", std::ios::binary | std::ios::out);

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -217,28 +217,6 @@ DeviceBuffer addresses_monitor_{{varname}}(sizeof({{c_data_type(var.dtype)}}*));
 DeviceBuffer* {{varname}} = nullptr;
 {% endfor %}
 
-{% for var, varname in eventspace_arrays | dictsort(by='value') %}
-void expand_eventspace{{ varname }}(int num_queues) {
-    int num_eventspaces = static_cast<int>(dev{{ varname }}.size());
-    if (num_queues <= num_eventspaces) return;
-    std::rotate(
-        dev{{ varname }}.begin(),
-        dev{{ varname }}.begin() + current_idx{{ varname }},
-        dev{{ varname }}.end());
-    current_idx{{ varname }} = 0;
-    for (int i = num_eventspaces; i < num_queues; i++) {
-        {{c_data_type(var.dtype)}}* new_eventspace;
-        CUDA_SAFE_CALL(cudaMalloc(
-            (void**)&new_eventspace,
-            sizeof({{c_data_type(var.dtype)}}) * _num_{{ varname }}));
-        CUDA_SAFE_CALL(cudaMemcpy(
-            new_eventspace, {{ varname }},
-            sizeof({{c_data_type(var.dtype)}}) * _num_{{ varname }},
-            cudaMemcpyHostToDevice));
-        dev{{ varname }}.push_back(new_eventspace);
-    }
-}
-{% endfor %}
 }  // namespace brian
 
 /////////////// static arrays /////////////
@@ -844,9 +822,6 @@ extern int max_shared_mem_size;
 extern int num_threads_per_warp;
 
 //////////////// host helpers /////////////////
-{% for var, varname in eventspace_arrays | dictsort(by='value') %}
-void expand_eventspace{{ varname }}(int num_queues);
-{% endfor %}
 int filter_subgroup_eventspace(int32_t* src, int n, int32_t* dst, int32_t start, int32_t stop);
 
 }

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -216,7 +216,6 @@ DeviceBuffer _dev_{{varname}}_eventspace(sizeof(int32_t));
 DeviceBuffer addresses_monitor_{{varname}}(sizeof({{c_data_type(var.dtype)}}*));
 DeviceBuffer* {{varname}} = nullptr;
 {% endfor %}
-
 }  // namespace brian
 
 /////////////// static arrays /////////////
@@ -534,10 +533,7 @@ void _write_arrays()
             for (int n=0; n<_num__array_{{var.owner.name}}__indices; n++)
             {
                 temp_array{{varname}}[n].resize({{varname}}[n].size());
-                if (!{{varname}}[n].empty())
-                {
-                    {{varname}}[n].copy_to_host(temp_array{{varname}}[n].data());
-                }
+                {{varname}}[n].copy_to_host(temp_array{{varname}}[n].data());
             }
             {% if var in profile_statemonitor_vars %}
             std::string profile_statemonitor_copy_to_host_varname = "{{varname}}_copy_to_host";

--- a/brian2cuda/templates/rand.cu
+++ b/brian2cuda/templates/rand.cu
@@ -7,6 +7,7 @@
 #include "brianlib/curand_utils.h"
 #include "network.h"
 #include <ctime>
+#include <cassert>
 #include <curand_kernel.h>
 
 // XXX: for some documentation on random number generation, check out our wiki:

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -12,13 +12,11 @@ static int start_offset = current_iteration;
 {% endblock %}
 
 {% block prepare_kernel_inner %}
-{% set Nt = array_basename(_dynamic_t) %}
-{% set Nr = array_basename(_dynamic_rate) %}
 int num_iterations = {{owner.clock.name}}.i_end;
 int size_till_now = static_cast<int>(dev{{_dynamic_t}}.size());
 int new_size = num_iterations + size_till_now - start_offset;
-resize_dev_array_{{ Nt }}(new_size);
-resize_dev_array_{{ Nr }}(new_size);
+dev{{_dynamic_t}}.resize(new_size);
+dev{{_dynamic_rate}}.resize(new_size);
 // Update size variables for Python side indexing to work
 // (Note: Need to update device variable which will be copied to host in write_arrays())
 _array_{{owner.name}}_N[0] = new_size;

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -3,10 +3,6 @@
 {# WRITES_TO_READ_ONLY_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
 
-{% block extra_headers %}
-#include "objects_api.h"
-{% endblock %}
-
 {% block define_N %}
 {% endblock %}
 

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -18,12 +18,7 @@ int new_size = num_iterations + size_till_now - start_offset;
 dev{{_dynamic_t}}.resize(new_size);
 dev{{_dynamic_rate}}.resize(new_size);
 // Update size variables for Python side indexing to work
-// (Note: Need to update device variable which will be copied to host in write_arrays())
 _array_{{owner.name}}_N[0] = new_size;
-CUDA_SAFE_CALL(
-        cudaMemcpy(dev_array_{{owner.name}}_N, _array_{{owner.name}}_N, sizeof(int32_t),
-                   cudaMemcpyHostToDevice)
-        );
 
 num_threads = 1;
 num_blocks = 1;
@@ -32,8 +27,8 @@ num_blocks = 1;
 {% block kernel_call %}
 _run_kernel_{{codeobj_name}}<<<num_blocks, num_threads>>>(
     current_iteration - start_offset,
-    dev{{_dynamic_rate}}.data_as<{{c_data_type(rate.dtype)}}>(),
-    dev{{_dynamic_t}}.data_as<{{c_data_type(t.dtype)}}>(),
+    dev{{_dynamic_rate}}.data_as<{{c_data_type(variables['rate'].dtype)}}>(),
+    dev{{_dynamic_t}}.data_as<{{c_data_type(variables['t'].dtype)}}>(),
     ///// HOST_PARAMETERS /////
     %HOST_PARAMETERS%);
 

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -34,8 +34,8 @@ num_blocks = 1;
 {% block kernel_call %}
 _run_kernel_{{codeobj_name}}<<<num_blocks, num_threads>>>(
     current_iteration - start_offset,
-    dev{{_dynamic_rate}}.data(),
-    dev{{_dynamic_t}}.data(),
+    dev{{_dynamic_rate}}.data_as<{{c_data_type(rate.dtype)}}>(),
+    dev{{_dynamic_t}}.data_as<{{c_data_type(t.dtype)}}>(),
     ///// HOST_PARAMETERS /////
     %HOST_PARAMETERS%);
 

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -16,11 +16,13 @@ static int start_offset = current_iteration;
 {% endblock %}
 
 {% block prepare_kernel_inner %}
+{% set Nt = array_basename(_dynamic_t) %}
+{% set Nr = array_basename(_dynamic_rate) %}
 int num_iterations = {{owner.clock.name}}.i_end;
-int size_till_now = _num_dev_array_{{ array_basename(_dynamic_t) }};
+int size_till_now = _num_dev_array_{{ Nt }};
 int new_size = num_iterations + size_till_now - start_offset;
-resize_dev_array_{{ array_basename(_dynamic_t) }}(new_size);
-resize_dev_array_{{ array_basename(_dynamic_rate) }}(new_size);
+resize_dev_array_{{ Nt }}(new_size);
+resize_dev_array_{{ Nr }}(new_size);
 // Update size variables for Python side indexing to work
 // (Note: Need to update device variable which will be copied to host in write_arrays())
 _array_{{owner.name}}_N[0] = new_size;
@@ -34,10 +36,12 @@ num_blocks = 1;
 {% endblock %}
 
 {% block kernel_call %}
+{% set Nt = array_basename(_dynamic_t) %}
+{% set Nr = array_basename(_dynamic_rate) %}
 _run_kernel_{{codeobj_name}}<<<num_blocks, num_threads>>>(
     current_iteration - start_offset,
-    dev_array_{{ array_basename(_dynamic_rate) }},
-    dev_array_{{ array_basename(_dynamic_t) }},
+    dev_array_{{ Nr }},
+    dev_array_{{ Nt }},
     ///// HOST_PARAMETERS /////
     %HOST_PARAMETERS%);
 

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -15,7 +15,7 @@ static int start_offset = current_iteration;
 {% set Nt = array_basename(_dynamic_t) %}
 {% set Nr = array_basename(_dynamic_rate) %}
 int num_iterations = {{owner.clock.name}}.i_end;
-int size_till_now = _num_dev_array_{{ Nt }};
+int size_till_now = static_cast<int>(dev{{_dynamic_t}}.size());
 int new_size = num_iterations + size_till_now - start_offset;
 resize_dev_array_{{ Nt }}(new_size);
 resize_dev_array_{{ Nr }}(new_size);
@@ -32,12 +32,10 @@ num_blocks = 1;
 {% endblock %}
 
 {% block kernel_call %}
-{% set Nt = array_basename(_dynamic_t) %}
-{% set Nr = array_basename(_dynamic_rate) %}
 _run_kernel_{{codeobj_name}}<<<num_blocks, num_threads>>>(
     current_iteration - start_offset,
-    dev_array_{{ Nr }},
-    dev_array_{{ Nt }},
+    dev{{_dynamic_rate}}.data(),
+    dev{{_dynamic_t}}.data(),
     ///// HOST_PARAMETERS /////
     %HOST_PARAMETERS%);
 

--- a/brian2cuda/templates/ratemonitor.cu
+++ b/brian2cuda/templates/ratemonitor.cu
@@ -3,6 +3,10 @@
 {# WRITES_TO_READ_ONLY_VARIABLES { N } #}
 {% extends 'common_group.cu' %}
 
+{% block extra_headers %}
+#include "objects_api.h"
+{% endblock %}
+
 {% block define_N %}
 {% endblock %}
 
@@ -13,14 +17,10 @@ static int start_offset = current_iteration;
 
 {% block prepare_kernel_inner %}
 int num_iterations = {{owner.clock.name}}.i_end;
-int size_till_now = dev{{_dynamic_t}}.size();
+int size_till_now = _num_dev_array_{{ array_basename(_dynamic_t) }};
 int new_size = num_iterations + size_till_now - start_offset;
-THRUST_CHECK_ERROR(
-        dev{{_dynamic_t}}.resize(new_size)
-        );
-THRUST_CHECK_ERROR(
-        dev{{_dynamic_rate}}.resize(new_size)
-        );
+resize_dev_array_{{ array_basename(_dynamic_t) }}(new_size);
+resize_dev_array_{{ array_basename(_dynamic_rate) }}(new_size);
 // Update size variables for Python side indexing to work
 // (Note: Need to update device variable which will be copied to host in write_arrays())
 _array_{{owner.name}}_N[0] = new_size;
@@ -36,8 +36,8 @@ num_blocks = 1;
 {% block kernel_call %}
 _run_kernel_{{codeobj_name}}<<<num_blocks, num_threads>>>(
     current_iteration - start_offset,
-    thrust::raw_pointer_cast(&(dev{{_dynamic_rate}}[0])),
-    thrust::raw_pointer_cast(&(dev{{_dynamic_t}}[0])),
+    dev_array_{{ array_basename(_dynamic_rate) }},
+    dev_array_{{ array_basename(_dynamic_t) }},
     ///// HOST_PARAMETERS /////
     %HOST_PARAMETERS%);
 

--- a/brian2cuda/templates/run.cu
+++ b/brian2cuda/templates/run.cu
@@ -2,7 +2,6 @@
 #include<stdlib.h>
 #include "brianlib/cuda_utils.h"
 #include "objects.h"
-#include "objects_api.h"
 #include "network.h"
 #include "rand.h"
 #include<ctime>

--- a/brian2cuda/templates/run.cu
+++ b/brian2cuda/templates/run.cu
@@ -18,7 +18,6 @@ void brian_start()
 {
     _init_arrays();
     _load_arrays();
-    brian::sync_all_dev_ptrs();
     srand(time(NULL));
 
     // Initialize clocks (link timestep and dt to the respective arrays)

--- a/brian2cuda/templates/run.cu
+++ b/brian2cuda/templates/run.cu
@@ -2,6 +2,7 @@
 #include<stdlib.h>
 #include "brianlib/cuda_utils.h"
 #include "objects.h"
+#include "objects_api.h"
 #include "network.h"
 #include "rand.h"
 #include<ctime>
@@ -18,6 +19,7 @@ void brian_start()
 {
     _init_arrays();
     _load_arrays();
+    brian::sync_all_dev_ptrs();
     srand(time(NULL));
 
     // Initialize clocks (link timestep and dt to the respective arrays)

--- a/brian2cuda/templates/run.cu
+++ b/brian2cuda/templates/run.cu
@@ -2,6 +2,7 @@
 #include<stdlib.h>
 #include "brianlib/cuda_utils.h"
 #include "objects.h"
+#include "network.h"
 #include "rand.h"
 #include<ctime>
 

--- a/brian2cuda/templates/run.cu
+++ b/brian2cuda/templates/run.cu
@@ -2,7 +2,6 @@
 #include<stdlib.h>
 #include "brianlib/cuda_utils.h"
 #include "objects.h"
-#include "network.h"
 #include "rand.h"
 #include<ctime>
 

--- a/brian2cuda/templates/spikegenerator.cu
+++ b/brian2cuda/templates/spikegenerator.cu
@@ -139,7 +139,7 @@
     // Note: If we have no delays, there is only one spikespace and
     //       current_idx equals previous_idx.
     _reset_{{codeobj_name}}<<<num_blocks, num_threads>>>(
-            dev{{ _spikespace_name }}_view[previous_idx{{ _spikespace_name }}],
+            dev{{ _spikespace_name }}[previous_idx{{ _spikespace_name }}],
             ///// HOST_PARAMETERS /////
             %HOST_PARAMETERS%
         );

--- a/brian2cuda/templates/spikegenerator.cu
+++ b/brian2cuda/templates/spikegenerator.cu
@@ -139,7 +139,7 @@
     // Note: If we have no delays, there is only one spikespace and
     //       current_idx equals previous_idx.
     _reset_{{codeobj_name}}<<<num_blocks, num_threads>>>(
-            dev{{ _spikespace_name }}[previous_idx{{ _spikespace_name }}],
+            dev{{_spikespace_name}}[previous_idx{{_spikespace_name}}],
             ///// HOST_PARAMETERS /////
             %HOST_PARAMETERS%
         );

--- a/brian2cuda/templates/spikegenerator.cu
+++ b/brian2cuda/templates/spikegenerator.cu
@@ -139,7 +139,7 @@
     // Note: If we have no delays, there is only one spikespace and
     //       current_idx equals previous_idx.
     _reset_{{codeobj_name}}<<<num_blocks, num_threads>>>(
-            dev{{_spikespace_name}}[previous_idx{{_spikespace_name}}],
+            dev{{ _spikespace_name }}_view[previous_idx{{ _spikespace_name }}],
             ///// HOST_PARAMETERS /////
             %HOST_PARAMETERS%
         );

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -59,12 +59,12 @@ CUDA_SAFE_CALL(
 _N = filter_subgroup_eventspace(
         _eventspace,
         _num_events,
-        _dev_{{owner.source.name}}_eventspace.data(),
+        _dev_{{owner.source.name}}_eventspace.data_as<int32_t>(),
         {{_source_start}},
         {{_source_stop}}
         );
 // Use same kernel as without subgroups on copied subgroup eventspace
-_eventspace = _dev_{{owner.source.name}}_eventspace.data();
+_eventspace = _dev_{{owner.source.name}}_eventspace.data_as<int32_t>();
 {% else %}{# not is_subgroup #}
 // Get the number of events
 _N = _num_events;
@@ -100,7 +100,7 @@ if (_N > 0)
             _eventspace,
             {% for varname, var in record_variables.items() %}
             {% set dyn_name = get_array_name(var, access_data=False) %}
-            dev{{ dyn_name }}.data(),
+            dev{{ dyn_name }}.data_as<{{c_data_type(var.dtype)}}>(),
             {% endfor %}
             ///// HOST_PARAMETERS /////
             %HOST_PARAMETERS%

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -59,12 +59,12 @@ CUDA_SAFE_CALL(
 _N = filter_subgroup_eventspace(
         _eventspace,
         _num_events,
-        dev_array_subgroup_eventspace_{{owner.source.name}},
+        _dev_{{owner.source.name}}_eventspace.data(),
         {{_source_start}},
         {{_source_stop}}
         );
 // Use same kernel as without subgroups on copied subgroup eventspace
-_eventspace = dev_array_subgroup_eventspace_{{owner.source.name}};
+_eventspace = _dev_{{owner.source.name}}_eventspace.data();
 {% else %}{# not is_subgroup #}
 // Get the number of events
 _N = _num_events;
@@ -76,8 +76,7 @@ _N = _num_events;
    because the pointers change when resizing leads to reallocation) #}
 {% set var = record_variables.values() | first %}
 {% set dyn_name = get_array_name(var, access_data=False) %}
-{% set N0 = array_basename(dyn_name) %}
-int _monitor_size = _num_dev_array_{{ N0 }};
+int _monitor_size = static_cast<int>(dev{{ dyn_name }}.size());
 
 {% for varname, var in record_variables.items() %}
 {% set dyn_name = get_array_name(var, access_data=False) %}
@@ -101,8 +100,7 @@ if (_N > 0)
             _eventspace,
             {% for varname, var in record_variables.items() %}
             {% set dyn_name = get_array_name(var, access_data=False) %}
-            {% set N = array_basename(dyn_name) %}
-            dev_array_{{ N }},
+            dev{{ dyn_name }}.data(),
             {% endfor %}
             ///// HOST_PARAMETERS /////
             %HOST_PARAMETERS%

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -42,7 +42,7 @@ resize_subgroup_eventspace_{{owner.source.name}}(_num_source_idx);
 
 // Number of events in eventspace
 int _num_events;
-int32_t* _eventspace = dev{{ _eventspace }}_view[current_idx{{ _eventspace }}];
+int32_t* _eventspace = dev{{ _eventspace }}[current_idx{{ _eventspace }}];
 CUDA_SAFE_CALL(
         cudaMemcpy(
             &_num_events,

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -4,24 +4,9 @@
 
 
 {% block extra_headers %}
-#include <thrust/copy.h>
-#include <thrust/count.h>
-#include <thrust/execution_policy.h>
+#include "objects_api.h"
+#include <cassert>
 {% endblock %}
-
-
-{% block extra_device_helper %}
-{% if owner.source.__class__.__name__ == 'Subgroup' %}
-struct is_in_subgroup
-{
-  __device__
-  bool operator()(const int32_t &neuron)
-  {
-    return ({{_source_start}} <= neuron && neuron < {{_source_stop}});
-  }
-};
-{% endif %}{# Subgroup #}
-{% endblock extra_device_helper %}
 
 
 {# We change _N depending on number of events and subgroups #}
@@ -40,10 +25,7 @@ int num_events, num_blocks;
 
 {% block modify_kernel_dimensions %}
 {% if owner.source.__class__.__name__ == 'Subgroup' %}
-// Initialize device vector for subgroup eventspace
-THRUST_CHECK_ERROR(
-    _dev_{{owner.source.name}}_eventspace.resize(_num_source_idx)
-);
+resize_subgroup_eventspace_{{owner.source.name}}(_num_source_idx);
 {% endif %}{# Subgroup #}
 {% endblock %}
 
@@ -60,8 +42,8 @@ THRUST_CHECK_ERROR(
    neurons are part of the subgroup). #}
 
 // Number of events in eventspace
-int _num_events, _num_events_subgroup;
-int32_t* _eventspace = dev{{_eventspace}}[current_idx{{_eventspace}}];
+int _num_events;
+int32_t* _eventspace = dev{{ _eventspace }}_view[current_idx{{ _eventspace }}];
 CUDA_SAFE_CALL(
         cudaMemcpy(
             &_num_events,
@@ -74,25 +56,16 @@ CUDA_SAFE_CALL(
 {# TODO: Use isintance instead (needs to be made available in Jinja templates) #}
 {% if owner.source.__class__.__name__ == 'Subgroup' %}
 // Count the elements in eventspace that are in the subgroup
-thrust::device_ptr<int32_t> _dev_eventspace(_eventspace);
-THRUST_CHECK_ERROR(
-    _N = thrust::count_if(
-        _dev_eventspace,
-        _dev_eventspace + _num_events,
-        is_in_subgroup()
-    )
-);
 // Copy all neuron IDs that are in this subgroup to the new device pointer
-THRUST_CHECK_ERROR(
-    thrust::copy_if(
-        _dev_eventspace,
-        _dev_eventspace + _num_events,
-        _dev_{{owner.source.name}}_eventspace.begin(),
-        is_in_subgroup()
-    )
-);
+_N = filter_subgroup_eventspace(
+        _eventspace,
+        _num_events,
+        dev_array_subgroup_eventspace_{{owner.source.name}},
+        {{_source_start}},
+        {{_source_stop}}
+        );
 // Use same kernel as without subgroups on copied subgroup eventspace
-_eventspace = thrust::raw_pointer_cast(&_dev_{{owner.source.name}}_eventspace[0]);
+_eventspace = dev_array_subgroup_eventspace_{{owner.source.name}};
 {% else %}{# not is_subgroup #}
 // Get the number of events
 _N = _num_events;
@@ -104,16 +77,14 @@ _N = _num_events;
    because the pointers underlying the device vectors change when resizing
    leads to memory reallocation) #}
 {% set var = record_variables.values() | first %}
-{% set dev_array_name = get_array_name(var, access_data=False, prefix='dev') %}
+{% set dyn_name = get_array_name(var, access_data=False) %}
 // Get current size of device vectors
-int _monitor_size = {{dev_array_name}}.size();
+int _monitor_size = _num_dev_array_{{ array_basename(dyn_name) }};
 
 // Increase device vectors based on number of events
 {% for varname, var in record_variables.items() %}
-{% set dev_array_name = get_array_name(var, access_data=False, prefix='dev') %}
-THRUST_CHECK_ERROR(
-        {{dev_array_name}}.resize(_monitor_size + _N)
-        );
+{% set dyn_name = get_array_name(var, access_data=False) %}
+resize_dev_array_{{ array_basename(dyn_name) }}(_monitor_size + _N);
 {% endfor %}
 {% endif %}{# not record_variables #}
 
@@ -130,12 +101,9 @@ if (_N > 0)
             _monitor_size,
             {% endif %}
             _eventspace,
-            {# We need to get a new raw_pointer_cast because the thrust vectors
-               were resized, which changes the underlying data pointer if memory
-               has to be reallocated #}
             {% for varname, var in record_variables.items() %}
-            {% set dev_array_name = get_array_name(var, access_data=False, prefix='dev') %}
-            thrust::raw_pointer_cast(&{{dev_array_name}}[0]),
+            {% set dyn_name = get_array_name(var, access_data=False) %}
+            dev_array_{{ array_basename(dyn_name) }},
             {% endfor %}
             ///// HOST_PARAMETERS /////
             %HOST_PARAMETERS%
@@ -164,8 +132,7 @@ _array_{{owner.name}}_N[0] += _N;
 
 {% block kernel_maincode %}
 {# We pass as _eventspace the filtered eventspace, such that all neuron IDs are
-   within the subgroup (if this is one). We take care of that with the
-   thrust::copy_if above. #}
+   within the subgroup (if this is one). Filtering is done via objects_api. #}
 
 // Eventspace is filled from left with all neuron IDs that triggered an event, rest -1
 int32_t spiking_neuron = _eventspace[_idx];

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -3,11 +3,6 @@
 {% extends 'common_group.cu' %}
 
 
-{% block extra_headers %}
-#include <cassert>
-{% endblock %}
-
-
 {# We change _N depending on number of events and subgroups #}
 {% block define_N %}
 // The _N of this kernel (total number of threads) is defined by the number of events

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -74,17 +74,16 @@ _N = _num_events;
 {# If we don't record variables, we don't need to resize the monitor vectors #}
 {% if record_variables %}
 {# Get any item to read the size (we need to resize before HOST_CONSTANTS
-   because the pointers underlying the device vectors change when resizing
-   leads to memory reallocation) #}
+   because the pointers change when resizing leads to reallocation) #}
 {% set var = record_variables.values() | first %}
 {% set dyn_name = get_array_name(var, access_data=False) %}
-// Get current size of device vectors
-int _monitor_size = _num_dev_array_{{ array_basename(dyn_name) }};
+{% set N0 = array_basename(dyn_name) %}
+int _monitor_size = _num_dev_array_{{ N0 }};
 
-// Increase device vectors based on number of events
 {% for varname, var in record_variables.items() %}
 {% set dyn_name = get_array_name(var, access_data=False) %}
-resize_dev_array_{{ array_basename(dyn_name) }}(_monitor_size + _N);
+{% set N = array_basename(dyn_name) %}
+resize_dev_array_{{ N }}(_monitor_size + _N);
 {% endfor %}
 {% endif %}{# not record_variables #}
 
@@ -103,7 +102,8 @@ if (_N > 0)
             _eventspace,
             {% for varname, var in record_variables.items() %}
             {% set dyn_name = get_array_name(var, access_data=False) %}
-            dev_array_{{ array_basename(dyn_name) }},
+            {% set N = array_basename(dyn_name) %}
+            dev_array_{{ N }},
             {% endfor %}
             ///// HOST_PARAMETERS /////
             %HOST_PARAMETERS%

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -24,7 +24,7 @@ int num_events, num_blocks;
 
 {% block modify_kernel_dimensions %}
 {% if owner.source.__class__.__name__ == 'Subgroup' %}
-resize_subgroup_eventspace_{{owner.source.name}}(_num_source_idx);
+_dev_{{owner.source.name}}_eventspace.resize(_num_source_idx);
 {% endif %}{# Subgroup #}
 {% endblock %}
 
@@ -80,8 +80,7 @@ int _monitor_size = static_cast<int>(dev{{ dyn_name }}.size());
 
 {% for varname, var in record_variables.items() %}
 {% set dyn_name = get_array_name(var, access_data=False) %}
-{% set N = array_basename(dyn_name) %}
-resize_dev_array_{{ N }}(_monitor_size + _N);
+dev{{ dyn_name }}.resize(_monitor_size + _N);
 {% endfor %}
 {% endif %}{# not record_variables #}
 

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -4,7 +4,6 @@
 
 
 {% block extra_headers %}
-#include "objects_api.h"
 #include <cassert>
 {% endblock %}
 
@@ -132,7 +131,7 @@ _array_{{owner.name}}_N[0] += _N;
 
 {% block kernel_maincode %}
 {# We pass as _eventspace the filtered eventspace, such that all neuron IDs are
-   within the subgroup (if this is one). Filtering is done via objects_api. #}
+   within the subgroup (if this is one). Filtering is done by filter_subgroup_eventspace. #}
 
 // Eventspace is filled from left with all neuron IDs that triggered an event, rest -1
 int32_t spiking_neuron = _eventspace[_idx];

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -37,7 +37,7 @@ _dev_{{owner.source.name}}_eventspace.resize(_num_source_idx);
 
 // Number of events in eventspace
 int _num_events;
-int32_t* _eventspace = dev{{ _eventspace }}[current_idx{{ _eventspace }}];
+int32_t* _eventspace = dev{{_eventspace}}[current_idx{{_eventspace}}];
 CUDA_SAFE_CALL(
         cudaMemcpy(
             &_num_events,

--- a/brian2cuda/templates/statemonitor.cu
+++ b/brian2cuda/templates/statemonitor.cu
@@ -2,10 +2,6 @@
 {# WRITES_TO_READ_ONLY_VARIABLES { t, N } #}
 {% extends 'common_group.cu' %}
 
-{% block extra_headers %}
-#include "objects_api.h"
-{% endblock %}
-
 {% block define_N %}
 {% endblock %}
 

--- a/brian2cuda/templates/statemonitor.cu
+++ b/brian2cuda/templates/statemonitor.cu
@@ -32,12 +32,8 @@ for(int i = 0; i < _num__array_{{owner.name}}__indices; i++)
 // recorded indices).
 const int _N = _num_indices;
 
-// We are using an extra variable because HOST_CONSTANTS uses the device vector, which
-// is not used (TODO: Fix this in HOST_CONSTANTS instead of this hack here...)
-const int _numt_host = _num_host_array_{{ owner.name }}_t;
-
-// We push t only on host and don't make a device->host copy in write_arrays()
-push_back_host_array_{{ owner.name }}_t({{ owner.clock.name }}.t[0]);
+const int _numt_host = _dynamic_array_{{ owner.name }}_t.size();
+_dynamic_array_{{ owner.name }}_t.push_back({{ owner.clock.name }}.t[0]);
 
 // Update size variables for Python side indexing to work
 _array_{{owner.name}}_N[0] += 1;

--- a/brian2cuda/templates/statemonitor.cu
+++ b/brian2cuda/templates/statemonitor.cu
@@ -7,18 +7,20 @@
 
 {# We are using block modify_kernel_dimensions for additional kernel preparation #}
 {% block modify_kernel_dimensions %}
-{% for varname, var in _recorded_variables | dictsort %}
-{% set _recorded = get_array_name(var, access_data=False) %}
-clear_monitor_addresses_{{ _recorded }}();
-{% endfor %}
 for(int i = 0; i < _num__array_{{owner.name}}__indices; i++)
 {
     {% for varname, var in _recorded_variables | dictsort %}
     {% set _recorded = get_array_name(var, access_data=False) %}
-    resize_monitor_row_{{ _recorded }}(i, _numt_host + num_iterations - current_iteration);
-    push_monitor_address_{{ _recorded }}(i);
+    {{ _recorded }}[i].resize(_numt_host + num_iterations - current_iteration);
     {% endfor %}
 }
+{% for varname, var in _recorded_variables | dictsort %}
+{% set _recorded = get_array_name(var, access_data=False) %}
+upload_monitor_row_addresses(
+    addresses_monitor_{{ _recorded }},
+    {{ _recorded }},
+    _num__array_{{ owner.name }}__indices);
+{% endfor %}
 {% endblock modify_kernel_dimensions %}
 
 {% block host_maincode %}
@@ -48,11 +50,17 @@ if(current_iteration >= num_iterations)
     for(int i = 0; i < _num__array_{{owner.name}}__indices; i++)
     {
         {% for varname, var in _recorded_variables | dictsort %}
-        {% set _recorded =  get_array_name(var, access_data=False) %}
-        resize_monitor_row_{{ _recorded }}(i, _numt_host + 1);
-        set_monitor_address_{{ _recorded }}(i);
+        {% set _recorded = get_array_name(var, access_data=False) %}
+        {{ _recorded }}[i].resize(_numt_host + 1);
         {% endfor %}
     }
+    {% for varname, var in _recorded_variables | dictsort %}
+    {% set _recorded = get_array_name(var, access_data=False) %}
+    upload_monitor_row_addresses(
+        addresses_monitor_{{ _recorded }},
+        {{ _recorded }},
+        _num__array_{{ owner.name }}__indices);
+    {% endfor %}
 }
 
 // TODO we get invalid launch configuration if this is 0, which happens e.g. for StateMonitor(..., variables=[])

--- a/brian2cuda/templates/statemonitor.cu
+++ b/brian2cuda/templates/statemonitor.cu
@@ -92,6 +92,6 @@ if (_num__array_{{owner.name}}__indices > 0)
     current_iteration - start_offset,
     {% for varname, var in _recorded_variables | dictsort %}
     {% set _recorded =  get_array_name(var, access_data=False) %}
-    monitor_addresses_{{ _recorded }},
+    addresses_monitor_{{ _recorded }}.data(),
     {% endfor %}
 {% endblock %}

--- a/brian2cuda/templates/statemonitor.cu
+++ b/brian2cuda/templates/statemonitor.cu
@@ -11,7 +11,7 @@ for(int i = 0; i < _num__array_{{owner.name}}__indices; i++)
 {
     {% for varname, var in _recorded_variables | dictsort %}
     {% set _recorded = get_array_name(var, access_data=False) %}
-    {{ _recorded }}[i].resize(_numt_host + num_iterations - current_iteration);
+    {{_recorded}}[i].resize(_numt_host + num_iterations - current_iteration);
     {% endfor %}
 }
 {% for varname, var in _recorded_variables | dictsort %}
@@ -30,8 +30,8 @@ upload_monitor_row_addresses(
 // recorded indices).
 const int _N = _num_indices;
 
-const int _numt_host = _dynamic_array_{{ owner.name }}_t.size();
-_dynamic_array_{{ owner.name }}_t.push_back({{ owner.clock.name }}.t[0]);
+const int _numt_host = _dynamic_array_{{owner.name}}_t.size();
+_dynamic_array_{{owner.name}}_t.push_back({{owner.clock.name}}.t[0]);
 
 // Update size variables for Python side indexing to work
 _array_{{owner.name}}_N[0] += 1;
@@ -51,7 +51,7 @@ if(current_iteration >= num_iterations)
     {
         {% for varname, var in _recorded_variables | dictsort %}
         {% set _recorded = get_array_name(var, access_data=False) %}
-        {{ _recorded }}[i].resize(_numt_host + 1);
+        {{_recorded}}[i].resize(_numt_host + 1);
         {% endfor %}
     }
     {% for varname, var in _recorded_variables | dictsort %}

--- a/brian2cuda/templates/statemonitor.cu
+++ b/brian2cuda/templates/statemonitor.cu
@@ -2,6 +2,10 @@
 {# WRITES_TO_READ_ONLY_VARIABLES { t, N } #}
 {% extends 'common_group.cu' %}
 
+{% block extra_headers %}
+#include "objects_api.h"
+{% endblock %}
+
 {% block define_N %}
 {% endblock %}
 
@@ -9,14 +13,14 @@
 {% block modify_kernel_dimensions %}
 {% for varname, var in _recorded_variables | dictsort %}
 {% set _recorded = get_array_name(var, access_data=False) %}
-addresses_monitor_{{_recorded}}.clear();
+clear_monitor_addresses_{{ _recorded }}();
 {% endfor %}
 for(int i = 0; i < _num__array_{{owner.name}}__indices; i++)
 {
     {% for varname, var in _recorded_variables | dictsort %}
     {% set _recorded = get_array_name(var, access_data=False) %}
-    {{_recorded}}[i].resize(_numt_host + num_iterations - current_iteration);
-    addresses_monitor_{{_recorded}}.push_back(thrust::raw_pointer_cast(&{{_recorded}}[i][0]));
+    resize_monitor_row_{{ _recorded }}(i, _numt_host + num_iterations - current_iteration);
+    push_monitor_address_{{ _recorded }}(i);
     {% endfor %}
 }
 {% endblock modify_kernel_dimensions %}
@@ -30,10 +34,10 @@ const int _N = _num_indices;
 
 // We are using an extra variable because HOST_CONSTANTS uses the device vector, which
 // is not used (TODO: Fix this in HOST_CONSTANTS instead of this hack here...)
-const int _numt_host = _dynamic_array_{{owner.name}}_t.size();
+const int _numt_host = _num_host_array_{{ owner.name }}_t;
 
 // We push t only on host and don't make a device->host copy in write_arrays()
-_dynamic_array_{{owner.name}}_t.push_back({{owner.clock.name}}.t[0]);
+push_back_host_array_{{ owner.name }}_t({{ owner.clock.name }}.t[0]);
 
 // Update size variables for Python side indexing to work
 _array_{{owner.name}}_N[0] += 1;
@@ -53,8 +57,8 @@ if(current_iteration >= num_iterations)
     {
         {% for varname, var in _recorded_variables | dictsort %}
         {% set _recorded =  get_array_name(var, access_data=False) %}
-        {{_recorded}}[i].resize(_numt_host + 1);
-        addresses_monitor_{{_recorded}}[i] = thrust::raw_pointer_cast(&{{_recorded}}[i][0]);
+        resize_monitor_row_{{ _recorded }}(i, _numt_host + 1);
+        set_monitor_address_{{ _recorded }}(i);
         {% endfor %}
     }
 }
@@ -96,6 +100,6 @@ if (_num__array_{{owner.name}}__indices > 0)
     current_iteration - start_offset,
     {% for varname, var in _recorded_variables | dictsort %}
     {% set _recorded =  get_array_name(var, access_data=False) %}
-    thrust::raw_pointer_cast(&addresses_monitor_{{_recorded}}[0]),
+    monitor_addresses_{{ _recorded }},
     {% endfor %}
 {% endblock %}

--- a/brian2cuda/templates/statemonitor.cu
+++ b/brian2cuda/templates/statemonitor.cu
@@ -92,6 +92,6 @@ if (_num__array_{{owner.name}}__indices > 0)
     current_iteration - start_offset,
     {% for varname, var in _recorded_variables | dictsort %}
     {% set _recorded =  get_array_name(var, access_data=False) %}
-    addresses_monitor_{{ _recorded }}.data(),
+    addresses_monitor_{{ _recorded }}.data_as<{{c_data_type(var.dtype)}}*>(),
     {% endfor %}
 {% endblock %}

--- a/brian2cuda/templates/statemonitor.cu
+++ b/brian2cuda/templates/statemonitor.cu
@@ -2,6 +2,10 @@
 {# WRITES_TO_READ_ONLY_VARIABLES { t, N } #}
 {% extends 'common_group.cu' %}
 
+{% block extra_headers %}
+#include <vector>
+{% endblock %}
+
 {% block define_N %}
 {% endblock %}
 
@@ -16,10 +20,13 @@ for(int i = 0; i < _num__array_{{owner.name}}__indices; i++)
 }
 {% for varname, var in _recorded_variables | dictsort %}
 {% set _recorded = get_array_name(var, access_data=False) %}
-upload_monitor_row_addresses(
-    addresses_monitor_{{ _recorded }},
-    {{ _recorded }},
-    _num__array_{{ owner.name }}__indices);
+{
+    std::vector<void*> host_ptrs(_num__array_{{owner.name}}__indices);
+    for (int i = 0; i < _num__array_{{owner.name}}__indices; i++)
+        host_ptrs[i] = {{_recorded}}[i].data();
+    addresses_monitor_{{_recorded}}.copy_from_host(
+        host_ptrs.data(), host_ptrs.size());
+}
 {% endfor %}
 {% endblock modify_kernel_dimensions %}
 
@@ -56,10 +63,13 @@ if(current_iteration >= num_iterations)
     }
     {% for varname, var in _recorded_variables | dictsort %}
     {% set _recorded = get_array_name(var, access_data=False) %}
-    upload_monitor_row_addresses(
-        addresses_monitor_{{ _recorded }},
-        {{ _recorded }},
-        _num__array_{{ owner.name }}__indices);
+    {
+        std::vector<void*> host_ptrs(_num__array_{{owner.name}}__indices);
+        for (int i = 0; i < _num__array_{{owner.name}}__indices; i++)
+            host_ptrs[i] = {{_recorded}}[i].data();
+        addresses_monitor_{{_recorded}}.copy_from_host(
+            host_ptrs.data(), host_ptrs.size());
+    }
     {% endfor %}
 }
 

--- a/brian2cuda/templates/synapses.cu
+++ b/brian2cuda/templates/synapses.cu
@@ -284,7 +284,7 @@ if ({{pathway.name}}_max_size > 0)
         if (defaultclock.timestep[0] >= {{pathway.name}}_delay)
         {
             cudaMemcpy(&num_spiking_neurons,
-                    &dev{{_eventspace}}[{{pathway.name}}_eventspace_idx][_num_{{_eventspace}} - 1],
+                    &dev{{_eventspace}}_view[{{pathway.name}}_eventspace_idx][_num_{{_eventspace}} - 1],
                     sizeof(int32_t), cudaMemcpyDeviceToHost);
             num_blocks = num_parallel_blocks * num_spiking_neurons;
             //TODO collect info abt mean, std of num spiking neurons per time
@@ -303,7 +303,7 @@ if ({{pathway.name}}_max_size > 0)
                 {% if bundle_mode %}
                 num_threads_per_bundle,
                 {% endif %}
-                dev{{_eventspace}}[{{pathway.name}}_eventspace_idx],
+                dev{{_eventspace}}_view[{{pathway.name}}_eventspace_idx],
                 {% if uses_atomics or synaptic_effects == "synapse" %}
                 num_spiking_neurons,
                 {% else %}
@@ -325,7 +325,7 @@ if ({{pathway.name}}_max_size > 0)
 void _debugmsg_{{codeobj_name}}()
 {
     using namespace brian;
-    std::cout << "Number of synapses: " << {{constant_or_scalar('N', variables['N'])}} << endl;
+    printf("Number of synapses: %d\n", {{constant_or_scalar('N', variables['N'])}});
 }
 {% endblock %}
 

--- a/brian2cuda/templates/synapses.cu
+++ b/brian2cuda/templates/synapses.cu
@@ -284,7 +284,7 @@ if ({{pathway.name}}_max_size > 0)
         if (defaultclock.timestep[0] >= {{pathway.name}}_delay)
         {
             cudaMemcpy(&num_spiking_neurons,
-                    &dev{{_eventspace}}_view[{{pathway.name}}_eventspace_idx][_num_{{_eventspace}} - 1],
+                    &dev{{_eventspace}}[{{pathway.name}}_eventspace_idx][_num_{{_eventspace}} - 1],
                     sizeof(int32_t), cudaMemcpyDeviceToHost);
             num_blocks = num_parallel_blocks * num_spiking_neurons;
             //TODO collect info abt mean, std of num spiking neurons per time
@@ -303,7 +303,7 @@ if ({{pathway.name}}_max_size > 0)
                 {% if bundle_mode %}
                 num_threads_per_bundle,
                 {% endif %}
-                dev{{_eventspace}}_view[{{pathway.name}}_eventspace_idx],
+                dev{{_eventspace}}[{{pathway.name}}_eventspace_idx],
                 {% if uses_atomics or synaptic_effects == "synapse" %}
                 num_spiking_neurons,
                 {% else %}

--- a/brian2cuda/templates/synapses_classes.cu
+++ b/brian2cuda/templates/synapses_classes.cu
@@ -1,4 +1,51 @@
 {% macro cu_file() %}
+#include "objects.h"
+#include "synapses_classes.h"
+#include "brianlib/spikequeue.h"
+#include "brianlib/cuda_utils.h"
+
+__device__ void SynapticPathway::init(
+        int32_t* _sources,
+        int32_t* _targets,
+        double _dt,
+        int32_t _spikes_start,
+        int32_t _spikes_stop)
+{
+    dev_sources = _sources;
+    dev_targets = _targets;
+    dt = _dt;
+    spikes_start = _spikes_start;
+    spikes_stop = _spikes_stop;
+    queue = new CudaSpikeQueue;
+}
+
+__device__ void SynapticPathway::destroy()
+{
+    queue->destroy();
+    delete queue;
+}
+
+{% for S in synapses | sort(attribute='name') %}
+{% for path in S._pathways | sort(attribute='name') %}
+__global__ void {{path.name}}_init(
+                int32_t* sources,
+                int32_t* targets,
+                double dt,
+                int32_t source_start,
+                int32_t source_stop)
+{
+    using namespace brian;
+    {{path.name}}.init(sources, targets, dt, source_start, source_stop);
+}
+
+__global__ void {{path.name}}_destroy()
+{
+    using namespace brian;
+    {{path.name}}.destroy();
+}
+{% endfor %}
+{% endfor %}
+
 {% endmacro %}
 
 {% macro h_file() %}
@@ -6,10 +53,9 @@
 #ifndef _BRIAN_SYNAPSES_H
 #define _BRIAN_SYNAPSES_H
 
-#include<vector>
-#include<algorithm>
+#include <stdint.h>
 
-#include "brianlib/spikequeue.h"
+class CudaSpikeQueue;
 
 class SynapticPathway
 {
@@ -26,29 +72,28 @@ public:
     CudaSpikeQueue* queue;
     bool no_or_const_delay_mode;
 
-    //our real constructor
     __device__ void init(
             int32_t* _sources,
             int32_t* _targets,
             double _dt,
             int32_t _spikes_start,
-            int32_t _spikes_stop)
-    {
-        dev_sources = _sources;
-        dev_targets = _targets;
-        dt = _dt;
-        spikes_start = _spikes_start;
-        spikes_stop = _spikes_stop;
-        queue = new CudaSpikeQueue;
-    };
+            int32_t _spikes_stop);
 
-    //our real destructor
-    __device__ void destroy()
-    {
-        queue->destroy();
-        delete queue;
-    }
+    __device__ void destroy();
 };
+
+{% for S in synapses | sort(attribute='name') %}
+{% for path in S._pathways | sort(attribute='name') %}
+__global__ void {{path.name}}_init(
+                int32_t* sources,
+                int32_t* targets,
+                double dt,
+                int32_t source_start,
+                int32_t source_stop);
+__global__ void {{path.name}}_destroy();
+{% endfor %}
+{% endfor %}
+
 #endif
 
 {% endmacro %}

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -78,14 +78,13 @@ for (int _idx=0; _idx<_numsources; _idx++) {
 const int32_t newsize = {{_dynamic__synaptic_pre}}.size();
 {% for variable in owner._registered_variables | sort(attribute='name') %}
     {% set varname = get_array_name(variable, access_data=False) %}
-    {% set N = array_basename(varname) %}
     {% if variable.name == 'delay' and no_or_const_delay_mode %}
         {{varname}}.resize(1);
-        resize_dev_array_{{ N }}(1);
+        dev{{varname}}.resize(1);
     {% else %}
         {% if not multisynaptic_index or not variable == multisynaptic_idx_var %}
         {{varname}}.resize(newsize);
-        resize_dev_array_{{ N }}(newsize);
+        dev{{varname}}.resize(newsize);
         {% else %}
         {{varname}}.resize(newsize);
         {% endif %}

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -58,8 +58,8 @@ std::cout << std::endl;
 constants or scalar arrays#}
 const int _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
 const int _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
-resize_host_array_{{ array_basename(_dynamic_N_incoming) }}(_N_post + _target_offset);
-resize_host_array_{{ array_basename(_dynamic_N_outgoing) }}(_N_pre + _source_offset);
+{{_dynamic_N_incoming}}.resize(_N_post + _target_offset);
+{{_dynamic_N_outgoing}}.resize(_N_pre + _source_offset);
 
 ///// pointers_lines /////
 {{pointers_lines|autoindent}}
@@ -70,25 +70,25 @@ for (int _idx=0; _idx<_numsources; _idx++) {
        only necessary for supporting subgroups #}
     {{vector_code|autoindent}}
 
-    push_back_host_array_{{ array_basename(_dynamic__synaptic_pre) }}(_real_sources);
-    push_back_host_array_{{ array_basename(_dynamic__synaptic_post) }}(_real_targets);
-    host_array_{{ array_basename(_dynamic_N_outgoing) }}[_real_sources]++;
-    host_array_{{ array_basename(_dynamic_N_incoming) }}[_real_targets]++;
+    {{_dynamic__synaptic_pre}}.push_back(_real_sources);
+    {{_dynamic__synaptic_post}}.push_back(_real_targets);
+    {{_dynamic_N_outgoing}}[_real_sources]++;
+    {{_dynamic_N_incoming}}[_real_targets]++;
 }
 
-// now we need to resize all registered variables
-const int32_t newsize = _num_host_array_{{ array_basename(_dynamic__synaptic_pre) }};
+const int32_t newsize = {{_dynamic__synaptic_pre}}.size();
 {% for variable in owner._registered_variables | sort(attribute='name') %}
     {% set varname = get_array_name(variable, access_data=False) %}
+    {% set N = array_basename(varname) %}
     {% if variable.name == 'delay' and no_or_const_delay_mode %}
-        resize_dev_array_{{ array_basename(varname) }}(1);
-        resize_host_array_{{ array_basename(varname) }}(1);
+        {{varname}}.resize(1);
+        resize_dev_array_{{ N }}(1);
     {% else %}
         {% if not multisynaptic_index or not variable == multisynaptic_idx_var %}
-        resize_dev_array_{{ array_basename(varname) }}(newsize);
-        resize_host_array_{{ array_basename(varname) }}(newsize);
+        {{varname}}.resize(newsize);
+        resize_dev_array_{{ N }}(newsize);
         {% else %}
-        resize_host_array_{{ array_basename(varname) }}(newsize);
+        {{varname}}.resize(newsize);
         {% endif %}
     {% endif %}
 {% endfor %}
@@ -104,12 +104,12 @@ for (int _i=0; _i<newsize; _i++)
     // Note that source_target_count will create a new entry initialized
     // with 0 when the key does not exist yet
     const std::pair<int32_t, int32_t> source_target = std::pair<int32_t, int32_t>(
-            host_array_{{ array_basename(_dynamic__synaptic_pre) }}[_i],
-            host_array_{{ array_basename(_dynamic__synaptic_post) }}[_i]);
+            {{_dynamic__synaptic_pre}}[_i],
+            {{_dynamic__synaptic_post}}[_i]);
     {% if multisynaptic_index %}
     // Save the "synapse number"
     {% set dynamic_multisynaptic_idx = get_array_name(multisynaptic_idx_var, access_data=False) %}
-    host_array_{{ array_basename(dynamic_multisynaptic_idx) }}[_i] = source_target_count[source_target];
+    {{dynamic_multisynaptic_idx}}[_i] = source_target_count[source_target];
     {% endif %}
     source_target_count[source_target]++;
     //printf("source target count = %i\n", source_target_count[source_target]);
@@ -121,15 +121,19 @@ for (int _i=0; _i<newsize; _i++)
         {% endif %}
     }
 }
-// Check
-// copy changed host data to device
-copy_host_to_dev_array_{{ array_basename(_dynamic_N_incoming) }}();
-copy_host_to_dev_array_{{ array_basename(_dynamic_N_outgoing) }}();
-copy_host_to_dev_array_{{ array_basename(_dynamic__synaptic_pre) }}();
-copy_host_to_dev_array_{{ array_basename(_dynamic__synaptic_post) }}();
+{% set Nin = array_basename(_dynamic_N_incoming) %}
+{% set Nout = array_basename(_dynamic_N_outgoing) %}
+{% set Npre = array_basename(_dynamic__synaptic_pre) %}
+{% set Npost = array_basename(_dynamic__synaptic_post) %}
+copy_host_to_dev_array_{{ Nin }}();
+copy_host_to_dev_array_{{ Nout }}();
+copy_host_to_dev_array_{{ Npre }}();
+copy_host_to_dev_array_{{ Npost }}();
 {% if multisynaptic_index %}
-copy_host_to_dev_array_{{ array_basename(dynamic_multisynaptic_idx) }}();
+{% set Nms = array_basename(dynamic_multisynaptic_idx) %}
+copy_host_to_dev_array_{{ Nms }}();
 {% endif %}
+sync_all_dev_ptrs();
 CUDA_SAFE_CALL(
         cudaMemcpy(dev{{get_array_name(variables['N'], access_data=False)}},
             {{get_array_name(variables['N'], access_data=False)}},

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -2,7 +2,6 @@
 
 {% block extra_headers %}
 {{ super() }}
-#include "objects_api.h"
 #include <iostream>
 #include<map>
 {% endblock %}

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -2,6 +2,8 @@
 
 {% block extra_headers %}
 {{ super() }}
+#include "objects_api.h"
+#include <iostream>
 #include<map>
 {% endblock %}
 
@@ -56,8 +58,8 @@ std::cout << std::endl;
 constants or scalar arrays#}
 const int _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
 const int _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
-{{_dynamic_N_incoming}}.resize(_N_post + _target_offset);
-{{_dynamic_N_outgoing}}.resize(_N_pre + _source_offset);
+resize_host_array_{{ array_basename(_dynamic_N_incoming) }}(_N_post + _target_offset);
+resize_host_array_{{ array_basename(_dynamic_N_outgoing) }}(_N_pre + _source_offset);
 
 ///// pointers_lines /////
 {{pointers_lines|autoindent}}
@@ -68,30 +70,26 @@ for (int _idx=0; _idx<_numsources; _idx++) {
        only necessary for supporting subgroups #}
     {{vector_code|autoindent}}
 
-    {{_dynamic__synaptic_pre}}.push_back(_real_sources);
-    {{_dynamic__synaptic_post}}.push_back(_real_targets);
-    {{_dynamic_N_outgoing}}[_real_sources]++;
-    {{_dynamic_N_incoming}}[_real_targets]++;
+    push_back_host_array_{{ array_basename(_dynamic__synaptic_pre) }}(_real_sources);
+    push_back_host_array_{{ array_basename(_dynamic__synaptic_post) }}(_real_targets);
+    host_array_{{ array_basename(_dynamic_N_outgoing) }}[_real_sources]++;
+    host_array_{{ array_basename(_dynamic_N_incoming) }}[_real_targets]++;
 }
 
 // now we need to resize all registered variables
-const int32_t newsize = {{_dynamic__synaptic_pre}}.size();
+const int32_t newsize = _num_host_array_{{ array_basename(_dynamic__synaptic_pre) }};
 {% for variable in owner._registered_variables | sort(attribute='name') %}
     {% set varname = get_array_name(variable, access_data=False) %}
     {% if variable.name == 'delay' and no_or_const_delay_mode %}
-        THRUST_CHECK_ERROR(
-                dev{{varname}}.resize(1)
-                );
-        {# //TODO: do we actually need to resize varname? #}
-        {{varname}}.resize(1);
+        resize_dev_array_{{ array_basename(varname) }}(1);
+        resize_host_array_{{ array_basename(varname) }}(1);
     {% else %}
         {% if not multisynaptic_index or not variable == multisynaptic_idx_var %}
-        THRUST_CHECK_ERROR(
-                dev{{varname}}.resize(newsize)
-                );
+        resize_dev_array_{{ array_basename(varname) }}(newsize);
+        resize_host_array_{{ array_basename(varname) }}(newsize);
+        {% else %}
+        resize_host_array_{{ array_basename(varname) }}(newsize);
         {% endif %}
-        {# //TODO: do we actually need to resize varname? #}
-        {{varname}}.resize(newsize);
     {% endif %}
 {% endfor %}
 CUDA_CHECK_MEMORY();
@@ -105,11 +103,13 @@ for (int _i=0; _i<newsize; _i++)
 {
     // Note that source_target_count will create a new entry initialized
     // with 0 when the key does not exist yet
-    const std::pair<int32_t, int32_t> source_target = std::pair<int32_t, int32_t>({{_dynamic__synaptic_pre}}[_i], {{_dynamic__synaptic_post}}[_i]);
+    const std::pair<int32_t, int32_t> source_target = std::pair<int32_t, int32_t>(
+            host_array_{{ array_basename(_dynamic__synaptic_pre) }}[_i],
+            host_array_{{ array_basename(_dynamic__synaptic_post) }}[_i]);
     {% if multisynaptic_index %}
     // Save the "synapse number"
     {% set dynamic_multisynaptic_idx = get_array_name(multisynaptic_idx_var, access_data=False) %}
-    {{dynamic_multisynaptic_idx}}[_i] = source_target_count[source_target];
+    host_array_{{ array_basename(dynamic_multisynaptic_idx) }}[_i] = source_target_count[source_target];
     {% endif %}
     source_target_count[source_target]++;
     //printf("source target count = %i\n", source_target_count[source_target]);
@@ -123,12 +123,12 @@ for (int _i=0; _i<newsize; _i++)
 }
 // Check
 // copy changed host data to device
-dev{{_dynamic_N_incoming}} = {{_dynamic_N_incoming}};
-dev{{_dynamic_N_outgoing}} = {{_dynamic_N_outgoing}};
-dev{{_dynamic__synaptic_pre}} = {{_dynamic__synaptic_pre}};
-dev{{_dynamic__synaptic_post}} = {{_dynamic__synaptic_post}};
+copy_host_to_dev_array_{{ array_basename(_dynamic_N_incoming) }}();
+copy_host_to_dev_array_{{ array_basename(_dynamic_N_outgoing) }}();
+copy_host_to_dev_array_{{ array_basename(_dynamic__synaptic_pre) }}();
+copy_host_to_dev_array_{{ array_basename(_dynamic__synaptic_post) }}();
 {% if multisynaptic_index %}
-dev{{dynamic_multisynaptic_idx}} = {{dynamic_multisynaptic_idx}};
+copy_host_to_dev_array_{{ array_basename(dynamic_multisynaptic_idx) }}();
 {% endif %}
 CUDA_SAFE_CALL(
         cudaMemcpy(dev{{get_array_name(variables['N'], access_data=False)}},

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -132,7 +132,6 @@ copy_host_to_dev_array_{{ Npost }}();
 {% set Nms = array_basename(dynamic_multisynaptic_idx) %}
 copy_host_to_dev_array_{{ Nms }}();
 {% endif %}
-sync_all_dev_ptrs();
 CUDA_SAFE_CALL(
         cudaMemcpy(dev{{get_array_name(variables['N'], access_data=False)}},
             {{get_array_name(variables['N'], access_data=False)}},

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -120,20 +120,20 @@ for (int _i=0; _i<newsize; _i++)
     }
 }
 dev{{_dynamic_N_incoming}}.copy_from_host(
-    {{_dynamic_N_incoming}}.empty() ? nullptr : {{_dynamic_N_incoming}}.data(),
+    {{_dynamic_N_incoming}}.data(),
     {{_dynamic_N_incoming}}.size());
 dev{{_dynamic_N_outgoing}}.copy_from_host(
-    {{_dynamic_N_outgoing}}.empty() ? nullptr : {{_dynamic_N_outgoing}}.data(),
+    {{_dynamic_N_outgoing}}.data(),
     {{_dynamic_N_outgoing}}.size());
 dev{{_dynamic__synaptic_pre}}.copy_from_host(
-    {{_dynamic__synaptic_pre}}.empty() ? nullptr : {{_dynamic__synaptic_pre}}.data(),
+    {{_dynamic__synaptic_pre}}.data(),
     {{_dynamic__synaptic_pre}}.size());
 dev{{_dynamic__synaptic_post}}.copy_from_host(
-    {{_dynamic__synaptic_post}}.empty() ? nullptr : {{_dynamic__synaptic_post}}.data(),
+    {{_dynamic__synaptic_post}}.data(),
     {{_dynamic__synaptic_post}}.size());
 {% if multisynaptic_index %}
 dev{{dynamic_multisynaptic_idx}}.copy_from_host(
-    {{dynamic_multisynaptic_idx}}.empty() ? nullptr : {{dynamic_multisynaptic_idx}}.data(),
+    {{dynamic_multisynaptic_idx}}.data(),
     {{dynamic_multisynaptic_idx}}.size());
 {% endif %}
 CUDA_SAFE_CALL(

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -119,17 +119,22 @@ for (int _i=0; _i<newsize; _i++)
         {% endif %}
     }
 }
-{% set Nin = array_basename(_dynamic_N_incoming) %}
-{% set Nout = array_basename(_dynamic_N_outgoing) %}
-{% set Npre = array_basename(_dynamic__synaptic_pre) %}
-{% set Npost = array_basename(_dynamic__synaptic_post) %}
-copy_host_to_dev_array_{{ Nin }}();
-copy_host_to_dev_array_{{ Nout }}();
-copy_host_to_dev_array_{{ Npre }}();
-copy_host_to_dev_array_{{ Npost }}();
+dev{{_dynamic_N_incoming}}.copy_from_host(
+    {{_dynamic_N_incoming}}.empty() ? nullptr : {{_dynamic_N_incoming}}.data(),
+    {{_dynamic_N_incoming}}.size());
+dev{{_dynamic_N_outgoing}}.copy_from_host(
+    {{_dynamic_N_outgoing}}.empty() ? nullptr : {{_dynamic_N_outgoing}}.data(),
+    {{_dynamic_N_outgoing}}.size());
+dev{{_dynamic__synaptic_pre}}.copy_from_host(
+    {{_dynamic__synaptic_pre}}.empty() ? nullptr : {{_dynamic__synaptic_pre}}.data(),
+    {{_dynamic__synaptic_pre}}.size());
+dev{{_dynamic__synaptic_post}}.copy_from_host(
+    {{_dynamic__synaptic_post}}.empty() ? nullptr : {{_dynamic__synaptic_post}}.data(),
+    {{_dynamic__synaptic_post}}.size());
 {% if multisynaptic_index %}
-{% set Nms = array_basename(dynamic_multisynaptic_idx) %}
-copy_host_to_dev_array_{{ Nms }}();
+dev{{dynamic_multisynaptic_idx}}.copy_from_host(
+    {{dynamic_multisynaptic_idx}}.empty() ? nullptr : {{dynamic_multisynaptic_idx}}.data(),
+    {{dynamic_multisynaptic_idx}}.size());
 {% endif %}
 CUDA_SAFE_CALL(
         cudaMemcpy(dev{{get_array_name(variables['N'], access_data=False)}},

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -13,6 +13,7 @@
 #include<brianlib/curand_buffer.h>
 #include "rand.h"
 #include<map>
+#include<set>
 {% endblock extra_headers %}
 
 {% block random_functions %}

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -398,11 +398,10 @@ std::cout << std::endl;
     const int32_t newsize = {{_dynamic__synaptic_pre}}.size();
     {% for variable in owner._registered_variables | sort(attribute='name') %}
         {% set varname = get_array_name(variable, access_data=False) %}
-        {% set N = array_basename(varname) %}
         {% if variable.name == 'delay' and no_or_const_delay_mode %}
             assert(dev{{ varname }}.size() <= 1);
             {{varname}}.resize(1);
-            resize_dev_array_{{ N }}(1);
+            dev{{ varname }}.resize(1);
         {% elif variable.name == '_synaptic_pre' and no_pre_references %}
         // prefs['devices.cuda_standalone.no_pre_references'] was set,
         // skipping synaptic_pre resize
@@ -412,7 +411,7 @@ std::cout << std::endl;
         {% else %}
             {% if not multisynaptic_index or not variable == multisynaptic_idx_var %}
             {{varname}}.resize(newsize);
-            resize_dev_array_{{ N }}(newsize);
+            dev{{varname}}.resize(newsize);
             {% else %}
             {{varname}}.resize(newsize);
             {% endif %}

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -11,9 +11,8 @@
 {{ super() }}
 #include<iostream>
 #include<brianlib/curand_buffer.h>
-#include "brianlib/cuda_utils.h"
+#include "rand.h"
 #include<map>
-#include<set>
 {% endblock extra_headers %}
 
 {% block random_functions %}

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -171,8 +171,8 @@ std::cout << std::endl;
     constants or scalar arrays#}
     const size_t _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
     const size_t _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
-    resize_host_array_{{ array_basename(_dynamic_N_incoming) }}(_N_post + _target_offset);
-    resize_host_array_{{ array_basename(_dynamic_N_outgoing) }}(_N_pre + _source_offset);
+    {{_dynamic_N_incoming}}.resize(_N_post + _target_offset);
+    {{_dynamic_N_outgoing}}.resize(_N_pre + _source_offset);
 
     size_t _raw_pre_idx, _raw_post_idx;
     {# For a connect call j='k+i for k in range(0, N_post, 2) if k+i < N_post'
@@ -388,22 +388,22 @@ std::cout << std::endl;
             {{vector_code['update']|autoindent}}
 
             for (size_t _repetition=0; _repetition<_n; _repetition++) {
-                host_array_{{ array_basename(_dynamic_N_outgoing) }}[_pre_idx] += 1;
-                host_array_{{ array_basename(_dynamic_N_incoming) }}[_post_idx] += 1;
-                push_back_host_array_{{ array_basename(_dynamic__synaptic_pre) }}(_pre_idx);
-                push_back_host_array_{{ array_basename(_dynamic__synaptic_post) }}(_post_idx);
+                {{_dynamic_N_outgoing}}[_pre_idx] += 1;
+                {{_dynamic_N_incoming}}[_post_idx] += 1;
+                {{_dynamic__synaptic_pre}}.push_back(_pre_idx);
+                {{_dynamic__synaptic_post}}.push_back(_post_idx);
             }
         }
     }
 
-    // now we need to resize all registered variables
-    const int32_t newsize = _num_host_array_{{ array_basename(_dynamic__synaptic_pre) }};
+    const int32_t newsize = {{_dynamic__synaptic_pre}}.size();
     {% for variable in owner._registered_variables | sort(attribute='name') %}
         {% set varname = get_array_name(variable, access_data=False) %}
+        {% set N = array_basename(varname) %}
         {% if variable.name == 'delay' and no_or_const_delay_mode %}
-            assert(_num_dev_array_{{ array_basename(varname) }} <= 1);
-            resize_dev_array_{{ array_basename(varname) }}(1);
-            resize_host_array_{{ array_basename(varname) }}(1);
+            assert(_num_dev_array_{{ N }} <= 1);
+            {{varname}}.resize(1);
+            resize_dev_array_{{ N }}(1);
         {% elif variable.name == '_synaptic_pre' and no_pre_references %}
         // prefs['devices.cuda_standalone.no_pre_references'] was set,
         // skipping synaptic_pre resize
@@ -412,10 +412,10 @@ std::cout << std::endl;
         // skipping synaptic_post resize
         {% else %}
             {% if not multisynaptic_index or not variable == multisynaptic_idx_var %}
-            resize_dev_array_{{ array_basename(varname) }}(newsize);
-            resize_host_array_{{ array_basename(varname) }}(newsize);
+            {{varname}}.resize(newsize);
+            resize_dev_array_{{ N }}(newsize);
             {% else %}
-            resize_host_array_{{ array_basename(varname) }}(newsize);
+            {{varname}}.resize(newsize);
             {% endif %}
         {% endif %}
     {% endfor %}
@@ -429,12 +429,12 @@ std::cout << std::endl;
         // Note that source_target_count will create a new entry initialized
         // with 0 when the key does not exist yet
         const std::pair<int32_t, int32_t> source_target = std::pair<int32_t, int32_t>(
-                host_array_{{ array_basename(_dynamic__synaptic_pre) }}[_i],
-                host_array_{{ array_basename(_dynamic__synaptic_post) }}[_i]);
+                {{_dynamic__synaptic_pre}}[_i],
+                {{_dynamic__synaptic_post}}[_i]);
         {% if multisynaptic_index %}
         // Save the "synapse number"
         {% set dynamic_multisynaptic_idx = get_array_name(multisynaptic_idx_var, access_data=False) %}
-        host_array_{{ array_basename(dynamic_multisynaptic_idx) }}[_i] = source_target_count[source_target];
+        {{dynamic_multisynaptic_idx}}[_i] = source_target_count[source_target];
         {% endif %}
         source_target_count[source_target]++;
         //printf("source target count = %i\n", source_target_count[source_target]);
@@ -447,14 +447,19 @@ std::cout << std::endl;
         }
     }
 
-    // copy changed host data to device
-    copy_host_to_dev_array_{{ array_basename(_dynamic_N_incoming) }}();
-    copy_host_to_dev_array_{{ array_basename(_dynamic_N_outgoing) }}();
-    copy_host_to_dev_array_{{ array_basename(_dynamic__synaptic_pre) }}();
-    copy_host_to_dev_array_{{ array_basename(_dynamic__synaptic_post) }}();
+    {% set Nin = array_basename(_dynamic_N_incoming) %}
+    {% set Nout = array_basename(_dynamic_N_outgoing) %}
+    {% set Npre = array_basename(_dynamic__synaptic_pre) %}
+    {% set Npost = array_basename(_dynamic__synaptic_post) %}
+    copy_host_to_dev_array_{{ Nin }}();
+    copy_host_to_dev_array_{{ Nout }}();
+    copy_host_to_dev_array_{{ Npre }}();
+    copy_host_to_dev_array_{{ Npost }}();
     {% if multisynaptic_index %}
-    copy_host_to_dev_array_{{ array_basename(dynamic_multisynaptic_idx) }}();
+    {% set Nms = array_basename(dynamic_multisynaptic_idx) %}
+    copy_host_to_dev_array_{{ Nms }}();
     {% endif %}
+    sync_all_dev_ptrs();
     CUDA_SAFE_CALL(
             cudaMemcpy(dev{{get_array_name(variables['N'], access_data=False)}},
                 {{get_array_name(variables['N'], access_data=False)}},

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -400,7 +400,7 @@ std::cout << std::endl;
         {% set varname = get_array_name(variable, access_data=False) %}
         {% set N = array_basename(varname) %}
         {% if variable.name == 'delay' and no_or_const_delay_mode %}
-            assert(_num_dev_array_{{ N }} <= 1);
+            assert(dev{{ varname }}.size() <= 1);
             {{varname}}.resize(1);
             resize_dev_array_{{ N }}(1);
         {% elif variable.name == '_synaptic_pre' and no_pre_references %}
@@ -458,7 +458,6 @@ std::cout << std::endl;
     {% set Nms = array_basename(dynamic_multisynaptic_idx) %}
     copy_host_to_dev_array_{{ Nms }}();
     {% endif %}
-    sync_all_dev_ptrs();
     CUDA_SAFE_CALL(
             cudaMemcpy(dev{{get_array_name(variables['N'], access_data=False)}},
                 {{get_array_name(variables['N'], access_data=False)}},

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -399,7 +399,7 @@ std::cout << std::endl;
     {% for variable in owner._registered_variables | sort(attribute='name') %}
         {% set varname = get_array_name(variable, access_data=False) %}
         {% if variable.name == 'delay' and no_or_const_delay_mode %}
-            assert(dev{{ varname }}.size() <= 1);
+            assert(dev{{varname}}.size() <= 1);
             {{varname}}.resize(1);
             dev{{ varname }}.resize(1);
         {% elif variable.name == '_synaptic_pre' and no_pre_references %}

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -9,7 +9,6 @@
 
 {% block extra_headers %}
 {{ super() }}
-#include "objects_api.h"
 #include<iostream>
 #include<brianlib/curand_buffer.h>
 #include "brianlib/cuda_utils.h"

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -9,10 +9,12 @@
 
 {% block extra_headers %}
 {{ super() }}
+#include "objects_api.h"
 #include<iostream>
 #include<brianlib/curand_buffer.h>
-#include "rand.h"
+#include "brianlib/cuda_utils.h"
 #include<map>
+#include<set>
 {% endblock extra_headers %}
 
 {% block random_functions %}
@@ -169,8 +171,8 @@ std::cout << std::endl;
     constants or scalar arrays#}
     const size_t _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
     const size_t _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
-    {{_dynamic_N_incoming}}.resize(_N_post + _target_offset);
-    {{_dynamic_N_outgoing}}.resize(_N_pre + _source_offset);
+    resize_host_array_{{ array_basename(_dynamic_N_incoming) }}(_N_post + _target_offset);
+    resize_host_array_{{ array_basename(_dynamic_N_outgoing) }}(_N_pre + _source_offset);
 
     size_t _raw_pre_idx, _raw_post_idx;
     {# For a connect call j='k+i for k in range(0, N_post, 2) if k+i < N_post'
@@ -259,7 +261,7 @@ std::cout << std::endl;
             {% if skip_if_invalid %}
             _uiter_size = _n_total;
             {% else %}
-            cout << "Error: Requested sample size " << _uiter_size << " is bigger than the " <<
+            std::cout << "Error: Requested sample size " << _uiter_size << " is bigger than the " <<
                     "population size " << _n_total << "." << std::endl;
             exit(1);
             {% endif %}
@@ -268,7 +270,7 @@ std::cout << std::endl;
             {% if skip_if_invalid %}
             continue;
             {% else %}
-            cout << "Error: Requested sample size " << _uiter_size << " is negative." << std::endl;
+            std::cout << "Error: Requested sample size " << _uiter_size << " is negative." << std::endl;
             exit(1);
             {% endif %}
         } else if (_uiter_size == 0)
@@ -351,7 +353,7 @@ std::cout << std::endl;
                     {% if skip_if_invalid %}
                     continue;
                     {% else %}
-                    cout << "Error: tried to create synapse to neuron {{result_index}}=" << _{{result_index}} << " outside range 0 to " <<
+                    std::cout << "Error: tried to create synapse to neuron {{result_index}}=" << _{{result_index}} << " outside range 0 to " <<
                                             _{{result_index_size}}-1 << std::endl;
                     exit(1);
                     {% endif %}
@@ -375,7 +377,7 @@ std::cout << std::endl;
                 {% if skip_if_invalid %}
                 continue;
                 {% else %}
-                cout << "Error: tried to create synapse to neuron {{result_index}}=" << _{{result_index}} <<
+                std::cout << "Error: tried to create synapse to neuron {{result_index}}=" << _{{result_index}} <<
                         " outside range 0 to " << _{{result_index_size}}-1 << std::endl;
                 exit(1);
                 {% endif %}
@@ -386,25 +388,22 @@ std::cout << std::endl;
             {{vector_code['update']|autoindent}}
 
             for (size_t _repetition=0; _repetition<_n; _repetition++) {
-                {{_dynamic_N_outgoing}}[_pre_idx] += 1;
-                {{_dynamic_N_incoming}}[_post_idx] += 1;
-                {{_dynamic__synaptic_pre}}.push_back(_pre_idx);
-                {{_dynamic__synaptic_post}}.push_back(_post_idx);
+                host_array_{{ array_basename(_dynamic_N_outgoing) }}[_pre_idx] += 1;
+                host_array_{{ array_basename(_dynamic_N_incoming) }}[_post_idx] += 1;
+                push_back_host_array_{{ array_basename(_dynamic__synaptic_pre) }}(_pre_idx);
+                push_back_host_array_{{ array_basename(_dynamic__synaptic_post) }}(_post_idx);
             }
         }
     }
 
     // now we need to resize all registered variables
-    const int32_t newsize = {{_dynamic__synaptic_pre}}.size();
+    const int32_t newsize = _num_host_array_{{ array_basename(_dynamic__synaptic_pre) }};
     {% for variable in owner._registered_variables | sort(attribute='name') %}
         {% set varname = get_array_name(variable, access_data=False) %}
         {% if variable.name == 'delay' and no_or_const_delay_mode %}
-            assert(dev{{varname}}.size() <= 1);
-            THRUST_CHECK_ERROR(
-                    dev{{varname}}.resize(1)
-                    );
-            {# //TODO: do we actually need to resize varname? #}
-            {{varname}}.resize(1);
+            assert(_num_dev_array_{{ array_basename(varname) }} <= 1);
+            resize_dev_array_{{ array_basename(varname) }}(1);
+            resize_host_array_{{ array_basename(varname) }}(1);
         {% elif variable.name == '_synaptic_pre' and no_pre_references %}
         // prefs['devices.cuda_standalone.no_pre_references'] was set,
         // skipping synaptic_pre resize
@@ -413,12 +412,11 @@ std::cout << std::endl;
         // skipping synaptic_post resize
         {% else %}
             {% if not multisynaptic_index or not variable == multisynaptic_idx_var %}
-            THRUST_CHECK_ERROR(
-                    dev{{varname}}.resize(newsize)
-                    );
+            resize_dev_array_{{ array_basename(varname) }}(newsize);
+            resize_host_array_{{ array_basename(varname) }}(newsize);
+            {% else %}
+            resize_host_array_{{ array_basename(varname) }}(newsize);
             {% endif %}
-            {# //TODO: do we actually need to resize varname? #}
-            {{varname}}.resize(newsize);
         {% endif %}
     {% endfor %}
     // Also update the total number of synapses
@@ -430,11 +428,13 @@ std::cout << std::endl;
     {
         // Note that source_target_count will create a new entry initialized
         // with 0 when the key does not exist yet
-        const std::pair<int32_t, int32_t> source_target = std::pair<int32_t, int32_t>({{_dynamic__synaptic_pre}}[_i], {{_dynamic__synaptic_post}}[_i]);
+        const std::pair<int32_t, int32_t> source_target = std::pair<int32_t, int32_t>(
+                host_array_{{ array_basename(_dynamic__synaptic_pre) }}[_i],
+                host_array_{{ array_basename(_dynamic__synaptic_post) }}[_i]);
         {% if multisynaptic_index %}
         // Save the "synapse number"
         {% set dynamic_multisynaptic_idx = get_array_name(multisynaptic_idx_var, access_data=False) %}
-        {{dynamic_multisynaptic_idx}}[_i] = source_target_count[source_target];
+        host_array_{{ array_basename(dynamic_multisynaptic_idx) }}[_i] = source_target_count[source_target];
         {% endif %}
         source_target_count[source_target]++;
         //printf("source target count = %i\n", source_target_count[source_target]);
@@ -448,12 +448,12 @@ std::cout << std::endl;
     }
 
     // copy changed host data to device
-    dev{{_dynamic_N_incoming}} = {{_dynamic_N_incoming}};
-    dev{{_dynamic_N_outgoing}} = {{_dynamic_N_outgoing}};
-    dev{{_dynamic__synaptic_pre}} = {{_dynamic__synaptic_pre}};
-    dev{{_dynamic__synaptic_post}} = {{_dynamic__synaptic_post}};
+    copy_host_to_dev_array_{{ array_basename(_dynamic_N_incoming) }}();
+    copy_host_to_dev_array_{{ array_basename(_dynamic_N_outgoing) }}();
+    copy_host_to_dev_array_{{ array_basename(_dynamic__synaptic_pre) }}();
+    copy_host_to_dev_array_{{ array_basename(_dynamic__synaptic_post) }}();
     {% if multisynaptic_index %}
-    dev{{dynamic_multisynaptic_idx}} = {{dynamic_multisynaptic_idx}};
+    copy_host_to_dev_array_{{ array_basename(dynamic_multisynaptic_idx) }}();
     {% endif %}
     CUDA_SAFE_CALL(
             cudaMemcpy(dev{{get_array_name(variables['N'], access_data=False)}},

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -446,20 +446,20 @@ std::cout << std::endl;
     }
 
     dev{{_dynamic_N_incoming}}.copy_from_host(
-        {{_dynamic_N_incoming}}.empty() ? nullptr : {{_dynamic_N_incoming}}.data(),
+        {{_dynamic_N_incoming}}.data(),
         {{_dynamic_N_incoming}}.size());
     dev{{_dynamic_N_outgoing}}.copy_from_host(
-        {{_dynamic_N_outgoing}}.empty() ? nullptr : {{_dynamic_N_outgoing}}.data(),
+        {{_dynamic_N_outgoing}}.data(),
         {{_dynamic_N_outgoing}}.size());
     dev{{_dynamic__synaptic_pre}}.copy_from_host(
-        {{_dynamic__synaptic_pre}}.empty() ? nullptr : {{_dynamic__synaptic_pre}}.data(),
+        {{_dynamic__synaptic_pre}}.data(),
         {{_dynamic__synaptic_pre}}.size());
     dev{{_dynamic__synaptic_post}}.copy_from_host(
-        {{_dynamic__synaptic_post}}.empty() ? nullptr : {{_dynamic__synaptic_post}}.data(),
+        {{_dynamic__synaptic_post}}.data(),
         {{_dynamic__synaptic_post}}.size());
     {% if multisynaptic_index %}
     dev{{dynamic_multisynaptic_idx}}.copy_from_host(
-        {{dynamic_multisynaptic_idx}}.empty() ? nullptr : {{dynamic_multisynaptic_idx}}.data(),
+        {{dynamic_multisynaptic_idx}}.data(),
         {{dynamic_multisynaptic_idx}}.size());
     {% endif %}
     CUDA_SAFE_CALL(

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -445,17 +445,22 @@ std::cout << std::endl;
         }
     }
 
-    {% set Nin = array_basename(_dynamic_N_incoming) %}
-    {% set Nout = array_basename(_dynamic_N_outgoing) %}
-    {% set Npre = array_basename(_dynamic__synaptic_pre) %}
-    {% set Npost = array_basename(_dynamic__synaptic_post) %}
-    copy_host_to_dev_array_{{ Nin }}();
-    copy_host_to_dev_array_{{ Nout }}();
-    copy_host_to_dev_array_{{ Npre }}();
-    copy_host_to_dev_array_{{ Npost }}();
+    dev{{_dynamic_N_incoming}}.copy_from_host(
+        {{_dynamic_N_incoming}}.empty() ? nullptr : {{_dynamic_N_incoming}}.data(),
+        {{_dynamic_N_incoming}}.size());
+    dev{{_dynamic_N_outgoing}}.copy_from_host(
+        {{_dynamic_N_outgoing}}.empty() ? nullptr : {{_dynamic_N_outgoing}}.data(),
+        {{_dynamic_N_outgoing}}.size());
+    dev{{_dynamic__synaptic_pre}}.copy_from_host(
+        {{_dynamic__synaptic_pre}}.empty() ? nullptr : {{_dynamic__synaptic_pre}}.data(),
+        {{_dynamic__synaptic_pre}}.size());
+    dev{{_dynamic__synaptic_post}}.copy_from_host(
+        {{_dynamic__synaptic_post}}.empty() ? nullptr : {{_dynamic__synaptic_post}}.data(),
+        {{_dynamic__synaptic_post}}.size());
     {% if multisynaptic_index %}
-    {% set Nms = array_basename(dynamic_multisynaptic_idx) %}
-    copy_host_to_dev_array_{{ Nms }}();
+    dev{{dynamic_multisynaptic_idx}}.copy_from_host(
+        {{dynamic_multisynaptic_idx}}.empty() ? nullptr : {{dynamic_multisynaptic_idx}}.data(),
+        {{dynamic_multisynaptic_idx}}.size());
     {% endif %}
     CUDA_SAFE_CALL(
             cudaMemcpy(dev{{get_array_name(variables['N'], access_data=False)}},

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -46,6 +46,7 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#include "brianlib/host_algorithms.h"
 {% endblock before_run_headers %}
 
 {% block extra_headers %}
@@ -116,46 +117,6 @@ namespace {
         memory_recorder.push_back(std::make_tuple(name, bytes, num_elements));
     }
 
-    void sort_by_key_int_int32(int* keys, int32_t* values, size_t n)
-    {
-        if (n <= 1)
-            return;
-        std::vector<std::pair<int, int32_t> > zipped(n);
-        for (size_t i = 0; i < n; ++i)
-            zipped[i] = std::pair<int, int32_t>(keys[i], values[i]);
-        std::sort(zipped.begin(), zipped.end(),
-                  [](const std::pair<int, int32_t>& a,
-                     const std::pair<int, int32_t>& b) {
-                      return a.first < b.first;
-                  });
-        for (size_t i = 0; i < n; ++i)
-        {
-            keys[i] = zipped[i].first;
-            values[i] = zipped[i].second;
-        }
-    }
-
-    void fill_sequence_int(int* out, size_t n)
-    {
-        std::iota(out, out + n, 0);
-    }
-
-    size_t unique_by_key_int_int(int* keys, int* values, size_t n)
-    {
-        if (n == 0)
-            return 0;
-        size_t out_n = 1;
-        for (size_t i = 1; i < n; ++i)
-        {
-            if (keys[i] != keys[out_n - 1])
-            {
-                keys[out_n] = keys[i];
-                values[out_n] = values[i];
-                ++out_n;
-            }
-        }
-        return out_n;
-    }
 }
 
 
@@ -498,7 +459,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
             // start indices in the synapses array for each unique delay
 
             // sort synapses (values) and delays (keys) by delay
-            sort_by_key_int_int32(
+            brian::sort_by_key(
                     h_vec_delays_by_pre[i].data(),     // keys start
                     h_vec_synapse_ids_by_pre[i].data(), // values start
                     num_elements);
@@ -507,15 +468,16 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
             h_vec_unique_delay_start_idcs_by_pre[i].resize(num_elements);
 
             // Initialise the unique delay start idcs array as a sequence
-            fill_sequence_int(
+            std::iota(
                     h_vec_unique_delay_start_idcs_by_pre[i].data(),
-                    num_elements);
+                    h_vec_unique_delay_start_idcs_by_pre[i].data() + num_elements,
+                    0);
 
             // get delays (keys) and values (indices) for first occurence of each delay value
-            size_t num_unique_elements = unique_by_key_int_int(
+            int num_unique_elements = static_cast<int>(brian::unique_by_key(
                     h_vec_delays_by_pre[i].data(),                 // keys start
                     h_vec_unique_delay_start_idcs_by_pre[i].data(), // values start (position in original delay array)
-                    num_elements);
+                    num_elements));
 
             // erase unneded vector entries
             h_vec_unique_delay_start_idcs_by_pre[i].resize(num_unique_elements);

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -42,6 +42,7 @@
 #include <chrono>
 #include <climits>
 #include <cmath>
+#include <numeric>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -113,6 +114,47 @@ namespace {
                 cudaMemcpyToSymbol(device_symbol, &device_array, sizeof(T*)),
                 file, line, "cudaMemcpyToSymbol");
         memory_recorder.push_back(std::make_tuple(name, bytes, num_elements));
+    }
+
+    void sort_by_key_int_int32(int* keys, int32_t* values, size_t n)
+    {
+        if (n <= 1)
+            return;
+        std::vector<std::pair<int, int32_t> > zipped(n);
+        for (size_t i = 0; i < n; ++i)
+            zipped[i] = std::pair<int, int32_t>(keys[i], values[i]);
+        std::sort(zipped.begin(), zipped.end(),
+                  [](const std::pair<int, int32_t>& a,
+                     const std::pair<int, int32_t>& b) {
+                      return a.first < b.first;
+                  });
+        for (size_t i = 0; i < n; ++i)
+        {
+            keys[i] = zipped[i].first;
+            values[i] = zipped[i].second;
+        }
+    }
+
+    void fill_sequence_int(int* out, size_t n)
+    {
+        std::iota(out, out + n, 0);
+    }
+
+    size_t unique_by_key_int_int(int* keys, int* values, size_t n)
+    {
+        if (n == 0)
+            return 0;
+        size_t out_n = 1;
+        for (size_t i = 1; i < n; ++i)
+        {
+            if (keys[i] != keys[out_n - 1])
+            {
+                keys[out_n] = keys[i];
+                values[out_n] = values[i];
+                ++out_n;
+            }
+        }
+        return out_n;
     }
 }
 

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -1018,7 +1018,7 @@ _run_kernel_{{codeobj_name}}(
 {% block host_maincode %}
     if ({{owner.name}}_scalar_delay)
     {
-        int num_eventspaces = _num_dev{{ _eventspace }};
+        int num_eventspaces = static_cast<int>(dev{{ _eventspace }}.size());
         {{owner.name}}_eventspace_idx = (current_idx{{_eventspace}} - {{owner.name}}_delay + num_eventspaces) % num_eventspaces;
 
         //////////////////////////////////////////////
@@ -1032,7 +1032,7 @@ _run_kernel_{{codeobj_name}}(
         int32_t num_spiking_neurons;
         CUDA_SAFE_CALL(
                 cudaMemcpy(&num_spiking_neurons,
-                    dev{{ _eventspace }}_view[current_idx{{ _eventspace }}] + _num_{{ owner.event }}space - 1,
+                    dev{{ _eventspace }}[current_idx{{ _eventspace }}] + _num_{{ owner.event }}space - 1,
                     sizeof(int32_t), cudaMemcpyDeviceToHost)
                 );
 
@@ -1085,7 +1085,7 @@ _run_kernel_{{codeobj_name}}(
                     num_parallel_blocks,
                     num_blocks,
                     num_threads,
-                    dev{{ _eventspace }}_view[current_idx{{ _eventspace }}]);
+                    dev{{ _eventspace }}[current_idx{{ _eventspace }}]);
 
             CUDA_CHECK_ERROR("_run_kernel_{{codeobj_name}}");
         }

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -36,7 +36,6 @@
  #}
 {% block before_run_headers %}
 {{ super() }}
-#include "objects_api.h"
 #include "synapses_classes.h"
 #include "brianlib/spikequeue.h"
 #include <algorithm>

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -35,20 +35,23 @@
  # sorted by their delay (if they have any).
  #}
 {% block before_run_headers %}
-#include <thrust/sort.h>
-#include <thrust/reduce.h>
-#include <thrust/unique.h>
-#include <iostream>
-#include <ctime>
-#include <limits.h>
-#include <tuple>
+{{ super() }}
+#include "objects_api.h"
+#include "synapses_classes.h"
+#include "brianlib/spikequeue.h"
+#include <algorithm>
+#include <chrono>
+#include <climits>
+#include <cmath>
 #include <string>
-#include <iomanip>
+#include <tuple>
 #include <vector>
-#include "objects.h"
-#include "code_objects/{{codeobj_name}}.h"
-#include "brianlib/cuda_utils.h"
 {% endblock before_run_headers %}
+
+{% block extra_headers %}
+#include "synapses_classes.h"
+#include "brianlib/spikequeue.h"
+{% endblock %}
 
 
 {% block before_run_defines %}
@@ -57,8 +60,7 @@
     _copyHostArrayToDeviceSymbol(a, b, c, d, e, __FILE__, __LINE__)
 
 namespace {
-    // vector_t<T> is an alias for thrust:host_vector<T>
-    template <typename T> using vector_t = thrust::host_vector<T>;
+    template <typename T> using vector_t = std::vector<T>;
     // tuple type typedef
     typedef std::tuple<std::string, size_t, int> tuple_t;
 
@@ -315,7 +317,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
 
 
     //fill vectors of connectivity matrix with synapse IDs and delays (in units of simulation time step)
-    int max_delay = (int)({{_dynamic_delay}}[0] / dt + 0.5);
+    int max_delay = (int)(host_array_{{ array_basename(_dynamic_delay) }}[0] / dt + 0.5);
     {% if not no_or_const_delay_mode %}
     int min_delay = max_delay;
     {% endif %}
@@ -368,11 +370,11 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
         // be NOT equal to the idx in their NeuronGroup
         {% set source_ids = get_array_name(owner.synapse_sources, access_data=False) %}
         {% set target_ids = get_array_name(owner.synapse_targets, access_data=False) %}
-        int32_t pre_neuron_id = {{source_ids}}[syn_id] - {{source_offset}};
-        int32_t post_neuron_id = {{target_ids}}[syn_id] - {{target_offset}};
+        int32_t pre_neuron_id = host_array_{{ array_basename(source_ids) }}[syn_id] - {{source_offset}};
+        int32_t post_neuron_id = host_array_{{ array_basename(target_ids) }}[syn_id] - {{target_offset}};
 
         {% if not no_or_const_delay_mode %}
-        int delay = (int)({{_dynamic_delay}}[syn_id] / dt + 0.5);
+        int delay = (int)(host_array_{{ array_basename(_dynamic_delay) }}[syn_id] / dt + 0.5);
         if (delay > max_delay)
             max_delay = delay;
         if (delay < min_delay)
@@ -454,44 +456,34 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
             // reduce the delay arrays to unique delays and store the
             // start indices in the synapses array for each unique delay
 
-            typedef vector_t<int>::iterator itr;
-
             // sort synapses (values) and delays (keys) by delay
-            thrust::sort_by_key(
-                    h_vec_delays_by_pre[i].begin(),     // keys start
-                    h_vec_delays_by_pre[i].end(),       // keys end
-                    h_vec_synapse_ids_by_pre[i].begin() // values start
-                    );
+            sort_by_key_int_int32(
+                    h_vec_delays_by_pre[i].data(),     // keys start
+                    h_vec_synapse_ids_by_pre[i].data(), // values start
+                    num_elements);
 
             // worst case: number of unique delays is num_elements
             h_vec_unique_delay_start_idcs_by_pre[i].resize(num_elements);
 
             // Initialise the unique delay start idcs array as a sequence
-            thrust::sequence(h_vec_unique_delay_start_idcs_by_pre[i].begin(),
-                    h_vec_unique_delay_start_idcs_by_pre[i].end());
+            fill_sequence_int(
+                    h_vec_unique_delay_start_idcs_by_pre[i].data(),
+                    num_elements);
 
             // get delays (keys) and values (indices) for first occurence of each delay value
-            thrust::pair<itr, itr> end_pair = thrust::unique_by_key(
-                    h_vec_delays_by_pre[i].begin(),                 // keys start
-                    h_vec_delays_by_pre[i].end(),                   // keys end
-                    h_vec_unique_delay_start_idcs_by_pre[i].begin() // values start (position in original delay array)
-                    );
-
-            itr unique_delay_end = end_pair.first;
-            itr idx_end = end_pair.second;
+            size_t num_unique_elements = unique_by_key_int_int(
+                    h_vec_delays_by_pre[i].data(),                 // keys start
+                    h_vec_unique_delay_start_idcs_by_pre[i].data(), // values start (position in original delay array)
+                    num_elements);
 
             // erase unneded vector entries
-            h_vec_unique_delay_start_idcs_by_pre[i].erase(
-                    idx_end, h_vec_unique_delay_start_idcs_by_pre[i].end());
+            h_vec_unique_delay_start_idcs_by_pre[i].resize(num_unique_elements);
             // free not used but allocated host memory
             h_vec_unique_delay_start_idcs_by_pre[i].shrink_to_fit();
-            h_vec_delays_by_pre[i].erase(unique_delay_end,
-                    h_vec_delays_by_pre[i].end());
+            h_vec_delays_by_pre[i].resize(num_unique_elements);
             // delay_by_pre holds the set of unique delays now
             // we don't need shrink_to_fit, swap takes care of that
             h_vec_unique_delays_by_pre[i].swap(h_vec_delays_by_pre[i]);
-
-            int num_unique_elements = h_vec_unique_delays_by_pre[i].size();
             sum_num_unique_elements += num_unique_elements;
 
             if (num_unique_elements > {{owner.name}}_max_num_unique_delays)
@@ -532,7 +524,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
 
                 // copy this bundle to device and store the device pointer
                 int32_t* d_this_bundle = d_ptr_synapse_ids + sum_bundle_sizes;
-                int32_t* h_this_bundle = thrust::raw_pointer_cast(&h_vec_synapse_ids_by_pre[i][synapses_start_idx]);
+                int32_t* h_this_bundle = &h_vec_synapse_ids_by_pre[i][synapses_start_idx];
                 size_t memory_size = sizeof(int32_t) * num_synapses;
                 CUDA_SAFE_CALL(
                         cudaMemcpy(d_this_bundle, h_this_bundle, memory_size, cudaMemcpyHostToDevice)
@@ -564,7 +556,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
             h_ptr_d_ptr_synapse_ids_by_pre[i] = d_ptr_synapse_ids + sum_num_elements;
             CUDA_SAFE_CALL(
                     cudaMemcpy(h_ptr_d_ptr_synapse_ids_by_pre[i],
-                        thrust::raw_pointer_cast(&(h_vec_synapse_ids_by_pre[i][0])),
+                        h_vec_synapse_ids_by_pre[i].data(),
                         sizeof(int32_t) * num_elements,
                         cudaMemcpyHostToDevice)
                     );
@@ -665,8 +657,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
                 CUDA_SAFE_CALL(
                         cudaMemcpy(d_ptr_unique_delays
                                        + sum_num_unique_elements,
-                                   thrust::raw_pointer_cast(
-                                       &(h_vec_unique_delays_by_pre[i][0])),
+                                   h_vec_unique_delays_by_pre[i].data(),
                                    sizeof(int)*num_unique_elements,
                                    cudaMemcpyHostToDevice)
                         );
@@ -677,7 +668,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
                 // copy the unique delays start indices to the device
                 CUDA_SAFE_CALL(
                         cudaMemcpy(d_ptr_unique_delay_start_idcs + sum_num_unique_elements,
-                                   thrust::raw_pointer_cast(&(h_vec_unique_delay_start_idcs_by_pre[i][0])),
+                                   h_vec_unique_delay_start_idcs_by_pre[i].data(),
                                    sizeof(int)*num_unique_elements,
                                    cudaMemcpyHostToDevice)
                         );
@@ -719,13 +710,13 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
         }
         // size by bundle
         COPY_HOST_ARRAY_TO_DEVICE_SYMBOL(d_ptr_num_synapses_by_bundle,
-                thrust::raw_pointer_cast(&h_num_synapses_by_bundle[0]),
+                h_num_synapses_by_bundle.data(),
                 {{owner.name}}_num_synapses_by_bundle, num_bundle_ids,
                 "number of synapses per bundle");
 
         // synapses offset by bundle
         COPY_HOST_ARRAY_TO_DEVICE_SYMBOL(d_ptr_synapses_offset_by_bundle,
-                thrust::raw_pointer_cast(&h_synapses_offset_by_bundle[0]),
+                h_synapses_offset_by_bundle.data(),
                 {{owner.name}}_synapses_offset_by_bundle, num_bundle_ids,
                 "synapses bundle offset");
 
@@ -774,20 +765,15 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
 
     // sum all allocated memory
     size_t total_memory = 0;
-    int max_string_length = 0;
     for(auto const& tuple: memory_recorder){
         total_memory += std::get<1>(tuple);
-        int str_len = std::get<0>(tuple).length();
-        if (str_len > max_string_length)
-            max_string_length = str_len;
     }
     double total_memory_MB = total_memory * to_MB;
-    max_string_length += 5;
 
     // sort tuples by used memory
-    std::sort(begin(memory_recorder), end(memory_recorder),
+    std::sort(memory_recorder.begin(), memory_recorder.end(),
             [](tuple_t const &t1, tuple_t const &t2) {
-            return std::get<1>(t1) > std::get<1>(t2); // or use a custom compare function
+            return std::get<1>(t1) > std::get<1>(t2);
             }
             );
 
@@ -800,30 +786,37 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
     {% endif %}{# not no_or_const_delay_mode #}
 
     // print memory information
-    std::cout.precision(1);
-    std::cout.setf(std::ios::fixed, std::ios::floatfield);
-    std::cout << "INFO: synapse statistics and memory usage for {{owner.name}}:\n"
-        << "\tnumber of synapses: " << syn_N << "\n"
+    printf("INFO: synapse statistics and memory usage for {{owner.name}}:\n"
+        "\tnumber of synapses: %d\n"
     {% if not no_or_const_delay_mode and bundle_mode %}
-        << "\tnumber of bundles: " << num_bundle_ids << "\n"
+        "\tnumber of bundles: %d\n"
     {% endif %}
-        << "\tnumber of pre/post blocks: " << num_pre_post_blocks << "\n"
-        << "\tnumber of synapses over all pre/post blocks:\n"
-        << "\t\tmean: " << mean_num_elements << "\tstd: "
-            << std_num_elements << "\n"
+        "\tnumber of pre/post blocks: %d\n"
+        "\tnumber of synapses over all pre/post blocks:\n"
+        "\t\tmean: %.1f\tstd: %.1f\n"
     {% if not no_or_const_delay_mode %}
-        << "\tnumber of unique delays over all pre/post blocks:\n"
-        << "\t\tmean: " << mean_num_unique_elements << "\tstd: "
-            << std_num_unique_elements << "\n"
+        "\tnumber of unique delays over all pre/post blocks:\n"
+        "\t\tmean: %.1f\tstd: %.1f\n"
     {% if bundle_mode %}
-    << "\tbundle size over all bundles:\n"
-        << "\t\tmean: " << mean_bundle_sizes << "\tstd: "
-        << std_bundle_sizes << "\n"
+        "\tbundle size over all bundles:\n"
+        "\t\tmean: %.1f\tstd: %.1f\n"
     {% endif %}{# bundle_mode #}
     {% endif %}{# not no_or_const_delay_mode #}
-    << "\n\tmemory usage: TOTAL: " << total_memory_MB << " MB (~"
-        << total_memory_MB / syn_N * 1024.0 * 1024.0  << " byte per synapse)"
-        << std::endl;
+        "\n\tmemory usage: TOTAL: %.1f MB (~%.1f byte per synapse)\n",
+        syn_N,
+    {% if not no_or_const_delay_mode and bundle_mode %}
+        num_bundle_ids,
+    {% endif %}
+        num_pre_post_blocks,
+        mean_num_elements, std_num_elements,
+    {% if not no_or_const_delay_mode %}
+        mean_num_unique_elements, std_num_unique_elements,
+    {% if bundle_mode %}
+        mean_bundle_sizes, std_bundle_sizes,
+    {% endif %}{# bundle_mode #}
+    {% endif %}{# not no_or_const_delay_mode #}
+        total_memory_MB,
+        total_memory_MB / syn_N * 1024.0 * 1024.0);
 
     for(auto const& tuple: memory_recorder){
         std::string name;
@@ -832,9 +825,8 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
         std::tie(name, bytes, num_elements) = tuple;
         double memory = bytes * to_MB;
         double fraction = memory / total_memory_MB * 100;
-        std::cout << "\t\t" << std::setprecision(1) << std::fixed << fraction
-            << "%\t" << std::setprecision(3) << std::fixed << memory << " MB\t"
-            << name << " [" << num_elements << "]" << std::endl;
+        printf("\t\t%.1f%%\t%.3f MB\t%s [%d]\n",
+               fraction, memory, name.c_str(), num_elements);
     }
 
 
@@ -843,41 +835,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
     if (scalar_delay)
     {% endif %}
     {
-        int num_eventspaces = dev{{_eventspace}}.size();
-        bool require_new_eventspaces = (num_queues > num_eventspaces);
-
-        if (require_new_eventspaces)
-        {
-            // rotate circular eventspace such that the current idx is at the start
-            // (logic copied from CSpikeQueue.expand() in Brian's cspikequeue.cpp)
-            std::rotate(
-                dev{{_eventspace}}.begin(),
-                dev{{_eventspace}}.begin() + current_idx{{_eventspace}},
-                dev{{_eventspace}}.end()
-            );
-            current_idx{{_eventspace}} = 0;
-            // add new eventspaces
-            for (int i = num_eventspaces; i < num_queues; i++)
-            {
-                {{c_data_type(eventspace_variable.dtype)}}* new_eventspace;
-                CUDA_SAFE_CALL(
-                    cudaMalloc(
-                        (void**)&new_eventspace,
-                        sizeof({{c_data_type(eventspace_variable.dtype)}}) * _num_{{_eventspace}}
-                    )
-                );
-                // initialize device eventspace with -1 and counter with 0
-                CUDA_SAFE_CALL(
-                    cudaMemcpy(
-                        new_eventspace,
-                        {{_eventspace}},  // defined in objects.cu
-                        sizeof({{c_data_type(eventspace_variable.dtype)}}) * _num_{{_eventspace}},
-                        cudaMemcpyHostToDevice
-                    )
-                );
-                dev{{_eventspace}}.push_back(new_eventspace);
-            }
-        }
+        expand_eventspace{{ _eventspace }}(num_queues);
     }
 
     int num_threads = num_queues;
@@ -977,17 +935,18 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
     }
 
     CUDA_CHECK_MEMORY();
-    double time_passed = std::chrono::duration<double>(std::chrono::high_resolution_clock::now() - start_timer).count();
-    std::cout << "INFO: {{owner.name}} initialisation took " <<  time_passed << "s";
+    double time_passed = std::chrono::duration<double>(
+            std::chrono::high_resolution_clock::now() - start_timer).count();
+    printf("INFO: {{owner.name}} initialisation took %.6fs", time_passed);
     if (used_device_memory_after_dealloc < used_device_memory_start){
         size_t freed_bytes = used_device_memory_start - used_device_memory_after_dealloc;
-        std::cout << ", freed " << freed_bytes * to_MB << "MB";
+        printf(", freed %.1fMB", freed_bytes * to_MB);
     }
     if (used_device_memory > used_device_memory_start){
         size_t used_bytes = used_device_memory - used_device_memory_start;
-        std::cout << " and used " << used_bytes * to_MB << "MB of device memory.";
+        printf(" and used %.1fMB of device memory.", used_bytes * to_MB);
     }
-    std::cout << std::endl;
+    printf("\n");
 
     first_run = false;
 {% endblock before_run_host_maincode %}
@@ -1056,7 +1015,7 @@ _run_kernel_{{codeobj_name}}(
 {% block host_maincode %}
     if ({{owner.name}}_scalar_delay)
     {
-        int num_eventspaces = dev{{_eventspace}}.size();
+        int num_eventspaces = _num_dev{{ _eventspace }};
         {{owner.name}}_eventspace_idx = (current_idx{{_eventspace}} - {{owner.name}}_delay + num_eventspaces) % num_eventspaces;
 
         //////////////////////////////////////////////
@@ -1070,7 +1029,7 @@ _run_kernel_{{codeobj_name}}(
         int32_t num_spiking_neurons;
         CUDA_SAFE_CALL(
                 cudaMemcpy(&num_spiking_neurons,
-                    dev{{_eventspace}}[current_idx{{_eventspace}}] + _num_{{owner.event}}space - 1,
+                    dev{{ _eventspace }}_view[current_idx{{ _eventspace }}] + _num_{{ owner.event }}space - 1,
                     sizeof(int32_t), cudaMemcpyDeviceToHost)
                 );
 
@@ -1123,7 +1082,7 @@ _run_kernel_{{codeobj_name}}(
                     num_parallel_blocks,
                     num_blocks,
                     num_threads,
-                    dev{{_eventspace}}[current_idx{{_eventspace}}]);
+                    dev{{ _eventspace }}_view[current_idx{{ _eventspace }}]);
 
             CUDA_CHECK_ERROR("_run_kernel_{{codeobj_name}}");
         }

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -116,7 +116,6 @@ namespace {
                 file, line, "cudaMemcpyToSymbol");
         memory_recorder.push_back(std::make_tuple(name, bytes, num_elements));
     }
-
 }
 
 

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -247,7 +247,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
      * STRUCTURE: the first array dimensions structure (`by_pre`, `by_bundle` or none)
      *   `by_pre`: Array (host pointer type) of size `num_pre_post_blocks`,
      *             which is the number of (preID, postBlock) pairs.
-     *   `by_bundle`: thrust::host_vector, size of total number of bundles,
+     *   `by_bundle`: std::vector, size of total number of bundles,
      *                which is one for each delay in each (preID, postBlock) pair.
      *                Different (preID, postBlock) pairs can have different sets
      *                of delay values -> each bundle gets a global bundleID
@@ -317,7 +317,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
 
 
     //fill vectors of connectivity matrix with synapse IDs and delays (in units of simulation time step)
-    int max_delay = (int)(host_array_{{ array_basename(_dynamic_delay) }}[0] / dt + 0.5);
+    int max_delay = (int)({{_dynamic_delay}}[0] / dt + 0.5);
     {% if not no_or_const_delay_mode %}
     int min_delay = max_delay;
     {% endif %}
@@ -370,11 +370,11 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
         // be NOT equal to the idx in their NeuronGroup
         {% set source_ids = get_array_name(owner.synapse_sources, access_data=False) %}
         {% set target_ids = get_array_name(owner.synapse_targets, access_data=False) %}
-        int32_t pre_neuron_id = host_array_{{ array_basename(source_ids) }}[syn_id] - {{source_offset}};
-        int32_t post_neuron_id = host_array_{{ array_basename(target_ids) }}[syn_id] - {{target_offset}};
+        int32_t pre_neuron_id = {{source_ids}}[syn_id] - {{source_offset}};
+        int32_t post_neuron_id = {{target_ids}}[syn_id] - {{target_offset}};
 
         {% if not no_or_const_delay_mode %}
-        int delay = (int)(host_array_{{ array_basename(_dynamic_delay) }}[syn_id] / dt + 0.5);
+        int delay = (int)({{_dynamic_delay}}[syn_id] / dt + 0.5);
         if (delay > max_delay)
             max_delay = delay;
         if (delay < min_delay)

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -1031,7 +1031,7 @@ _run_kernel_{{codeobj_name}}(
         int32_t num_spiking_neurons;
         CUDA_SAFE_CALL(
                 cudaMemcpy(&num_spiking_neurons,
-                    dev{{ _eventspace }}[current_idx{{ _eventspace }}] + _num_{{ owner.event }}space - 1,
+                    dev{{_eventspace}}[current_idx{{_eventspace}}] + _num_{{owner.event}}space - 1,
                     sizeof(int32_t), cudaMemcpyDeviceToHost)
                 );
 
@@ -1084,7 +1084,7 @@ _run_kernel_{{codeobj_name}}(
                     num_parallel_blocks,
                     num_blocks,
                     num_threads,
-                    dev{{ _eventspace }}[current_idx{{ _eventspace }}]);
+                    dev{{_eventspace}}[current_idx{{_eventspace}}]);
 
             CUDA_CHECK_ERROR("_run_kernel_{{codeobj_name}}");
         }

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -837,7 +837,37 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
     if (scalar_delay)
     {% endif %}
     {
-        expand_eventspace{{ _eventspace }}(num_queues);
+        int num_eventspaces = static_cast<int>(dev{{_eventspace}}.size());
+        if (num_queues > num_eventspaces)
+        {
+            // rotate circular eventspace such that the current idx is at the start
+            // (logic copied from CSpikeQueue.expand() in Brian's cspikequeue.cpp)
+            std::rotate(
+                dev{{_eventspace}}.begin(),
+                dev{{_eventspace}}.begin() + current_idx{{_eventspace}},
+                dev{{_eventspace}}.end());
+            current_idx{{_eventspace}} = 0;
+            for (int i = num_eventspaces; i < num_queues; i++)
+            {
+                {{c_data_type(eventspace_variable.dtype)}}* new_eventspace;
+                CUDA_SAFE_CALL(
+                    cudaMalloc(
+                        (void**)&new_eventspace,
+                        sizeof({{c_data_type(eventspace_variable.dtype)}}) * _num_{{_eventspace}}
+                    )
+                );
+                // initialize device eventspace with -1 and counter with 0
+                CUDA_SAFE_CALL(
+                    cudaMemcpy(
+                        new_eventspace,
+                        {{_eventspace}},  // defined in objects.cu
+                        sizeof({{c_data_type(eventspace_variable.dtype)}}) * _num_{{_eventspace}},
+                        cudaMemcpyHostToDevice
+                    )
+                );
+                dev{{_eventspace}}.push_back(new_eventspace);
+            }
+        }
     }
 
     int num_threads = num_queues;

--- a/brian2cuda/templates/threshold.cu
+++ b/brian2cuda/templates/threshold.cu
@@ -78,7 +78,7 @@ _reset_{{codeobj_name}}(
 {% block extra_kernel_call %}
     {% if extra_threshold_kernel %}
         _reset_{{codeobj_name}}<<<num_blocks, num_threads>>>(
-                dev{{ _eventspace_name }}[current_idx{{ _eventspace_name }}]
+                dev{{_eventspace_name}}[current_idx{{_eventspace_name}}]
             );
 
         CUDA_CHECK_ERROR("_reset_{{codeobj_name}}");
@@ -90,7 +90,7 @@ _reset_{{codeobj_name}}(
 {% if not extra_threshold_kernel %}
     // reset eventspace counter to 0
     CUDA_SAFE_CALL(
-            cudaMemset(&(dev{{ _eventspace_name }}[current_idx{{ _eventspace_name }}][_N]), 0, sizeof(int32_t))
+            cudaMemset(&(dev{{_eventspace_name}}[current_idx{{_eventspace_name}}][_N]), 0, sizeof(int32_t))
             );
 {% endif %}
 {% endblock host_maincode %}
@@ -136,7 +136,7 @@ num_threads = min(max_threads_per_block, (int)ceil(_N/(double)num_blocks));
 {% endif %}
 
 _reset_{{codeobj_name}}<<<num_blocks, num_threads>>>(
-        dev{{ _eventspace_name }}[current_idx{{ _eventspace_name }}]
+        dev{{_eventspace_name}}[current_idx{{_eventspace_name}}]
     );
 
 CUDA_CHECK_ERROR("_reset_{{codeobj_name}}");

--- a/brian2cuda/templates/threshold.cu
+++ b/brian2cuda/templates/threshold.cu
@@ -78,7 +78,7 @@ _reset_{{codeobj_name}}(
 {% block extra_kernel_call %}
     {% if extra_threshold_kernel %}
         _reset_{{codeobj_name}}<<<num_blocks, num_threads>>>(
-                dev{{ _eventspace_name }}_view[current_idx{{ _eventspace_name }}]
+                dev{{ _eventspace_name }}[current_idx{{ _eventspace_name }}]
             );
 
         CUDA_CHECK_ERROR("_reset_{{codeobj_name}}");
@@ -90,7 +90,7 @@ _reset_{{codeobj_name}}(
 {% if not extra_threshold_kernel %}
     // reset eventspace counter to 0
     CUDA_SAFE_CALL(
-            cudaMemset(&(dev{{ _eventspace_name }}_view[current_idx{{ _eventspace_name }}][_N]), 0, sizeof(int32_t))
+            cudaMemset(&(dev{{ _eventspace_name }}[current_idx{{ _eventspace_name }}][_N]), 0, sizeof(int32_t))
             );
 {% endif %}
 {% endblock host_maincode %}
@@ -136,7 +136,7 @@ num_threads = min(max_threads_per_block, (int)ceil(_N/(double)num_blocks));
 {% endif %}
 
 _reset_{{codeobj_name}}<<<num_blocks, num_threads>>>(
-        dev{{ _eventspace_name }}_view[current_idx{{ _eventspace_name }}]
+        dev{{ _eventspace_name }}[current_idx{{ _eventspace_name }}]
     );
 
 CUDA_CHECK_ERROR("_reset_{{codeobj_name}}");

--- a/brian2cuda/templates/threshold.cu
+++ b/brian2cuda/templates/threshold.cu
@@ -78,7 +78,7 @@ _reset_{{codeobj_name}}(
 {% block extra_kernel_call %}
     {% if extra_threshold_kernel %}
         _reset_{{codeobj_name}}<<<num_blocks, num_threads>>>(
-                dev{{_eventspace_name}}[current_idx{{_eventspace_name}}]
+                dev{{ _eventspace_name }}_view[current_idx{{ _eventspace_name }}]
             );
 
         CUDA_CHECK_ERROR("_reset_{{codeobj_name}}");
@@ -90,7 +90,7 @@ _reset_{{codeobj_name}}(
 {% if not extra_threshold_kernel %}
     // reset eventspace counter to 0
     CUDA_SAFE_CALL(
-            cudaMemset(&(dev{{_eventspace_name}}[current_idx{{_eventspace_name}}][_N]), 0, sizeof(int32_t))
+            cudaMemset(&(dev{{ _eventspace_name }}_view[current_idx{{ _eventspace_name }}][_N]), 0, sizeof(int32_t))
             );
 {% endif %}
 {% endblock host_maincode %}
@@ -136,7 +136,7 @@ num_threads = min(max_threads_per_block, (int)ceil(_N/(double)num_blocks));
 {% endif %}
 
 _reset_{{codeobj_name}}<<<num_blocks, num_threads>>>(
-        dev{{_eventspace_name}}[current_idx{{_eventspace_name}}]
+        dev{{ _eventspace_name }}_view[current_idx{{ _eventspace_name }}]
     );
 
 CUDA_CHECK_ERROR("_reset_{{codeobj_name}}");


### PR DESCRIPTION
This is the second slice of compile-time work for #179, on top of the headers optimization(see #330).

Most generated .cu files currently pull Thrust in through objects.h, so NVCC spends way too much time re-parsing those heavy headers. To fix this, I kept Thrust inside the objects translation unit and exposed a small C API alongside lean host/device pointers to the rest of the generated code.

what changed:
Split objects headers: Created `objects_storage.h` (for Thrust vectors) and `objects_api.h `(for resize, copy, sort, etc.).
Lean pointer symbols: `objects.h` now only exports lightweight `host_array_* `/ `dev_array_*` pointers and `eventspace _view `handles.
Template updates: Updated `device.py` and templates to use these new symbols and API helpers instead of calling thrust:: directly.
Name mapping helper: Added `array_basename()` to convert names like _dynamic_array_foo into API symbol suffixes easily.