### PR TITLE
Issue 103 jinja logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ nosetests.xml
 .ipynb_checkpoints
 
 # Python virtual environments
-.venv/
+.venv*/
 
 # ignore all .DS_Store files
 **/.DS_Store

--- a/brian2cuda/brianlib/cudaVector.h
+++ b/brian2cuda/brianlib/cudaVector.h
@@ -2,6 +2,7 @@
 #define _CUDA_VECTOR_H_
 
 #include <cstdio>
+#include "brianlib/logging.h"
 #include <assert.h>
 
 /*
@@ -35,7 +36,7 @@ public:
             }
             else
             {
-                printf("ERROR while creating cudaVector with size %ld in cudaVector.h (constructor)\n", sizeof(scalar)*INITIAL_SIZE);
+                B2C_LOG_ERROR("while creating cudaVector with size %ld in cudaVector.h (constructor)", sizeof(scalar)*INITIAL_SIZE);
                 assert(m_data != NULL);
             }
         }
@@ -56,7 +57,7 @@ public:
         if (index < 0 || index >= m_size)
         {
             // TODO: check for proper exception throwing in cuda kernels
-            printf("ERROR returning a reference to index %d in cudaVector::at() (size = %u)\n", index, m_size);
+            B2C_LOG_ERROR("returning a reference to index %d in cudaVector::at() (size = %u)", index, m_size);
             assert(index < m_size);
         }
         return m_data[index];
@@ -85,7 +86,7 @@ public:
         }
         else
         {
-            printf("ERROR invalid index %d, must be in range 0 - %d\n", pos, m_size);
+            B2C_LOG_ERROR("invalid index %d, must be in range 0 - %d", pos, m_size);
             assert(pos <= m_size);
         }
     };
@@ -134,7 +135,7 @@ public:
             }
             else
             {
-                printf("ERROR while allocating %ld bytes in cudaVector.h/reserve()\n", sizeof(scalar)*new_capacity);
+                B2C_LOG_ERROR("while allocating %ld bytes in cudaVector.h/reserve()", sizeof(scalar)*new_capacity);
                 assert(new_data != NULL);
             }
         }

--- a/brian2cuda/brianlib/cuda_utils.h
+++ b/brian2cuda/brianlib/cuda_utils.h
@@ -2,6 +2,7 @@
 #define BRIAN2CUDA_ERROR_CHECK_H
 #include <stdio.h>
 #include <cuda_runtime.h>
+#include "brianlib/logging.h"
 
 namespace brian{
   extern size_t used_device_memory;
@@ -30,7 +31,7 @@ inline void _cudaSafeCall(cudaError err, const char *file, const int line, const
 #ifdef BRIAN2CUDA_ERROR_CHECK
     if (cudaSuccess != err)
     {
-        fprintf(stderr, "ERROR: %s failed at %s:%i : %s\n",
+        B2C_LOG_ERROR("%s failed at %s:%i : %s",
                 call, file, line, cudaGetErrorString(err));
         exit(-1);
     }
@@ -46,7 +47,7 @@ inline void _cudaCheckError(const char *file, const int line, const char *msg)
     cudaError err = cudaDeviceSynchronize();
     if(cudaSuccess != err)
     {
-        fprintf(stderr, "ERROR: CUDA_CHECK_ERROR() failed after %s at %s:%i : %s\n",
+        B2C_LOG_ERROR("CUDA_CHECK_ERROR() failed after %s at %s:%i : %s",
                 msg, file, line, cudaGetErrorString(err));
         exit(-1);
     }
@@ -55,7 +56,7 @@ inline void _cudaCheckError(const char *file, const int line, const char *msg)
     cudaError err = cudaGetLastError();
     if (cudaSuccess != err)
     {
-        fprintf(stderr, "ERROR: CUDA_CHECK_ERROR() failed at %s:%i : %s\n",
+        B2C_LOG_ERROR("CUDA_CHECK_ERROR() failed at %s:%i : %s",
                 file, line, cudaGetErrorString(err));
         exit(-1);
     }
@@ -88,11 +89,11 @@ inline void _cudaCheckMemory(const char *file, const int line)
     // newly requested allocation.
     if (diff > 0)
     {
-        fprintf(stdout, "INFO: cuda device memory usage in %s:%i\n"
+        B2C_LOG_INFO("cuda device memory usage in %s:%i\n"
                "\t used:  \t %f MB\n"
                "\t avail: \t %f MB\n"
                "\t total: \t %f MB\n"
-               "\t diff:  \t %f MB \t (%zu bytes)\n",
+               "\t diff:  \t %f MB \t (%zu bytes)",
                file, line,
                double(used) * to_MB,
                double(avail) * to_MB,
@@ -107,7 +108,7 @@ inline void _cudaCheckMemory(const char *file, const int line)
 inline void _thrustCheckError(const char *file, const int line,
         const char *code)
 {
-    fprintf(stderr, "ERROR: THRUST_CHECK_ERROR() caught an exception from %s at %s:%i\n",
+    B2C_LOG_ERROR("THRUST_CHECK_ERROR() caught an exception from %s at %s:%i",
             code, file, line);
     throw;
 }

--- a/brian2cuda/brianlib/curand_buffer.cu
+++ b/brian2cuda/brianlib/curand_buffer.cu
@@ -1,5 +1,6 @@
 #include "brianlib/curand_buffer.h"
 #include "brianlib/curand_utils.h"
+#include "brianlib/logging.h"
 #include <cstdio>
 #include <cstdlib>
 
@@ -38,7 +39,7 @@ void CurandBuffer<randomNumber_t>::generate_numbers()
 {
     if (current_idx != buffer_size && memory_allocated)
     {
-        printf("WARNING: CurandBuffer::generate_numbers() called before "
+        B2C_LOG_WARN("CurandBuffer::generate_numbers() called before "
                "buffer was empty (current_idx = %u, buffer_size = %u)",
                current_idx, buffer_size);
     }
@@ -47,7 +48,7 @@ void CurandBuffer<randomNumber_t>::generate_numbers()
         host_data = new randomNumber_t[buffer_size];
         if (!host_data)
         {
-            printf("ERROR allocating host_data for CurandBuffer (size %ld)\n",
+            B2C_LOG_ERROR("allocating host_data for CurandBuffer (size %ld)",
                    sizeof(randomNumber_t) * buffer_size);
             exit(EXIT_FAILURE);
         }

--- a/brian2cuda/brianlib/curand_utils.h
+++ b/brian2cuda/brianlib/curand_utils.h
@@ -3,6 +3,7 @@
 
 #include <curand.h>
 #include "brianlib/cuda_utils.h"
+#include "brianlib/logging.h"
 
 // adapted from NVIDIA cuda samples, shipped with cuda 10.1 (common/inc/helper_cuda.h)
 // cuRAND API errors
@@ -56,7 +57,7 @@ inline void _cudaSafeCall(curandStatus_t err, const char *file, const int line, 
 #ifdef BRIAN2CUDA_ERROR_CHECK
     if (CURAND_STATUS_SUCCESS != err)
     {
-        fprintf(stderr, "ERROR: %s failed at %s:%i : %s\n",
+        B2C_LOG_ERROR("%s failed at %s:%i : %s",
                 call, file, line, _curandGetErrorEnum(err));
         exit(-1);
     }

--- a/brian2cuda/brianlib/device_buffer.cu
+++ b/brian2cuda/brianlib/device_buffer.cu
@@ -3,7 +3,6 @@
 
 #include <thrust/device_vector.h>
 
-#include <cstdio>
 #include <cstdlib>
 
 namespace brian {
@@ -37,7 +36,7 @@ void DeviceBuffer::resize(size_t n)
 {
     if (elem_size_ == 0)
     {
-        fprintf(stderr, "ERROR: DeviceBuffer used before elem_size was set\n");
+        B2C_LOG_ERROR("DeviceBuffer used before elem_size was set");
         exit(EXIT_FAILURE);
     }
     if (n == 0)

--- a/brian2cuda/brianlib/logging.cu
+++ b/brian2cuda/brianlib/logging.cu
@@ -1,0 +1,66 @@
+#include "logging.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <string>
+
+namespace brian {
+
+static FILE* b2c_log_fp = nullptr;
+static std::string b2c_log_path;
+
+static void b2c_vlog(FILE* fp, const char* level, const char* fmt, va_list ap)
+{
+    fprintf(fp, "[brian2cuda][%s] ", level);
+    vfprintf(fp, fmt, ap);
+    fprintf(fp, "\n");
+}
+
+static bool b2c_should_persist(const char* level)
+{
+    return strcmp(level, "ERROR") == 0 || strcmp(level, "WARNING") == 0;
+}
+
+void b2c_log_open(const char* results_dir)
+{
+    b2c_log_close();
+    b2c_log_path = std::string(results_dir) + "cuda_log.txt";
+    remove(b2c_log_path.c_str());
+}
+
+void b2c_log_close()
+{
+    if (b2c_log_fp != nullptr)
+    {
+        fclose(b2c_log_fp);
+        b2c_log_fp = nullptr;
+    }
+    b2c_log_path.clear();
+}
+
+void b2c_log_message(const char* level, const char* fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    b2c_vlog(stdout, level, fmt, ap);
+    va_end(ap);
+
+    if (!b2c_should_persist(level) || b2c_log_path.empty())
+        return;
+
+    if (b2c_log_fp == nullptr)
+    {
+        b2c_log_fp = fopen(b2c_log_path.c_str(), "a");
+        if (b2c_log_fp == nullptr)
+            return;
+    }
+
+    va_start(ap, fmt);
+    b2c_vlog(b2c_log_fp, level, fmt, ap);
+    fflush(b2c_log_fp);
+    va_end(ap);
+}
+
+}  // namespace brian

--- a/brian2cuda/brianlib/logging.cu
+++ b/brian2cuda/brianlib/logging.cu
@@ -44,7 +44,7 @@ void b2c_log_message(const char* level, const char* fmt, ...)
     va_list ap;
 
     va_start(ap, fmt);
-    b2c_vlog(stdout, level, fmt, ap);
+    b2c_vlog(stderr, level, fmt, ap);
     va_end(ap);
 
     if (!b2c_should_persist(level) || b2c_log_path.empty())

--- a/brian2cuda/brianlib/logging.h
+++ b/brian2cuda/brianlib/logging.h
@@ -1,0 +1,57 @@
+#ifndef BRIAN2CUDA_LOGGING_H
+#define BRIAN2CUDA_LOGGING_H
+
+#include <stdio.h>
+
+#define B2C_LOG_LEVEL_DEBUG 10
+#define B2C_LOG_LEVEL_INFO 20
+#define B2C_LOG_LEVEL_WARNING 30
+#define B2C_LOG_LEVEL_ERROR 40
+
+#ifndef B2C_LOG_LEVEL
+#define B2C_LOG_LEVEL B2C_LOG_LEVEL_WARNING
+#endif
+
+// Declarations must stay visible in nvcc's device pass (__CUDA_ARCH__ set).
+namespace brian {
+void b2c_log_open(const char* results_dir);
+void b2c_log_close();
+void b2c_log_message(const char* level, const char* fmt, ...);
+}
+
+#if defined(__CUDA_ARCH__)
+#define B2C_LOG_EMIT(tag, ...)                                                 \
+    do {                                                                       \
+        printf("[brian2cuda][" tag "] " __VA_ARGS__);                          \
+        printf("\n");                                                          \
+    } while (0)
+#else
+#define B2C_LOG_EMIT(tag, ...)                                                 \
+    do { ::brian::b2c_log_message(tag, __VA_ARGS__); } while (0)
+#endif
+
+#if B2C_LOG_LEVEL <= B2C_LOG_LEVEL_ERROR
+#define B2C_LOG_ERROR(...) B2C_LOG_EMIT("ERROR", __VA_ARGS__)
+#else
+#define B2C_LOG_ERROR(...) ((void)0)
+#endif
+
+#if B2C_LOG_LEVEL <= B2C_LOG_LEVEL_WARNING
+#define B2C_LOG_WARN(...) B2C_LOG_EMIT("WARNING", __VA_ARGS__)
+#else
+#define B2C_LOG_WARN(...) ((void)0)
+#endif
+
+#if B2C_LOG_LEVEL <= B2C_LOG_LEVEL_INFO
+#define B2C_LOG_INFO(...) B2C_LOG_EMIT("INFO", __VA_ARGS__)
+#else
+#define B2C_LOG_INFO(...) ((void)0)
+#endif
+
+#if B2C_LOG_LEVEL <= B2C_LOG_LEVEL_DEBUG
+#define B2C_LOG_DEBUG(...) B2C_LOG_EMIT("DEBUG", __VA_ARGS__)
+#else
+#define B2C_LOG_DEBUG(...) ((void)0)
+#endif
+
+#endif  // BRIAN2CUDA_LOGGING_H

--- a/brian2cuda/brianlib/spikequeue.h
+++ b/brian2cuda/brianlib/spikequeue.h
@@ -2,6 +2,7 @@
 #define _BRIAN_SPIKEQUEUE_H
 
 #include <inttypes.h>
+#include "brianlib/logging.h"
 #include "cudaVector.h"
 #include <assert.h>
 #include <cstdio>
@@ -116,8 +117,8 @@ public:
                 synapses_queue = new cuda_vector*[required_num_queues];
                 if (!synapses_queue)
                 {
-                    printf("ERROR while allocating memory with size %ld in"
-                           " spikequeue.h/prepare()\n",
+                    B2C_LOG_ERROR("while allocating memory with size %ld in"
+                           " spikequeue.h/prepare()",
                            sizeof(cuda_vector*) * required_num_queues);
                 }
                 // only reset queue offset if we require new queues, in which
@@ -189,8 +190,8 @@ public:
                     synapses_queue[i] = new cuda_vector[num_blocks];
                     if (!synapses_queue[i])
                     {
-                        printf("ERROR while allocating memory with size %ld in"
-                                " spikequeue.h/prepare()\n",
+                        B2C_LOG_ERROR("while allocating memory with size %ld in"
+                                " spikequeue.h/prepare()",
                                 sizeof(cuda_vector)*num_blocks);
                     }
                 }

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -33,7 +33,12 @@ from brian2.input.spikegeneratorgroup import SpikeGeneratorGroup
 
 from brian2cuda.utils.stringtools import replace_floating_point_literals
 from brian2cuda.utils.gputools import select_gpu, get_nvcc_path, get_cuda_path
-from brian2cuda.utils.logger import report_issue_message
+from brian2cuda.utils.logger import (
+    report_issue_message,
+    nvcc_log_flags,
+    update_log_flags_stamp,
+    reemit_cuda_log,
+)
 
 from .codeobject import (
     CUDAStandaloneCodeObject,
@@ -90,6 +95,7 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
         # store the ID of the used GPU and it's compute capability
         self.gpu_id = None
         self.compute_capability = None
+        self._b2c_log_flags_changed = False
         # list of pre/post ID and delay arrays that are not needed in device memory
         self.delete_synaptic_pre = {}
         self.delete_synaptic_post = {}
@@ -1119,6 +1125,30 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
             elif file.lower().endswith('.h'):
                 writer.header_files.add('brianlib/'+file)
 
+    def run(self, directory=None, results_directory=None, with_output=True,
+            run_args=None):
+        try:
+            super().run(
+                directory=directory,
+                results_directory=results_directory,
+                with_output=with_output,
+                run_args=run_args,
+            )
+        finally:
+            reemit_cuda_log(self.results_dir)
+
+    def delete(self, code=True, data=True, run_args=True, directory=True, force=False):
+        if data and self.results_dir is not None:
+            cuda_log = os.path.join(self.results_dir, 'cuda_log.txt')
+            if os.path.isfile(cuda_log):
+                try:
+                    os.remove(cuda_log)
+                except (IOError, OSError) as ex:
+                    logger.warn(f"Cannot delete '{cuda_log}': {ex}")
+        super().delete(
+            code=code, data=data, run_args=run_args, directory=directory, force=force
+        )
+
     def generate_network_source(self, writer):
         maximum_run_time = self._maximum_run_time
         if maximum_run_time is not None:
@@ -1236,6 +1266,9 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
         else:
             compiler_debug_flags = ''
             linker_debug_flags = ''
+
+        nvcc_compiler_flags.extend(nvcc_log_flags())
+        self._b2c_log_flags_changed = update_log_flags_stamp(self.project_dir)
 
         nvcc_flags_str = ' '.join(nvcc_compiler_flags)
         gpu_arch_str = ' '.join(gpu_arch_flags)
@@ -1581,7 +1614,10 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
                 logger.debug(f"\t{pref_name} = {prefs[pref_name]}")
 
         if compile:
-            self.compile_source(directory, cpp_compiler, debug, clean)
+            force_clean = clean or self._b2c_log_flags_changed
+            if force_clean and not clean:
+                logger.info("CUDA log level flags changed; forcing make clean.")
+            self.compile_source(directory, cpp_compiler, debug, force_clean)
             if run:
                 self.run(
                     directory=directory,

--- a/brian2cuda/device.py
+++ b/brian2cuda/device.py
@@ -1138,13 +1138,19 @@ class CUDAStandaloneDevice(CPPStandaloneDevice):
             reemit_cuda_log(self.results_dir)
 
     def delete(self, code=True, data=True, run_args=True, directory=True, force=False):
+        # Remove our extra files before Brian's delete, which treats unknown
+        # project files as foreign and may skip directory deletion.
+        extra = []
         if data and self.results_dir is not None:
-            cuda_log = os.path.join(self.results_dir, 'cuda_log.txt')
-            if os.path.isfile(cuda_log):
+            extra.append(os.path.join(self.results_dir, 'cuda_log.txt'))
+        if self.project_dir is not None:
+            extra.append(os.path.join(self.project_dir, 'b2c_log_flags.stamp'))
+        for path in extra:
+            if os.path.isfile(path):
                 try:
-                    os.remove(cuda_log)
+                    os.remove(path)
                 except (IOError, OSError) as ex:
-                    logger.warn(f"Cannot delete '{cuda_log}': {ex}")
+                    logger.warn(f"Cannot delete '{path}': {ex}")
         super().delete(
             code=code, data=data, run_args=run_args, directory=directory, force=force
         )

--- a/brian2cuda/templates/common_group.cu
+++ b/brian2cuda/templates/common_group.cu
@@ -81,19 +81,19 @@ namespace {
     // functions works. Hacky, hacky ...
     randomNumber_t _host_rand(const int _vectorisation_idx)
     {
-        printf("ERROR: Called dummy function `_host_rand` in %s:%d\n", __FILE__,
+        B2C_LOG_ERROR("Called dummy function `_host_rand` in %s:%d", __FILE__,
                 __LINE__);
         exit(EXIT_FAILURE);
     }
     randomNumber_t _host_randn(const int _vectorisation_idx)
     {
-        printf("ERROR: Called dummy function `_host_rand` in %s:%d\n", __FILE__,
+        B2C_LOG_ERROR("Called dummy function `_host_randn` in %s:%d", __FILE__,
                 __LINE__);
         exit(EXIT_FAILURE);
     }
     int32_t _host_poisson(double _lambda, const int _vectorisation_idx)
     {
-        printf("ERROR: Called dummy function `_host_poisson` in %s:%d\n", __FILE__,
+        B2C_LOG_ERROR("Called dummy function `_host_poisson` in %s:%d", __FILE__,
                 __LINE__);
         exit(EXIT_FAILURE);
     }
@@ -248,14 +248,14 @@ void _run_{{codeobj_name}}()
         {
             // use the max num_threads before launch failure
             num_threads = funcAttrib.maxThreadsPerBlock;
-            printf("WARNING Not enough ressources available to call "
+            B2C_LOG_WARN("Not enough ressources available to call "
                    "_run_kernel_{{codeobj_name}} "
                    "with maximum possible threads per block (%u). "
                    "Reducing num_threads to %u. (Kernel needs %i "
                    "registers per block, %i bytes of "
                    "statically-allocated shared memory per block, %i "
                    "bytes of local memory per thread and a total of %i "
-                   "bytes of user-allocated constant memory)\n",
+                   "bytes of user-allocated constant memory)",
                    max_threads_per_block, num_threads, funcAttrib.numRegs,
                    funcAttrib.sharedSizeBytes, funcAttrib.localSizeBytes,
                    funcAttrib.constSizeBytes);
@@ -278,7 +278,7 @@ void _run_{{codeobj_name}}()
         {% block kernel_info %}
         else
         {
-            printf("INFO _run_kernel_{{codeobj_name}}\n"
+            B2C_LOG_DEBUG("_run_kernel_{{codeobj_name}}\n"
                    {% block kernel_info_num_blocks_str %}
                    "\t%u blocks\n"
                    {% endblock %}
@@ -286,9 +286,9 @@ void _run_{{codeobj_name}}()
                    "\t%i registers per thread\n"
                    "\t%i bytes statically-allocated shared memory per block\n"
                    "\t%i bytes local memory per thread\n"
-                   "\t%i bytes user-allocated constant memory\n"
+                   "\t%i bytes user-allocated constant memory"
                    {% if calc_occupancy %}
-                   "\t%.3f theoretical occupancy\n",
+                   "\n\t%.3f theoretical occupancy",
                    {% else %}
                    "",
                    {% endif %}

--- a/brian2cuda/templates/main.cu
+++ b/brian2cuda/templates/main.cu
@@ -56,11 +56,10 @@ int main(int argc, char **argv)
     if (args.size() >=2 && args[0] == "--results_dir")
     {
         brian::results_dir = args[1];
-        #ifdef DEBUG
-        std::cout << "Setting results dir to '" << brian::results_dir << "'" << std::endl;
-        #endif
+        B2C_LOG_DEBUG("Setting results dir to '%s'", brian::results_dir.c_str());
         args.erase(args.begin(), args.begin()+2);
     }
+    brian::b2c_log_open(brian::results_dir.c_str());
     {{'\n'.join(code_lines['before_start'])|autoindent}}
 
     // seed variable set in Python through brian2.seed() calls can use this
@@ -100,6 +99,8 @@ int main(int argc, char **argv)
     {{'\n'.join(code_lines['before_end'])|autoindent}}
     brian_end();
     {{'\n'.join(code_lines['after_end'])|autoindent}}
+
+    brian::b2c_log_close();
 
     return 0;
 }

--- a/brian2cuda/templates/objects.cu
+++ b/brian2cuda/templates/objects.cu
@@ -21,7 +21,7 @@ set_variable_from_value(name, {{array_name}}, var_size, (char)atoi(s_value.c_str
 {% endif %}
 #include "brianlib/cuda_utils.h"
 #include "rand.h"
-#include <iostream>
+#include <sstream>
 #include <fstream>
 #include <chrono>
 #include <ctime>
@@ -48,38 +48,39 @@ Network brian::{{net.name}};
 {% endfor %}
 
 void set_variable_from_value(std::string varname, char* var_pointer, size_t size, char value) {
-    #ifdef DEBUG
-    std::cout << "Setting '" << varname << "' to " << (value == 1 ? "True" : "False") << std::endl;
-    #endif
+    B2C_LOG_DEBUG("Setting '%s' to %s", varname.c_str(), (value == 1 ? "True" : "False"));
     std::fill(var_pointer, var_pointer+size, value);
 }
 
 template<class T> void set_variable_from_value(std::string varname, T* var_pointer, size_t size, T value) {
-    #ifdef DEBUG
-    std::cout << "Setting '" << varname << "' to " << value << std::endl;
-    #endif
+#if B2C_LOG_LEVEL <= B2C_LOG_LEVEL_DEBUG
+    {
+        std::ostringstream _b2c_msg;
+        _b2c_msg << "Setting '" << varname << "' to " << value;
+        B2C_LOG_DEBUG("%s", _b2c_msg.str().c_str());
+    }
+#endif
     std::fill(var_pointer, var_pointer+size, value);
 }
 
 template<class T> void set_variable_from_file(std::string varname, T* var_pointer, size_t data_size, std::string filename) {
     std::ifstream f;
     std::streampos size;
-    #ifdef DEBUG
-    std::cout << "Setting '" << varname << "' from file '" << filename << "'" << std::endl;
-    #endif
+    B2C_LOG_DEBUG("Setting '%s' from file '%s'", varname.c_str(), filename.c_str());
     f.open(filename, std::ios::in | std::ios::binary | std::ios::ate);
     size = f.tellg();
     if (size != data_size) {
-        std::cerr << "Error reading '" << filename << "': file size " << size << " does not match expected size " << data_size << std::endl;
+        B2C_LOG_ERROR("Error reading '%s': file size %ld does not match expected size %ld",
+                      filename.c_str(), (long)size, (long)data_size);
         return;
     }
     f.seekg(0, std::ios::beg);
     if (f.is_open())
         f.read(reinterpret_cast<char *>(var_pointer), data_size);
     else
-        std::cerr << "Could not read '" << filename << "'" << std::endl;
+        B2C_LOG_ERROR("Could not read '%s'", filename.c_str());
     if (f.fail())
-        std::cerr << "Error reading '" << filename << "'" << std::endl;
+        B2C_LOG_ERROR("Error reading '%s'", filename.c_str());
 }
 
 //////////////// set arrays by name ///////
@@ -169,7 +170,7 @@ void brian::set_variable_by_name(std::string name, std::string s_value) {
         return;
     }
     {% endfor %}
-    std::cerr << "Cannot set unknown variable '" << name << "'." << std::endl;
+    B2C_LOG_ERROR("Cannot set unknown variable '%s'.", name.c_str());
     exit(1);
 }
 //////////////// arrays ///////////////////
@@ -475,10 +476,11 @@ void _init_arrays()
     const double to_MB = 1.0 / (1024.0 * 1024.0);
     double tot_memory_MB = (used_device_memory - used_device_memory_start) * to_MB;
     double time_passed = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start_timer).count();
-    std::cout << "INFO: _init_arrays() took " <<  time_passed << "s";
     if (tot_memory_MB > 0)
-        std::cout << " and used " << tot_memory_MB << "MB of device memory.";
-    std::cout << std::endl;
+        B2C_LOG_DEBUG("_init_arrays() took %g s and used %g MB of device memory.",
+                      time_passed, tot_memory_MB);
+    else
+        B2C_LOG_DEBUG("_init_arrays() took %g s", time_passed);
 }
 
 void _load_arrays()
@@ -497,7 +499,7 @@ void _load_arrays()
         {% endif %}
     } else
     {
-        std::cout << "Error opening static array {{name}}." << std::endl;
+        B2C_LOG_ERROR("Error opening static array {{name}}.");
     }
     {% if not (name in dynamic_array_specs.values()) %}
     CUDA_SAFE_CALL(
@@ -533,7 +535,7 @@ void _write_arrays()
         outfile_{{varname}}.close();
     } else
     {
-        std::cout << "Error writing output file for {{varname}}." << std::endl;
+        B2C_LOG_ERROR("Error writing output file for {{varname}}.");
     }
     {% endif %}
     {% endfor %}
@@ -551,7 +553,7 @@ void _write_arrays()
         outfile_{{varname}}.close();
     } else
     {
-        std::cout << "Error writing output file for {{varname}}." << std::endl;
+        B2C_LOG_ERROR("Error writing output file for {{varname}}.");
     }
     {% endfor %}
 
@@ -592,7 +594,7 @@ void _write_arrays()
             outfile_{{varname}}.close();
         } else
         {
-            std::cout << "Error writing output file for {{varname}}." << std::endl;
+        B2C_LOG_ERROR("Error writing output file for {{varname}}.");
         }
     {% endfor %}
 
@@ -620,7 +622,7 @@ void _write_arrays()
     outfile_profiling_info.close();
     } else
     {
-        std::cout << "Error writing profiling info to file." << std::endl;
+        B2C_LOG_ERROR("Error writing profiling info to file.");
     }
     {% endif %}
     // Write last run info to disk
@@ -632,7 +634,7 @@ void _write_arrays()
         outfile_last_run_info.close();
     } else
     {
-        std::cout << "Error writing last run info to file." << std::endl;
+        B2C_LOG_ERROR("Error writing last run info to file.");
     }
 }
 

--- a/brian2cuda/templates/rand.cu
+++ b/brian2cuda/templates/rand.cu
@@ -140,12 +140,12 @@ void RandomNumberBuffer::init()
         // this checks per codeobject the number of generated floats against total available floats
         while (num_free_floats < num_per_gen_{{type}}_{{co.name}})
         {
-            printf("INFO not enough memory available to generate %i random numbers for {{co.name}}, reducing the buffer size\n", num_free_floats);
+            B2C_LOG_DEBUG("not enough memory available to generate %i random numbers for {{co.name}}, reducing the buffer size", num_free_floats);
             if (num_per_gen_{{type}}_{{co.name}} < num_per_cycle_{{type}}_{{co.name}})
             {
                 if (num_free_floats < num_per_cycle_{{type}}_{{co.name}})
                 {
-                    printf("ERROR not enough memory to generate random numbers for {{co.name}} %s:%d\n", __FILE__, __LINE__);
+                    B2C_LOG_ERROR("not enough memory to generate random numbers for {{co.name}} %s:%d", __FILE__, __LINE__);
                     _dealloc_arrays();
                     exit(1);
                 }
@@ -157,7 +157,7 @@ void RandomNumberBuffer::init()
             }
             num_per_gen_{{type}}_{{co.name}} /= 2;
         }
-        printf("INFO generating %i {{type}} every %i clock cycles for {{co.name}}\n", num_per_gen_{{type}}_{{co.name}}, {{type}}_interval_{{co.name}});
+        B2C_LOG_DEBUG("generating %i {{type}} every %i clock cycles for {{co.name}}", num_per_gen_{{type}}_{{co.name}}, {{type}}_interval_{{co.name}});
 
         {% if type in ['rand', 'randn'] %}
         {% set dtype = "randomNumber_t" %}
@@ -182,7 +182,7 @@ void RandomNumberBuffer::init()
         {
             // TODO: find a way to deal with this? E.g. looping over buffers sorted
             // by buffer size and reducing them until it fits.
-            printf("MEMORY ERROR: Trying to generate more random numbers than fit "
+            B2C_LOG_ERROR("Trying to generate more random numbers than fit "
                    "into available memory. Please report this as an issue on "
                    "GitHub: https://github.com/brian-team/brian2cuda/issues/new");
             _dealloc_arrays();
@@ -403,8 +403,7 @@ void RandomNumberBuffer::refill_poisson_numbers(
         int &idx_poisson)
 {
     // generate poisson distributed random numbers and reset buffer index
-
-    printf("num_per_gen_poisson %d, lambda %f\n", num_per_gen_poisson, lambda);
+    B2C_LOG_DEBUG("num_per_gen_poisson %d, lambda %f", num_per_gen_poisson, lambda);
     CUDA_SAFE_CALL(
             curandGeneratePoisson(curand_generator, dev_poisson_allocator, num_per_gen_poisson, lambda)
             );

--- a/brian2cuda/templates/spatialstateupdate.cu
+++ b/brian2cuda/templates/spatialstateupdate.cu
@@ -511,15 +511,14 @@ __global__ void _currents_kernel_{{codeobj_name}}(
 
             float occupancy_currents = (max_active_blocks_currents * num_threads_currents / num_threads_per_warp) /
                               (float)(max_threads_per_sm / num_threads_per_warp);
-
-            printf("INFO _currents\n_kernel_{{codeobj_name}}"
+            B2C_LOG_DEBUG("_currents\n_kernel_{{codeobj_name}}"
                        "\t%u blocks\n"
                        "\t%u threads\n"
                        "\t%i registers per thread\n"
                        "\t%i bytes statically-allocated shared memory per block\n"
                        "\t%i bytes local memory per thread\n"
                        "\t%i bytes user-allocated constant memory\n"
-                       "\t%.3f theoretical occupancy\n",
+                       "\t%.3f theoretical occupancy",
                        num_blocks_currents, num_threads_currents, funcAttrib_currents.numRegs,
                        funcAttrib_currents.sharedSizeBytes, funcAttrib_currents.localSizeBytes,
                        funcAttrib_currents.constSizeBytes, occupancy_currents);

--- a/brian2cuda/templates/spikemonitor.cu
+++ b/brian2cuda/templates/spikemonitor.cu
@@ -161,8 +161,7 @@ void _debugmsg_{{codeobj_name}}()
 
     // HOST_CONSTANTS
     %HOST_CONSTANTS%
-
-    printf("Number of spikes: %d\n", _array_{{owner.name}}_N[0]);
+    B2C_LOG_DEBUG("Number of spikes: %d", _array_{{owner.name}}_N[0]);
 }
 {% endblock %}
 

--- a/brian2cuda/templates/synapses.cu
+++ b/brian2cuda/templates/synapses.cu
@@ -211,7 +211,7 @@ num_threads = max_threads_per_block;
 {% if bundle_mode %}
 //num_threads_per_bundle = {{pathway.name}}_bundle_size_max;
 num_threads_per_bundle = getThreadsPerBundle();
-printf("INFO _run_kernel_{{codeobj_name}}: Using %d threads per bundle\n", num_threads_per_bundle);
+B2C_LOG_DEBUG("_run_kernel_{{codeobj_name}}: Using %d threads per bundle", num_threads_per_bundle);
 {% endif %}
 num_loops = 1;
 
@@ -231,12 +231,12 @@ if (!{{owner.name}}_multiple_pre_post){
     {% endif %}
 }
 else {
-    printf("WARNING: Detected multiple synapses for same (pre, post) neuron "
+    B2C_LOG_WARN("Detected multiple synapses for same (pre, post) neuron "
            "pair in Synapses object ``{{owner.name}}`` and no atomic operations are used. "
            "Falling back to serialised effect application for SynapticPathway "
            "``{{pathway.name}}``. This will be slow. You can avoid serialisation "
            "by separating this Synapses object into multiple Synapses objects "
-           "with at most one connection between the same (pre, post) neuron pair.\n");
+           "with at most one connection between the same (pre, post) neuron pair.");
 }
 if (num_threads > max_threads_per_block)
     num_threads = max_threads_per_block;
@@ -255,7 +255,7 @@ num_threads_per_bundle = 1;
 num_loops = num_parallel_blocks;
 
 {% else %}
-printf("ERROR: got unknown 'synaptic_effects' mode ({{synaptic_effects}})\n");
+B2C_LOG_ERROR("got unknown 'synaptic_effects' mode ({{synaptic_effects}})");
 _dealloc_arrays();
 exit(1);
 {% endif %}
@@ -265,7 +265,7 @@ exit(1);
 {% block extra_info_msg %}
 else if ({{pathway.name}}_max_size <= 0)
 {
-    printf("INFO there are no synapses in the {{pathway.name}} pathway. Skipping synapses_push and synapses kernels.\n");
+    B2C_LOG_DEBUG("there are no synapses in the {{pathway.name}} pathway. Skipping synapses_push and synapses kernels.");
 }
 {% endblock %}
 
@@ -325,7 +325,7 @@ if ({{pathway.name}}_max_size > 0)
 void _debugmsg_{{codeobj_name}}()
 {
     using namespace brian;
-    printf("Number of synapses: %d\n", {{constant_or_scalar('N', variables['N'])}});
+    B2C_LOG_DEBUG("Number of synapses: %d", {{constant_or_scalar('N', variables['N'])}});
 }
 {% endblock %}
 

--- a/brian2cuda/templates/synapses_create_array.cu
+++ b/brian2cuda/templates/synapses_create_array.cu
@@ -39,10 +39,12 @@ CUDA_CHECK_MEMORY();
 const double to_MB = 1.0 / (1024.0 * 1024.0);
 double tot_memory_MB = (used_device_memory - used_device_memory_start) * to_MB;
 double time_passed = std::chrono::duration<double>(std::chrono::high_resolution_clock::now() - start_timer).count();
-std::cout << "INFO: {{owner.name}} creation took " <<  time_passed << "s";
+
 if (tot_memory_MB > 0)
-    std::cout << " and used " << tot_memory_MB << "MB of device memory.";
-std::cout << std::endl;
+    B2C_LOG_DEBUG("{{owner.name}} creation took %g s and used %g MB of device memory.",
+                  time_passed, tot_memory_MB);
+else
+    B2C_LOG_DEBUG("{{owner.name}} creation took %g s", time_passed);
 {% endblock %}
 
 {% block host_maincode %}

--- a/brian2cuda/templates/synapses_create_generator.cu
+++ b/brian2cuda/templates/synapses_create_generator.cu
@@ -124,7 +124,6 @@ int32_t _host_poisson(double lam, int32_t _idx) {
 }
 {% endblock random_functions %}
 
-
 {% block kernel %}
 {% endblock %}
 
@@ -155,10 +154,12 @@ CUDA_CHECK_MEMORY();
 const double to_MB = 1.0 / (1024.0 * 1024.0);
 double tot_memory_MB = (used_device_memory - used_device_memory_start) * to_MB;
 double time_passed = std::chrono::duration<double>(std::chrono::high_resolution_clock::now() - start_timer).count();
-std::cout << "INFO: {{owner.name}} creation took " <<  time_passed << "s";
+
 if (tot_memory_MB > 0)
-    std::cout << " and used " << tot_memory_MB << "MB of memory.";
-std::cout << std::endl;
+    B2C_LOG_DEBUG("{{owner.name}} creation took %g s and used %g MB of memory.",
+                  time_passed, tot_memory_MB);
+else
+    B2C_LOG_DEBUG("{{owner.name}} creation took %g s", time_passed);
 {% endblock %}
 
 {% block host_maincode %}
@@ -260,8 +261,8 @@ std::cout << std::endl;
             {% if skip_if_invalid %}
             _uiter_size = _n_total;
             {% else %}
-            std::cout << "Error: Requested sample size " << _uiter_size << " is bigger than the " <<
-                    "population size " << _n_total << "." << std::endl;
+            B2C_LOG_ERROR("Requested sample size %lu is bigger than the population size %lu.",
+                          (unsigned long)_uiter_size, (unsigned long)_n_total);
             exit(1);
             {% endif %}
         } else if (_uiter_size < 0)
@@ -269,7 +270,7 @@ std::cout << std::endl;
             {% if skip_if_invalid %}
             continue;
             {% else %}
-            std::cout << "Error: Requested sample size " << _uiter_size << " is negative." << std::endl;
+            B2C_LOG_ERROR("Requested sample size %ld is negative.", (long)_uiter_size);
             exit(1);
             {% endif %}
         } else if (_uiter_size == 0)
@@ -352,8 +353,8 @@ std::cout << std::endl;
                     {% if skip_if_invalid %}
                     continue;
                     {% else %}
-                    std::cout << "Error: tried to create synapse to neuron {{result_index}}=" << _{{result_index}} << " outside range 0 to " <<
-                                            _{{result_index_size}}-1 << std::endl;
+                    B2C_LOG_ERROR("tried to create synapse to neuron {{result_index}}=%ld outside range 0 to %ld",
+                                  (long)_{{result_index}}, (long)(_{{result_index_size}}-1));
                     exit(1);
                     {% endif %}
                 }
@@ -376,8 +377,8 @@ std::cout << std::endl;
                 {% if skip_if_invalid %}
                 continue;
                 {% else %}
-                std::cout << "Error: tried to create synapse to neuron {{result_index}}=" << _{{result_index}} <<
-                        " outside range 0 to " << _{{result_index_size}}-1 << std::endl;
+                B2C_LOG_ERROR("tried to create synapse to neuron {{result_index}}=%ld outside range 0 to %ld",
+                              (long)_{{result_index}}, (long)(_{{result_index_size}}-1));
                 exit(1);
                 {% endif %}
             }

--- a/brian2cuda/templates/synapses_push_spikes.cu
+++ b/brian2cuda/templates/synapses_push_spikes.cu
@@ -43,6 +43,7 @@
 #include <climits>
 #include <cmath>
 #include <numeric>
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -191,8 +192,8 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
         return;
     }
     else if (syn_N_check > INT_MAX){
-        printf("ERROR: There are more Synapses (%lu) than an int can "
-               "hold on this system (%u).\n", syn_N_check, INT_MAX);
+        B2C_LOG_ERROR("There are more Synapses (%lu) than an int can "
+               "hold on this system (%u).", syn_N_check, INT_MAX);
     }
     // total number of synapses
     int syn_N = (int)syn_N_check;
@@ -567,7 +568,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
         sum_num_elements += num_elements;
         updateMeanStd(count_num_elements, mean_num_elements, M2_num_elements, num_elements);
     }  // end for loop through connectivity matrix
-    printf("INFO connectivity matrix has size %i, number of (pre neuron ID, post neuron block) pairs is %u\n",
+    B2C_LOG_DEBUG("connectivity matrix has size %i, number of (pre neuron ID, post neuron block) pairs is %u",
             size_connectivity_matrix, num_pre_post_blocks);
 
     {# If we have don't have heterogeneous delays, we just need to copy the
@@ -787,8 +788,8 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
     double std_num_unique_elements = getStd(count_num_unique_elements, M2_num_unique_elements);
     {% endif %}{# not no_or_const_delay_mode #}
 
-    // print memory information
-    printf("INFO: synapse statistics and memory usage for {{owner.name}}:\n"
+#if B2C_LOG_LEVEL <= B2C_LOG_LEVEL_DEBUG
+    B2C_LOG_DEBUG("synapse statistics and memory usage for {{owner.name}}:\n"
         "\tnumber of synapses: %d\n"
     {% if not no_or_const_delay_mode and bundle_mode %}
         "\tnumber of bundles: %d\n"
@@ -804,7 +805,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
         "\t\tmean: %.1f\tstd: %.1f\n"
     {% endif %}{# bundle_mode #}
     {% endif %}{# not no_or_const_delay_mode #}
-        "\n\tmemory usage: TOTAL: %.1f MB (~%.1f byte per synapse)\n",
+        "\n\tmemory usage: TOTAL: %.1f MB (~%.1f byte per synapse)",
         syn_N,
     {% if not no_or_const_delay_mode and bundle_mode %}
         num_bundle_ids,
@@ -827,9 +828,10 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
         std::tie(name, bytes, num_elements) = tuple;
         double memory = bytes * to_MB;
         double fraction = memory / total_memory_MB * 100;
-        printf("\t\t%.1f%%\t%.3f MB\t%s [%d]\n",
+        B2C_LOG_DEBUG("\t\t%.1f%%\t%.3f MB\t%s [%d]",
                fraction, memory, name.c_str(), num_elements);
     }
+#endif
 
 
     // Create circular eventspaces in no_or_const_delay_mode
@@ -855,28 +857,27 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
     {
         // use the max num_threads before launch failure
         num_threads = funcAttrib.maxThreadsPerBlock;
-        printf("WARNING Not enough ressources available to call "
+        B2C_LOG_WARN("Not enough ressources available to call "
                "_before_run_kernel_{{codeobj_name}}"
                "with maximum possible threads per block (%u). "
                "Reducing num_threads to %u. (Kernel needs %i "
                "registers per block, %i bytes of "
                "statically-allocated shared memory per block, %i "
                "bytes of local memory per thread and a total of %i "
-               "bytes of user-allocated constant memory)\n",
+               "bytes of user-allocated constant memory)",
                max_threads_per_block, num_threads, funcAttrib.numRegs,
                funcAttrib.sharedSizeBytes, funcAttrib.localSizeBytes,
                funcAttrib.constSizeBytes);
     }
     else
     {
-        printf("INFO _before_run_kernel_{{codeobj_name}}\n"
+        B2C_LOG_DEBUG("_before_run_kernel_{{codeobj_name}}\n"
                "\t%u blocks\n"
                "\t%u threads\n"
                "\t%i registers per thread\n"
                "\t%i bytes statically-allocated shared memory per block\n"
                "\t%i bytes local memory per thread\n"
-               "\t%i bytes user-allocated constant memory\n"
-               "",
+               "\t%i bytes user-allocated constant memory",
                num_blocks, num_threads, funcAttrib.numRegs,
                funcAttrib.sharedSizeBytes, funcAttrib.localSizeBytes,
                funcAttrib.constSizeBytes);
@@ -930,7 +931,7 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
     cudaError_t status = cudaGetLastError();
     if (status != cudaSuccess)
     {
-        printf("ERROR initialising {{owner.name}} in %s:%d %s\n",
+        B2C_LOG_ERROR("initialising {{owner.name}} in %s:%d %s",
                 __FILE__, __LINE__, cudaGetErrorString(status));
         _dealloc_arrays();
         exit(status);
@@ -939,16 +940,21 @@ __global__ void _before_run_kernel_{{codeobj_name}}(
     CUDA_CHECK_MEMORY();
     double time_passed = std::chrono::duration<double>(
             std::chrono::high_resolution_clock::now() - start_timer).count();
-    printf("INFO: {{owner.name}} initialisation took %.6fs", time_passed);
-    if (used_device_memory_after_dealloc < used_device_memory_start){
-        size_t freed_bytes = used_device_memory_start - used_device_memory_after_dealloc;
-        printf(", freed %.1fMB", freed_bytes * to_MB);
+#if B2C_LOG_LEVEL <= B2C_LOG_LEVEL_DEBUG
+    {
+        std::ostringstream _b2c_msg;
+        _b2c_msg << "{{owner.name}} initialisation took " << time_passed << "s";
+        if (used_device_memory_after_dealloc < used_device_memory_start) {
+            size_t freed_bytes = used_device_memory_start - used_device_memory_after_dealloc;
+            _b2c_msg << ", freed " << (freed_bytes * to_MB) << "MB";
+        }
+        if (used_device_memory > used_device_memory_start) {
+            size_t used_bytes = used_device_memory - used_device_memory_start;
+            _b2c_msg << " and used " << (used_bytes * to_MB) << "MB of device memory.";
+        }
+        B2C_LOG_DEBUG("%s", _b2c_msg.str().c_str());
     }
-    if (used_device_memory > used_device_memory_start){
-        size_t used_bytes = used_device_memory - used_device_memory_start;
-        printf(" and used %.1fMB of device memory.", used_bytes * to_MB);
-    }
-    printf("\n");
+#endif
 
     first_run = false;
 {% endblock before_run_host_maincode %}

--- a/brian2cuda/utils/logger.py
+++ b/brian2cuda/utils/logger.py
@@ -1,9 +1,97 @@
 '''
-Brian2CUDA's logging system extensions
-'''
-from brian2.utils.logger import BrianLogger
+Brian2CUDA logging helpers.
 
-__all__ = ['suppress_brian2_logs']
+Map the Brian2 console level to nvcc ``-DB2C_LOG_LEVEL`` for ``B2C_LOG_*``
+macros, and re-emit host WARNING/ERROR from ``results/cuda_log.txt`` after the
+standalone process exits.
+'''
+import logging
+import os
+import re
+
+from brian2.core.preferences import prefs
+from brian2.utils.logger import BrianLogger, get_logger
+
+__all__ = [
+    'suppress_brian2_logs',
+    'get_codegen_log_level',
+    'nvcc_log_flags',
+    'update_log_flags_stamp',
+    'reemit_cuda_log',
+    'report_issue_message',
+]
+
+logger = get_logger(__name__)
+
+_CUDA_LOG_LINE = re.compile(
+    r'^\[brian2cuda\]\[(ERROR|WARNING)\]\s?(.*)$'
+)
+
+
+def get_codegen_log_level():
+    '''Brian2 console level clamped to DEBUG..ERROR for CUDA codegen.'''
+    if BrianLogger.console_handler is not None:
+        level = BrianLogger.console_handler.level
+    else:
+        level = getattr(
+            logging, prefs['logging.console_log_level'].upper(), logging.INFO
+        )
+    # DIAGNOSTIC to DEBUG; CRITICAL to ERROR
+    return min(max(level, logging.DEBUG), logging.ERROR)
+
+
+def nvcc_log_flags():
+    '''nvcc ``-D`` flags for compile-time ``B2C_LOG_*`` gating.'''
+    return [f'-DB2C_LOG_LEVEL={get_codegen_log_level()}']
+
+
+def update_log_flags_stamp(project_dir):
+    '''Return True if log -D flags changed since the last build.'''
+    stamp_path = os.path.join(project_dir, 'b2c_log_flags.stamp')
+    new_stamp = '\n'.join(nvcc_log_flags()) + '\n'
+    old_stamp = None
+    if os.path.isfile(stamp_path):
+        with open(stamp_path, encoding='utf-8') as f:
+            old_stamp = f.read()
+    with open(stamp_path, 'w', encoding='utf-8') as f:
+        f.write(new_stamp)
+    return old_stamp is not None and old_stamp != new_stamp
+
+
+def reemit_cuda_log(results_dir):
+    '''Re-emit persisted host WARNING/ERROR via the Brian2 logger.'''
+    if not results_dir:
+        return
+    path = os.path.join(results_dir, 'cuda_log.txt')
+    if not os.path.isfile(path):
+        return
+
+    emit = {'ERROR': logger.error, 'WARNING': logger.warn}
+    level = None
+    parts = []
+
+    def flush():
+        nonlocal level, parts
+        if level is not None and parts:
+            emit[level]('\n'.join(parts), name_suffix='cuda_log')
+        level, parts = None, []
+
+    try:
+        with open(path, encoding='utf-8', errors='replace') as f:
+            for raw in f:
+                line = raw.rstrip('\n')
+                match = _CUDA_LOG_LINE.match(line)
+                if match:
+                    flush()
+                    level = match.group(1)
+                    parts = [match.group(2)]
+                elif level is not None:
+                    parts.append(line)
+            flush()
+    except (IOError, OSError) as ex:
+        logger.warn(f"Could not read CUDA log '{path}': {ex}",
+                    name_suffix='cuda_log')
+
 
 def suppress_brian2_logs():
     '''

--- a/brian2cuda/utils/logger.py
+++ b/brian2cuda/utils/logger.py
@@ -2,8 +2,8 @@
 Brian2CUDA logging helpers.
 
 Map the Brian2 console level to nvcc ``-DB2C_LOG_LEVEL`` for ``B2C_LOG_*``
-macros, and re-emit host WARNING/ERROR from ``results/cuda_log.txt`` after the
-standalone process exits.
+macros, and re-emit host WARNING/ERROR from ``results/cuda_log.txt`` to
+Brian's file handler only after the standalone process exits.
 '''
 import logging
 import os
@@ -26,6 +26,10 @@ logger = get_logger(__name__)
 _CUDA_LOG_LINE = re.compile(
     r'^\[brian2cuda\]\[(ERROR|WARNING)\]\s?(.*)$'
 )
+_CUDA_LOG_LEVELS = {
+    'ERROR': logging.ERROR,
+    'WARNING': logging.WARNING,
+}
 
 
 def get_codegen_log_level():
@@ -59,35 +63,31 @@ def update_log_flags_stamp(project_dir):
 
 
 def reemit_cuda_log(results_dir):
-    '''Re-emit persisted host WARNING/ERROR via the Brian2 logger.'''
-    if not results_dir:
+    '''Re-emit persisted host WARNING/ERROR to Brian's file handler only.'''
+    handler = BrianLogger.file_handler
+    if not results_dir or handler is None:
         return
     path = os.path.join(results_dir, 'cuda_log.txt')
     if not os.path.isfile(path):
         return
 
-    emit = {'ERROR': logger.error, 'WARNING': logger.warn}
-    level = None
-    parts = []
-
-    def flush():
-        nonlocal level, parts
-        if level is not None and parts:
-            emit[level]('\n'.join(parts), name_suffix='cuda_log')
-        level, parts = None, []
-
     try:
         with open(path, encoding='utf-8', errors='replace') as f:
             for raw in f:
-                line = raw.rstrip('\n')
-                match = _CUDA_LOG_LINE.match(line)
-                if match:
-                    flush()
-                    level = match.group(1)
-                    parts = [match.group(2)]
-                elif level is not None:
-                    parts.append(line)
-            flush()
+                match = _CUDA_LOG_LINE.match(raw.rstrip('\n'))
+                if not match:
+                    continue
+                record = logging.LogRecord(
+                    name='brian2cuda.utils.logger.cuda_log',
+                    level=_CUDA_LOG_LEVELS[match.group(1)],
+                    pathname=__file__,
+                    lineno=0,
+                    msg=match.group(2),
+                    args=(),
+                    exc_info=None,
+                )
+                if record.levelno >= handler.level:
+                    handler.handle(record)
     except (IOError, OSError) as ex:
         logger.warn(f"Could not read CUDA log '{path}': {ex}",
                     name_suffix='cuda_log')


### PR DESCRIPTION
Hi @mstimberg, this PR introduces a unified compile-time logging system for Brian2CUDA built around `B2C_LOG_*` macros.

The Brian2 console log level maps to `-DB2C_LOG_LEVEL` at build time, ensuring host and device diagnostics are gated before compilation. On the host, log messages print to `stdout`, while WARNING and ERROR logs are also saved to `results/cuda_log.txt` and re-emitted via the Brian2 logger after the standalone process completes. On the device, logging currently relies on `printf`.

The main change replaces ad-hoc `printf`, `std::cout`, and `std::cerr` calls across the codebase with the new `B2C_LOG_ERROR/WARN/INFO/DEBUG` macros.